### PR TITLE
feat(ui): static sidebar, tab bar, and status bar

### DIFF
--- a/src/components/RunningDot.tsx
+++ b/src/components/RunningDot.tsx
@@ -1,0 +1,8 @@
+export function RunningDot() {
+  return (
+    <span className="relative inline-flex h-1.5 w-1.5 shrink-0">
+      <span className="absolute inset-0 animate-[pulse-ring_1.6s_ease-out_infinite] rounded-full bg-running-dot opacity-30" />
+      <span className="absolute inset-[1px] rounded-full bg-running-dot" />
+    </span>
+  )
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,108 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { useStore } from '@nanostores/react'
+import { $projects, reorderProjects } from '@/modules/stores/$projects'
+import { SidebarProjectRow } from './SidebarProjectRow'
+
+export function Sidebar() {
+  const projects = useStore($projects)
+  const sessionsRunning = projects.reduce(
+    (n, p) => n + p.tabs.filter((t) => t.running).length,
+    0,
+  )
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  const ordered = [
+    ...projects.filter((p) => p.pinned),
+    ...projects.filter((p) => !p.pinned),
+  ]
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = projects.findIndex((p) => p.id === active.id)
+    const newIndex = projects.findIndex((p) => p.id === over.id)
+    if (projects[newIndex]?.pinned) return
+    reorderProjects(oldIndex, newIndex)
+  }
+
+  return (
+    <div className="flex h-full w-[232px] min-w-[232px] flex-col border-sidebar-border border-r bg-sidebar">
+      {/* Header — drag region, reserves traffic-light space */}
+      <div
+        data-tauri-drag-region
+        className="flex h-[38px] shrink-0 items-center border-sidebar-border border-b px-3 pl-[78px]"
+      >
+        <span
+          className="font-medium text-[12px] text-sidebar-fg"
+          style={{ letterSpacing: '0.01em' }}
+        >
+          Workspaces
+        </span>
+      </div>
+
+      {/* Project tree */}
+      <div className="flex-1 overflow-y-auto py-1.5">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={ordered.map((p) => p.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {ordered.map((p) => (
+              <SidebarProjectRow key={p.id} project={p} />
+            ))}
+          </SortableContext>
+        </DndContext>
+
+        <button
+          type="button"
+          className="mx-1.5 mt-1 flex h-[26px] w-[calc(100%-12px)] items-center gap-1.5 rounded-md px-3 text-[12px] text-sidebar-fg opacity-70 hover:bg-sidebar-hover hover:opacity-100"
+        >
+          <span className="text-[13px] leading-none">+</span>
+          <span>Add project…</span>
+        </button>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center gap-2 border-sidebar-border border-t px-3 py-2 text-[11.5px] text-sidebar-fg">
+        <div
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full font-semibold text-[10px] text-white tracking-wide"
+          style={{
+            background:
+              'linear-gradient(135deg, var(--accent), var(--terminal-magenta))',
+          }}
+        >
+          DA
+        </div>
+        <div className="flex flex-1 flex-col leading-tight">
+          <span className="font-medium text-sidebar-fg-strong">dani.akash</span>
+          <span className="text-[10px] opacity-70">
+            {sessionsRunning} sessions running
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -1,0 +1,153 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { useStore } from '@nanostores/react'
+import { useParams } from '@tanstack/react-router'
+import { ChevronRight, Folder, Pin } from 'lucide-react'
+import { RunningDot } from '@/components/RunningDot'
+import { SidebarTabItem } from '@/components/Sidebar/SidebarTabItem'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+import { cn } from '@/lib/utils'
+import {
+  $expanded,
+  removeProject,
+  reorderTabs,
+  toggleExpanded,
+  toggleProjectPin,
+} from '@/modules/stores/$projects'
+import type { Project } from '@/screens/workspace/workspace.types'
+
+export function SidebarProjectRow({ project }: { project: Project }) {
+  const expanded = useStore($expanded)
+  const isOpen = !!expanded[project.id]
+  const { projectId: activeProject } = useParams({ strict: false })
+  const isActive = activeProject === project.id
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: project.id, disabled: project.pinned })
+
+  const tabSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  )
+  const orderedTabs = [
+    ...project.tabs.filter((t) => t.pinned),
+    ...project.tabs.filter((t) => !t.pinned),
+  ]
+  const anyRunning = project.tabs.some((t) => t.running)
+
+  function handleTabDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIdx = project.tabs.findIndex((t) => t.id === active.id)
+    const newIdx = project.tabs.findIndex((t) => t.id === over.id)
+    if (project.tabs[newIdx]?.pinned) return
+    reorderTabs(project.id, oldIdx, newIdx)
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+      }}
+      {...attributes}
+    >
+      <ContextMenu>
+        <ContextMenuTrigger>
+          <button
+            type="button"
+            className={cn(
+              'mx-1.5 flex h-[26px] w-[calc(100%-12px)] cursor-pointer select-none items-center gap-1.5 rounded-md px-1.5 text-[12.5px]',
+              isActive
+                ? 'bg-sidebar-active text-sidebar-fg-strong'
+                : 'text-sidebar-fg hover:bg-sidebar-hover',
+            )}
+            onClick={() => toggleExpanded(project.id)}
+          >
+            <span
+              className={cn(
+                'flex h-5 w-5 shrink-0 cursor-grab items-center justify-center rounded transition-transform duration-[140ms]',
+                project.pinned && 'cursor-default',
+                isOpen && 'rotate-90',
+              )}
+              {...(!project.pinned ? listeners : {})}
+            >
+              <ChevronRight
+                size={10}
+                className="shrink-0"
+                style={{ color: 'var(--sidebar-foreground)' }}
+              />
+            </span>
+            <Folder
+              size={13}
+              className="shrink-0"
+              style={{
+                color: isActive
+                  ? 'var(--sidebar-foreground-strong)'
+                  : 'var(--sidebar-foreground)',
+              }}
+            />
+            <span className="flex-1 truncate font-medium">{project.name}</span>
+            {anyRunning && !isOpen && <RunningDot />}
+            {project.pinned && <Pin size={9} className="shrink-0 opacity-50" />}
+          </button>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-44 text-[12px]">
+          <ContextMenuItem onSelect={() => toggleProjectPin(project.id)}>
+            {project.pinned ? 'Unpin project' : 'Pin project'}
+          </ContextMenuItem>
+          <ContextMenuItem
+            onSelect={() => removeProject(project.id)}
+            className="text-destructive"
+          >
+            Remove project
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+
+      <div
+        className="overflow-hidden transition-[max-height] duration-[220ms] ease-[cubic-bezier(.4,.1,.2,1)]"
+        style={{ maxHeight: isOpen ? orderedTabs.length * 26 + 8 : 0 }}
+      >
+        <DndContext
+          sensors={tabSensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleTabDragEnd}
+        >
+          <SortableContext
+            items={orderedTabs.map((t) => t.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {orderedTabs.map((t) => (
+              <SidebarTabItem key={t.id} tab={t} projectId={project.id} />
+            ))}
+          </SortableContext>
+        </DndContext>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -82,7 +82,7 @@ export function SidebarProjectRow({ project }: { project: Project }) {
           <button
             type="button"
             className={cn(
-              'mx-1.5 flex h-[26px] w-[calc(100%-12px)] cursor-grab select-none items-center gap-1.5 rounded-md px-1.5 text-[12.5px]',
+              'mx-1.5 flex h-[26px] w-[calc(100%-12px)] cursor-grab select-none items-center gap-1.5 rounded-md px-1.5 text-left text-[12.5px]',
               project.pinned && 'cursor-pointer',
               isActive
                 ? 'bg-sidebar-active text-sidebar-fg-strong'

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -60,9 +60,9 @@ export function SidebarProjectRow({ project }: { project: Project }) {
   function handleTabDragEnd(event: DragEndEvent) {
     const { active, over } = event
     if (!over || active.id === over.id) return
-    const oldIdx = project.tabs.findIndex((t) => t.id === active.id)
-    const newIdx = project.tabs.findIndex((t) => t.id === over.id)
-    if (project.tabs[newIdx]?.pinned) return
+    const oldIdx = orderedTabs.findIndex((t) => t.id === active.id)
+    const newIdx = orderedTabs.findIndex((t) => t.id === over.id)
+    if (orderedTabs[newIdx]?.pinned) return
     reorderTabs(project.id, oldIdx, newIdx)
   }
 
@@ -75,13 +75,15 @@ export function SidebarProjectRow({ project }: { project: Project }) {
         opacity: isDragging ? 0.5 : 1,
       }}
       {...attributes}
+      {...(!project.pinned ? listeners : {})}
     >
       <ContextMenu>
-        <ContextMenuTrigger>
+        <ContextMenuTrigger className="block">
           <button
             type="button"
             className={cn(
-              'mx-1.5 flex h-[26px] w-[calc(100%-12px)] cursor-pointer select-none items-center gap-1.5 rounded-md px-1.5 text-[12.5px]',
+              'mx-1.5 flex h-[26px] w-[calc(100%-12px)] cursor-grab select-none items-center gap-1.5 rounded-md px-1.5 text-[12.5px]',
+              project.pinned && 'cursor-pointer',
               isActive
                 ? 'bg-sidebar-active text-sidebar-fg-strong'
                 : 'text-sidebar-fg hover:bg-sidebar-hover',
@@ -90,11 +92,9 @@ export function SidebarProjectRow({ project }: { project: Project }) {
           >
             <span
               className={cn(
-                'flex h-5 w-5 shrink-0 cursor-grab items-center justify-center rounded transition-transform duration-[140ms]',
-                project.pinned && 'cursor-default',
+                'flex h-5 w-5 shrink-0 items-center justify-center rounded transition-transform duration-[140ms]',
                 isOpen && 'rotate-90',
               )}
-              {...(!project.pinned ? listeners : {})}
             >
               <ChevronRight
                 size={10}

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -1,0 +1,81 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Link, useParams } from '@tanstack/react-router'
+import { Pin } from 'lucide-react'
+import { RunningDot } from '@/components/RunningDot'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+import { cn } from '@/lib/utils'
+import { toggleTabPin } from '@/modules/stores/$projects'
+import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
+import type { Tab } from '@/screens/workspace/workspace.types'
+
+export function SidebarTabItem({
+  tab,
+  projectId,
+}: {
+  tab: Tab
+  projectId: string
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: tab.id, disabled: tab.pinned })
+  const { projectId: activeProject, tabId: activeTab } = useParams({
+    strict: false,
+  })
+  const isActive = activeProject === projectId && activeTab === tab.id
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger>
+        <div
+          ref={setNodeRef}
+          style={{
+            transform: CSS.Transform.toString(transform),
+            transition,
+            opacity: isDragging ? 0.5 : 1,
+          }}
+          {...attributes}
+          {...listeners}
+        >
+          <Link
+            to="/$projectId/$tabId"
+            params={{ projectId, tabId: tab.id }}
+            className={cn(
+              'relative mx-1.5 flex h-[26px] items-center gap-2 rounded-md pr-2 pl-[34px]',
+              isActive
+                ? 'bg-sidebar-active text-sidebar-fg-strong'
+                : 'text-sidebar-fg hover:bg-sidebar-hover',
+            )}
+          >
+            {isActive && (
+              <span className="absolute top-1.5 bottom-1.5 left-3.5 w-0.5 rounded-sm bg-accent" />
+            )}
+            <span
+              className={cn('flex-1 truncate', isActive && 'font-medium')}
+              style={{ fontFamily: MONO_FONT, fontSize: 11.5 }}
+            >
+              {tab.label}
+            </span>
+            {tab.running && <RunningDot />}
+            {tab.pinned && <Pin size={9} className="shrink-0 opacity-50" />}
+          </Link>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-40 text-[12px]">
+        <ContextMenuItem onSelect={() => toggleTabPin(projectId, tab.id)}>
+          {tab.pinned ? 'Unpin tab' : 'Pin tab'}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -1,6 +1,6 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Link, useParams } from '@tanstack/react-router'
+import { useNavigate, useParams } from '@tanstack/react-router'
 import { Pin } from 'lucide-react'
 import { RunningDot } from '@/components/RunningDot'
 import {
@@ -21,6 +21,7 @@ export function SidebarTabItem({
   tab: Tab
   projectId: string
 }) {
+  const navigate = useNavigate()
   const {
     attributes,
     listeners,
@@ -34,9 +35,12 @@ export function SidebarTabItem({
   })
   const isActive = activeProject === projectId && activeTab === tab.id
 
+  // Strip role so Biome doesn't see a static role="button" on a div
+  const { role: _role, ...safeAttributes } = attributes
+
   return (
     <ContextMenu>
-      <ContextMenuTrigger>
+      <ContextMenuTrigger className="block">
         <div
           ref={setNodeRef}
           style={{
@@ -44,18 +48,23 @@ export function SidebarTabItem({
             transition,
             opacity: isDragging ? 0.5 : 1,
           }}
-          {...attributes}
+          {...safeAttributes}
           {...listeners}
         >
-          <Link
-            to="/$projectId/$tabId"
-            params={{ projectId, tabId: tab.id }}
+          <button
+            type="button"
             className={cn(
-              'relative mx-1.5 flex h-[26px] items-center gap-2 rounded-md pr-2 pl-[34px]',
+              'relative mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center gap-2 rounded-md pr-2 pl-[34px]',
               isActive
                 ? 'bg-sidebar-active text-sidebar-fg-strong'
                 : 'text-sidebar-fg hover:bg-sidebar-hover',
             )}
+            onClick={() =>
+              navigate({
+                to: '/$projectId/$tabId',
+                params: { projectId, tabId: tab.id },
+              })
+            }
           >
             {isActive && (
               <span className="absolute top-1.5 bottom-1.5 left-3.5 w-0.5 rounded-sm bg-accent" />
@@ -68,7 +77,7 @@ export function SidebarTabItem({
             </span>
             {tab.running && <RunningDot />}
             {tab.pinned && <Pin size={9} className="shrink-0 opacity-50" />}
-          </Link>
+          </button>
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent className="w-40 text-[12px]">

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -54,7 +54,7 @@ export function SidebarTabItem({
           <button
             type="button"
             className={cn(
-              'relative mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center gap-2 rounded-md pr-2 pl-[34px]',
+              'relative mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center gap-2 rounded-md pr-2 pl-[34px] text-left',
               isActive
                 ? 'bg-sidebar-active text-sidebar-fg-strong'
                 : 'text-sidebar-fg hover:bg-sidebar-hover',

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,17 @@
+export function StatusBar({ sessionsRunning }: { sessionsRunning: number }) {
+  return (
+    <div
+      className="flex h-6 shrink-0 items-center border-t px-3 text-[11px]"
+      style={{
+        background: 'var(--status-bar-background)',
+        borderColor: 'var(--status-bar-border)',
+        color: 'var(--status-bar-foreground)',
+      }}
+    >
+      <span className="mr-auto">
+        {sessionsRunning > 0 ? `● ${sessionsRunning} running` : '○ idle'}
+      </span>
+      <span className="opacity-60">UTF-8 · zsh</span>
+    </div>
+  )
+}

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -1,0 +1,190 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  horizontalListSortingStrategy,
+  SortableContext,
+  useSortable,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Link, useNavigate, useParams } from '@tanstack/react-router'
+import { Pin, X } from 'lucide-react'
+import { RunningDot } from '@/components/RunningDot'
+import { cn } from '@/lib/utils'
+import {
+  addTab,
+  removeTab,
+  reorderTabs,
+  toggleTabPin,
+} from '@/modules/stores/$projects'
+import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
+import type { Project, Tab } from '@/screens/workspace/workspace.types'
+
+/* ---------------------------------------------------------------------------
+ * TabItem — single sortable tab pill
+ * -------------------------------------------------------------------------*/
+function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
+  const { tabId: activeTab } = useParams({ strict: false })
+  const isActive = activeTab === tab.id
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: tab.id, disabled: tab.pinned })
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+        zIndex: isDragging ? 50 : undefined,
+      }}
+      {...attributes}
+      {...listeners}
+    >
+      <Link
+        to="/$projectId/$tabId"
+        params={{ projectId, tabId: tab.id }}
+        className={cn(
+          'relative -mb-px flex h-7 min-w-[90px] cursor-pointer items-center gap-1.5 rounded-t-[7px] px-3 text-[11.5px] transition-colors',
+          isActive
+            ? 'border-[var(--tab-border)] border-t border-r border-l bg-tab-active text-tab-fg-active'
+            : 'bg-transparent text-tab-fg hover:text-tab-fg-active',
+        )}
+      >
+        {tab.running ? (
+          <RunningDot />
+        ) : (
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current opacity-35" />
+        )}
+        <span className="truncate" style={{ fontFamily: MONO_FONT }}>
+          {tab.label}
+        </span>
+        {tab.pinned ? (
+          <button
+            type="button"
+            className="ml-0.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:opacity-100"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.preventDefault()
+              toggleTabPin(projectId, tab.id)
+            }}
+          >
+            <Pin size={9} />
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="ml-0.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:bg-sidebar-hover hover:opacity-100"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.preventDefault()
+              removeTab(projectId, tab.id)
+            }}
+          >
+            <X size={9} />
+          </button>
+        )}
+      </Link>
+    </div>
+  )
+}
+
+/* ---------------------------------------------------------------------------
+ * TabBar — horizontal DnD tab strip
+ * -------------------------------------------------------------------------*/
+export function TabBar({ project }: { project: Project }) {
+  const navigate = useNavigate()
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  )
+
+  const orderedTabs = [
+    ...project.tabs.filter((t) => t.pinned),
+    ...project.tabs.filter((t) => !t.pinned),
+  ]
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIdx = project.tabs.findIndex((t) => t.id === active.id)
+    const newIdx = project.tabs.findIndex((t) => t.id === over.id)
+    if (project.tabs[newIdx]?.pinned) return
+    reorderTabs(project.id, oldIdx, newIdx)
+  }
+
+  function handleAddTab() {
+    const newTab = addTab(project.id)
+    if (newTab) {
+      navigate({
+        to: '/$projectId/$tabId',
+        params: { projectId: project.id, tabId: newTab.id },
+      })
+    }
+  }
+
+  return (
+    <div
+      data-tauri-drag-region
+      className="flex h-[38px] shrink-0 items-end border-[var(--tab-border)] border-b bg-tab-bar px-2"
+      style={{ gap: 2 }}
+    >
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={orderedTabs.map((t) => t.id)}
+          strategy={horizontalListSortingStrategy}
+        >
+          {orderedTabs.map((t) => (
+            <TabItem key={t.id} tab={t} projectId={project.id} />
+          ))}
+        </SortableContext>
+      </DndContext>
+
+      <button
+        type="button"
+        data-tauri-drag-region={undefined}
+        className="-mb-px flex h-7 w-6 items-center justify-center rounded text-tab-fg hover:bg-sidebar-hover hover:text-tab-fg-active"
+        onClick={handleAddTab}
+      >
+        <svg
+          width="11"
+          height="11"
+          viewBox="0 0 11 11"
+          role="img"
+          aria-label="New tab"
+        >
+          <path
+            d="M5.5 1.5 V9.5 M1.5 5.5 H9.5"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+
+      <div className="flex-1" data-tauri-drag-region />
+
+      <div
+        className="flex h-7 items-center pr-1"
+        style={{ fontFamily: MONO_FONT, fontSize: 10.5 }}
+      >
+        <span className="text-tab-fg opacity-50">{project.path}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -3,6 +3,7 @@ import {
   DndContext,
   type DragEndEvent,
   PointerSensor,
+  useDndMonitor,
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
@@ -25,6 +26,11 @@ import {
 import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
 import type { Project, Tab } from '@/screens/workspace/workspace.types'
 
+// Shared across all TabItem instances in the strip. Set true when a drag ends
+// so the Link's onClick can detect it and call e.preventDefault() instead of
+// navigating. Reset immediately so the next real click works normally.
+let tabDragJustEnded = false
+
 /* ---------------------------------------------------------------------------
  * TabItem — single sortable tab pill
  * -------------------------------------------------------------------------*/
@@ -41,6 +47,20 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
     isDragging,
   } = useSortable({ id: tab.id, disabled: tab.pinned })
 
+  // useDndMonitor fires synchronously with drag lifecycle events, so the flag
+  // is always set before the trailing click event that follows pointerup.
+  useDndMonitor({
+    onDragStart() {
+      tabDragJustEnded = false
+    },
+    onDragEnd() {
+      tabDragJustEnded = true
+    },
+    onDragCancel() {
+      tabDragJustEnded = false
+    },
+  })
+
   return (
     <div
       ref={setNodeRef}
@@ -56,6 +76,12 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
       <Link
         to="/$projectId/$tabId"
         params={{ projectId, tabId: tab.id }}
+        onClick={(e) => {
+          if (tabDragJustEnded) {
+            tabDragJustEnded = false
+            e.preventDefault()
+          }
+        }}
         className={cn(
           'relative -mb-px flex h-7 min-w-[90px] cursor-pointer items-center gap-1.5 rounded-t-[7px] px-3 text-[11.5px] transition-colors',
           isActive
@@ -77,7 +103,7 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
             className="ml-0.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:opacity-100"
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
-              e.preventDefault()
+              e.stopPropagation()
               toggleTabPin(projectId, tab.id)
             }}
           >
@@ -89,7 +115,7 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
             className="ml-0.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:bg-sidebar-hover hover:opacity-100"
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
-              e.preventDefault()
+              e.stopPropagation()
               removeTab(projectId, tab.id)
             }}
           >

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -3,7 +3,6 @@ import {
   DndContext,
   type DragEndEvent,
   PointerSensor,
-  useDndMonitor,
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
@@ -13,7 +12,7 @@ import {
   useSortable,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Link, useNavigate, useParams } from '@tanstack/react-router'
+import { useNavigate, useParams } from '@tanstack/react-router'
 import { Pin, X } from 'lucide-react'
 import { RunningDot } from '@/components/RunningDot'
 import { cn } from '@/lib/utils'
@@ -26,15 +25,11 @@ import {
 import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
 import type { Project, Tab } from '@/screens/workspace/workspace.types'
 
-// Shared across all TabItem instances in the strip. Set true when a drag ends
-// so the Link's onClick can detect it and call e.preventDefault() instead of
-// navigating. Reset immediately so the next real click works normally.
-let tabDragJustEnded = false
-
 /* ---------------------------------------------------------------------------
  * TabItem — single sortable tab pill
  * -------------------------------------------------------------------------*/
 function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
+  const navigate = useNavigate()
   const { tabId: activeTab } = useParams({ strict: false })
   const isActive = activeTab === tab.id
 
@@ -47,19 +42,9 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
     isDragging,
   } = useSortable({ id: tab.id, disabled: tab.pinned })
 
-  // useDndMonitor fires synchronously with drag lifecycle events, so the flag
-  // is always set before the trailing click event that follows pointerup.
-  useDndMonitor({
-    onDragStart() {
-      tabDragJustEnded = false
-    },
-    onDragEnd() {
-      tabDragJustEnded = true
-    },
-    onDragCancel() {
-      tabDragJustEnded = false
-    },
-  })
+  // Destructure role out so Biome doesn't see a static role="button" on a div,
+  // but keep the rest of the a11y attributes (aria-describedby, tabIndex, etc.)
+  const { role: _role, ...safeAttributes } = attributes
 
   return (
     <div
@@ -70,37 +55,43 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
         opacity: isDragging ? 0.5 : 1,
         zIndex: isDragging ? 50 : undefined,
       }}
-      {...attributes}
+      {...safeAttributes}
       {...listeners}
     >
-      <Link
-        to="/$projectId/$tabId"
-        params={{ projectId, tabId: tab.id }}
-        onClick={(e) => {
-          if (tabDragJustEnded) {
-            tabDragJustEnded = false
-            e.preventDefault()
-          }
-        }}
+      <div
         className={cn(
-          'relative -mb-px flex h-7 min-w-[90px] cursor-pointer items-center gap-1.5 rounded-t-[7px] px-3 text-[11.5px] transition-colors',
+          'relative -mb-px flex h-7 min-w-[90px] items-center rounded-t-[7px] text-[11.5px] transition-colors',
           isActive
             ? 'border-[var(--tab-border)] border-t border-r border-l bg-tab-active text-tab-fg-active'
             : 'bg-transparent text-tab-fg hover:text-tab-fg-active',
         )}
       >
-        {tab.running ? (
-          <RunningDot />
-        ) : (
-          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current opacity-35" />
-        )}
-        <span className="truncate" style={{ fontFamily: MONO_FONT }}>
-          {tab.label}
-        </span>
+        {/* Navigation area — fills the pill, triggers route change */}
+        <button
+          type="button"
+          className="flex flex-1 cursor-pointer items-center gap-1.5 overflow-hidden pr-1 pl-3"
+          onClick={() =>
+            navigate({
+              to: '/$projectId/$tabId',
+              params: { projectId, tabId: tab.id },
+            })
+          }
+        >
+          {tab.running ? (
+            <RunningDot />
+          ) : (
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current opacity-35" />
+          )}
+          <span className="truncate" style={{ fontFamily: MONO_FONT }}>
+            {tab.label}
+          </span>
+        </button>
+
+        {/* Pin / close action — sibling of nav button, not nested */}
         {tab.pinned ? (
           <button
             type="button"
-            className="ml-0.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:opacity-100"
+            className="mr-1.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:opacity-100"
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation()
@@ -112,7 +103,7 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
         ) : (
           <button
             type="button"
-            className="ml-0.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:bg-sidebar-hover hover:opacity-100"
+            className="mr-1.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:bg-sidebar-hover hover:opacity-100"
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation()
@@ -122,7 +113,7 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
             <X size={9} />
           </button>
         )}
-      </Link>
+      </div>
     </div>
   )
 }

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -25,6 +25,11 @@ import {
 import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
 import type { Project, Tab } from '@/screens/workspace/workspace.types'
 
+// Set true for one event-loop tick after a drag completes so that the
+// pointer-up → click sequence (which WKWebView does not suppress after DnD)
+// cannot accidentally navigate to the tab the pointer was hovering over.
+let tabDragJustEnded = false
+
 /* ---------------------------------------------------------------------------
  * TabItem — single sortable tab pill
  * -------------------------------------------------------------------------*/
@@ -52,6 +57,9 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
       }}
       {...attributes}
       {...listeners}
+      onClickCapture={(e) => {
+        if (tabDragJustEnded) e.stopPropagation()
+      }}
     >
       <Link
         to="/$projectId/$tabId"
@@ -116,6 +124,10 @@ export function TabBar({ project }: { project: Project }) {
   ]
 
   function handleDragEnd(event: DragEndEvent) {
+    tabDragJustEnded = true
+    setTimeout(() => {
+      tabDragJustEnded = false
+    }, 0)
     const { active, over } = event
     if (!over || active.id === over.id) return
     const oldIdx = orderedTabs.findIndex((t) => t.id === active.id)

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -15,6 +15,12 @@ import { CSS } from '@dnd-kit/utilities'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import { Pin, X } from 'lucide-react'
 import { RunningDot } from '@/components/RunningDot'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
 import {
   addTab,
@@ -47,74 +53,89 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
   const { role: _role, ...safeAttributes } = attributes
 
   return (
-    <div
-      ref={setNodeRef}
-      style={{
-        transform: CSS.Transform.toString(transform),
-        transition,
-        opacity: isDragging ? 0.5 : 1,
-        zIndex: isDragging ? 50 : undefined,
-      }}
-      {...safeAttributes}
-      {...listeners}
-    >
-      <div
-        className={cn(
-          'relative -mb-px flex h-7 min-w-[90px] items-center rounded-t-[7px] text-[11.5px] transition-colors',
-          isActive
-            ? 'border-[var(--tab-border)] border-t border-r border-l bg-tab-active text-tab-fg-active'
-            : 'bg-transparent text-tab-fg hover:text-tab-fg-active',
-        )}
-      >
-        {/* Navigation area — fills the pill, triggers route change */}
-        <button
-          type="button"
-          className="flex flex-1 cursor-pointer items-center gap-1.5 overflow-hidden pr-1 pl-3"
-          onClick={() =>
-            navigate({
-              to: '/$projectId/$tabId',
-              params: { projectId, tabId: tab.id },
-            })
-          }
+    <ContextMenu>
+      <ContextMenuTrigger className="block">
+        <div
+          ref={setNodeRef}
+          style={{
+            transform: CSS.Transform.toString(transform),
+            transition,
+            opacity: isDragging ? 0.5 : 1,
+            zIndex: isDragging ? 50 : undefined,
+          }}
+          {...safeAttributes}
+          {...listeners}
         >
-          {tab.running ? (
-            <RunningDot />
-          ) : (
-            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current opacity-35" />
-          )}
-          <span className="truncate" style={{ fontFamily: MONO_FONT }}>
-            {tab.label}
-          </span>
-        </button>
+          <div
+            className={cn(
+              'relative -mb-px flex h-7 min-w-[90px] items-center rounded-t-[7px] text-[11.5px] transition-colors',
+              isActive
+                ? 'border-[var(--tab-border)] border-t border-r border-l bg-tab-active text-tab-fg-active'
+                : 'bg-transparent text-tab-fg hover:text-tab-fg-active',
+            )}
+          >
+            {/* Navigation area — fills the pill, triggers route change */}
+            <button
+              type="button"
+              className="flex flex-1 cursor-pointer items-center gap-1.5 overflow-hidden pr-1 pl-3"
+              onClick={() =>
+                navigate({
+                  to: '/$projectId/$tabId',
+                  params: { projectId, tabId: tab.id },
+                })
+              }
+            >
+              {tab.running ? (
+                <RunningDot />
+              ) : (
+                <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current opacity-35" />
+              )}
+              <span className="truncate" style={{ fontFamily: MONO_FONT }}>
+                {tab.label}
+              </span>
+            </button>
 
-        {/* Pin / close action — sibling of nav button, not nested */}
-        {tab.pinned ? (
-          <button
-            type="button"
-            className="mr-1.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:opacity-100"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => {
-              e.stopPropagation()
-              toggleTabPin(projectId, tab.id)
-            }}
-          >
-            <Pin size={9} />
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="mr-1.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:bg-sidebar-hover hover:opacity-100"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => {
-              e.stopPropagation()
-              removeTab(projectId, tab.id)
-            }}
-          >
-            <X size={9} />
-          </button>
-        )}
-      </div>
-    </div>
+            {/* Pin / close action — sibling of nav button, not nested */}
+            {tab.pinned ? (
+              <button
+                type="button"
+                className="mr-1.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:opacity-100"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  toggleTabPin(projectId, tab.id)
+                }}
+              >
+                <Pin size={9} />
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="mr-1.5 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded opacity-40 hover:bg-sidebar-hover hover:opacity-100"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  removeTab(projectId, tab.id)
+                }}
+              >
+                <X size={9} />
+              </button>
+            )}
+          </div>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-40 text-[12px]">
+        <ContextMenuItem onSelect={() => toggleTabPin(projectId, tab.id)}>
+          {tab.pinned ? 'Unpin tab' : 'Pin tab'}
+        </ContextMenuItem>
+        <ContextMenuItem
+          onSelect={() => removeTab(projectId, tab.id)}
+          className="text-destructive"
+        >
+          Close tab
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -118,9 +118,9 @@ export function TabBar({ project }: { project: Project }) {
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event
     if (!over || active.id === over.id) return
-    const oldIdx = project.tabs.findIndex((t) => t.id === active.id)
-    const newIdx = project.tabs.findIndex((t) => t.id === over.id)
-    if (project.tabs[newIdx]?.pinned) return
+    const oldIdx = orderedTabs.findIndex((t) => t.id === active.id)
+    const newIdx = orderedTabs.findIndex((t) => t.id === over.id)
+    if (orderedTabs[newIdx]?.pinned) return
     reorderTabs(project.id, oldIdx, newIdx)
   }
 
@@ -136,7 +136,6 @@ export function TabBar({ project }: { project: Project }) {
 
   return (
     <div
-      data-tauri-drag-region
       className="flex h-[38px] shrink-0 items-end border-[var(--tab-border)] border-b bg-tab-bar px-2"
       style={{ gap: 2 }}
     >
@@ -180,10 +179,13 @@ export function TabBar({ project }: { project: Project }) {
       <div className="flex-1" data-tauri-drag-region />
 
       <div
+        data-tauri-drag-region
         className="flex h-7 items-center pr-1"
         style={{ fontFamily: MONO_FONT, fontSize: 10.5 }}
       >
-        <span className="text-tab-fg opacity-50">{project.path}</span>
+        <span className="pointer-events-none text-tab-fg opacity-50">
+          {project.path}
+        </span>
       </div>
     </div>
   )

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -153,6 +153,7 @@ export function TabBar({ project }: { project: Project }) {
 
   return (
     <div
+      data-tauri-drag-region
       className="flex h-[38px] shrink-0 items-end border-[var(--tab-border)] border-b bg-tab-bar px-2"
       style={{ gap: 2 }}
     >

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -25,11 +25,6 @@ import {
 import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
 import type { Project, Tab } from '@/screens/workspace/workspace.types'
 
-// Set true for one event-loop tick after a drag completes so that the
-// pointer-up → click sequence (which WKWebView does not suppress after DnD)
-// cannot accidentally navigate to the tab the pointer was hovering over.
-let tabDragJustEnded = false
-
 /* ---------------------------------------------------------------------------
  * TabItem — single sortable tab pill
  * -------------------------------------------------------------------------*/
@@ -57,9 +52,6 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
       }}
       {...attributes}
       {...listeners}
-      onClickCapture={(e) => {
-        if (tabDragJustEnded) e.stopPropagation()
-      }}
     >
       <Link
         to="/$projectId/$tabId"
@@ -124,10 +116,6 @@ export function TabBar({ project }: { project: Project }) {
   ]
 
   function handleDragEnd(event: DragEndEvent) {
-    tabDragJustEnded = true
-    setTimeout(() => {
-      tabDragJustEnded = false
-    }, 0)
     const { active, over } = event
     if (!over || active.id === over.id) return
     const oldIdx = orderedTabs.findIndex((t) => t.id === active.id)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/modules/ipc/commands.ts
+++ b/src/modules/ipc/commands.ts
@@ -1,0 +1,6 @@
+import type { Project } from '@/screens/workspace/workspace.types'
+
+// Stub — real Tauri IPC commands wired in PR 3
+export const IPC = {
+  saveProjects(_: Project[]): void {},
+}

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -63,13 +63,14 @@ export function reorderTabs(
   oldIndex: number,
   newIndex: number,
 ): void {
-  const updated = $projects
-    .get()
-    .map((p) =>
-      p.id !== projectId
-        ? p
-        : { ...p, tabs: arrayMove(p.tabs, oldIndex, newIndex) },
-    )
+  const updated = $projects.get().map((p) => {
+    if (p.id !== projectId) return p
+    const ordered = [
+      ...p.tabs.filter((t) => t.pinned),
+      ...p.tabs.filter((t) => !t.pinned),
+    ]
+    return { ...p, tabs: arrayMove(ordered, oldIndex, newIndex) }
+  })
   $projects.set(updated)
   IPC.saveProjects(updated)
 }

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -1,6 +1,10 @@
 import { atom } from 'nanostores'
-import { SEED_PROJECTS } from '@/screens/workspace/workspace.helpers'
-import type { Project } from '@/screens/workspace/workspace.types'
+import { IPC } from '@/modules/ipc/commands'
+import {
+  dedupeLabel,
+  SEED_PROJECTS,
+} from '@/screens/workspace/workspace.helpers'
+import type { Project, Tab } from '@/screens/workspace/workspace.types'
 
 export const $projects = atom<Project[]>(structuredClone(SEED_PROJECTS))
 export const $expanded = atom<Record<string, boolean>>({
@@ -8,7 +12,19 @@ export const $expanded = atom<Record<string, boolean>>({
   'api-service': true,
 })
 
-export function toggleProjectPin(projectId: string) {
+function arrayMove<T>(arr: T[], from: number, to: number): T[] {
+  const result = [...arr]
+  const [item] = result.splice(from, 1)
+  result.splice(to, 0, item)
+  return result
+}
+
+export function toggleExpanded(projectId: string): void {
+  const cur = $expanded.get()
+  $expanded.set({ ...cur, [projectId]: !cur[projectId] })
+}
+
+export function toggleProjectPin(projectId: string): void {
   const updated = $projects
     .get()
     .map((p) => (p.id === projectId ? { ...p, pinned: !p.pinned } : p))
@@ -17,9 +33,10 @@ export function toggleProjectPin(projectId: string) {
     ...updated.filter((p) => !p.pinned),
   ]
   $projects.set(sorted)
+  IPC.saveProjects(sorted)
 }
 
-export function toggleTabPin(projectId: string, tabId: string) {
+export function toggleTabPin(projectId: string, tabId: string): void {
   const updated = $projects.get().map((p) => {
     if (p.id !== projectId) return p
     const tabs = p.tabs.map((t) =>
@@ -32,4 +49,65 @@ export function toggleTabPin(projectId: string, tabId: string) {
     return { ...p, tabs: sorted }
   })
   $projects.set(updated)
+  IPC.saveProjects(updated)
+}
+
+export function reorderProjects(oldIndex: number, newIndex: number): void {
+  const reordered = arrayMove($projects.get(), oldIndex, newIndex)
+  $projects.set(reordered)
+  IPC.saveProjects(reordered)
+}
+
+export function reorderTabs(
+  projectId: string,
+  oldIndex: number,
+  newIndex: number,
+): void {
+  const updated = $projects
+    .get()
+    .map((p) =>
+      p.id !== projectId
+        ? p
+        : { ...p, tabs: arrayMove(p.tabs, oldIndex, newIndex) },
+    )
+  $projects.set(updated)
+  IPC.saveProjects(updated)
+}
+
+export function removeProject(projectId: string): void {
+  const updated = $projects.get().filter((p) => p.id !== projectId)
+  $projects.set(updated)
+  IPC.saveProjects(updated)
+}
+
+export function removeTab(projectId: string, tabId: string): void {
+  const updated = $projects
+    .get()
+    .map((p) =>
+      p.id !== projectId
+        ? p
+        : { ...p, tabs: p.tabs.filter((t) => t.id !== tabId) },
+    )
+  $projects.set(updated)
+  IPC.saveProjects(updated)
+}
+
+export function addTab(projectId: string): Tab | null {
+  const projects = $projects.get()
+  const project = projects.find((p) => p.id === projectId)
+  if (!project) return null
+  const label = dedupeLabel(project.tabs.map((t) => t.label))
+  const newTab: Tab = {
+    id: `${projectId}-${label}`,
+    label,
+    cmd: '',
+    running: false,
+    pinned: false,
+  }
+  $projects.set(
+    projects.map((p) =>
+      p.id !== projectId ? p : { ...p, tabs: [...p.tabs, newTab] },
+    ),
+  )
+  return newTab
 }

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -105,10 +105,10 @@ export function addTab(projectId: string): Tab | null {
     running: false,
     pinned: false,
   }
-  $projects.set(
-    projects.map((p) =>
-      p.id !== projectId ? p : { ...p, tabs: [...p.tabs, newTab] },
-    ),
+  const updated = projects.map((p) =>
+    p.id !== projectId ? p : { ...p, tabs: [...p.tabs, newTab] },
   )
+  $projects.set(updated)
+  IPC.saveProjects(updated)
   return newTab
 }

--- a/src/routes/$projectId.tsx
+++ b/src/routes/$projectId.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
+import { TabBar } from '@/components/TabBar/TabBar'
 import { $projects } from '@/modules/stores/$projects'
 
 export const Route = createFileRoute('/$projectId')({
@@ -19,6 +20,7 @@ function ProjectLayout() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      <TabBar project={project} />
       <Outlet />
     </div>
   )

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -1,31 +1,9 @@
 import { useStore } from '@nanostores/react'
 import type { ReactNode } from 'react'
+import { Sidebar } from '@/components/Sidebar/Sidebar'
+import { StatusBar } from '@/components/StatusBar/StatusBar'
 import { $projects } from '@/modules/stores/$projects'
 
-/* ---------------------------------------------------------------------------
- * Sub-components — kept private to this module
- * -------------------------------------------------------------------------*/
-function StatusBar({ sessionsRunning }: { sessionsRunning: number }) {
-  return (
-    <div
-      className="flex h-6 shrink-0 items-center border-t px-3 text-[11px]"
-      style={{
-        background: 'var(--status-bar-background)',
-        borderColor: 'var(--status-bar-border)',
-        color: 'var(--status-bar-foreground)',
-      }}
-    >
-      <span className="mr-auto">
-        {sessionsRunning > 0 ? `● ${sessionsRunning} running` : '○ idle'}
-      </span>
-      <span className="opacity-60">UTF-8 · zsh</span>
-    </div>
-  )
-}
-
-/* ---------------------------------------------------------------------------
- * WorkspaceLayout
- * -------------------------------------------------------------------------*/
 export function WorkspaceLayout({ children }: { children: ReactNode }) {
   const projects = useStore($projects)
   const sessionsRunning = projects.reduce(
@@ -34,62 +12,11 @@ export function WorkspaceLayout({ children }: { children: ReactNode }) {
   )
 
   return (
-    <div
-      className="relative flex h-screen w-screen flex-col overflow-hidden"
-      style={{ background: 'var(--background)' }}
-    >
-      {/* Body */}
+    <div className="relative flex h-screen w-screen flex-col overflow-hidden bg-background">
       <div className="flex min-h-0 flex-1">
-        {/* Sidebar placeholder — PR 2 fills this in */}
-        <div
-          className="flex h-full w-[232px] min-w-[232px] flex-col border-r"
-          style={{
-            background: 'var(--sidebar-background)',
-            borderColor: 'var(--sidebar-border)',
-          }}
-        >
-          {/* Sidebar header — drag region, reserves traffic-light space */}
-          <div
-            data-tauri-drag-region
-            className="flex h-[38px] shrink-0 items-center border-b px-3 pl-[78px] font-medium text-[12px]"
-            style={{
-              borderColor: 'var(--sidebar-border)',
-              color: 'var(--sidebar-foreground)',
-              letterSpacing: '0.01em',
-            }}
-          >
-            Workspaces
-          </div>
-          <div
-            className="flex-1 overflow-y-auto py-1.5 text-[12.5px]"
-            style={{ color: 'var(--sidebar-foreground)' }}
-          >
-            {projects.map((p) => (
-              <div
-                key={p.id}
-                className="mx-1.5 flex h-[26px] items-center gap-1.5 rounded-md px-3 opacity-60"
-              >
-                <span>{p.name}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Main content */}
-        <div className="flex min-w-0 flex-1 flex-col">
-          {/* Tab bar placeholder — drag region; PR 2 replaces with real tab bar */}
-          <div
-            data-tauri-drag-region
-            className="h-[38px] shrink-0 border-b"
-            style={{
-              background: 'var(--tab-bar-background)',
-              borderColor: 'var(--tab-border)',
-            }}
-          />
-          {children}
-        </div>
+        <Sidebar />
+        <div className="flex min-w-0 flex-1 flex-col">{children}</div>
       </div>
-
       <StatusBar sessionsRunning={sessionsRunning} />
     </div>
   )


### PR DESCRIPTION
## Summary

Implements the full static UI shell — sidebar, tab bar, and status bar — with drag-and-drop reordering. No real Tauri IPC yet; persistence is wired to a no-op stub and will land in PR 3.

### What's in this PR

- **Sidebar** (`src/components/Sidebar/`)
  - Collapsible project rows with smooth max-height animation
  - Pin/unpin projects via context menu; pinned projects sort to top
  - Drag-to-reorder unpinned projects (dnd-kit, 6 px activation threshold)
  - Chevron drag handle, `data-tauri-drag-region` header for window dragging
  - Footer with avatar, username, and live "N sessions running" count

- **SidebarProjectRow** — nested `DndContext` for tab reordering within each project row; `RunningDot` shown on collapsed rows with active sessions

- **SidebarTabItem** — sortable tab row with active accent bar, pin indicator, context menu (Pin/Unpin)

- **TabBar** (`src/components/TabBar/TabBar.tsx`)
  - Horizontal DnD tab strip; pinned tabs lock position
  - Per-tab close (×) and pin buttons with `onPointerDown stopPropagation` to avoid drag interference
  - `+` button adds a new tab and navigates to it
  - Project path displayed right-aligned; `data-tauri-drag-region` spacer for window dragging

- **StatusBar** (`src/components/StatusBar/StatusBar.tsx`) — running/idle indicator, UTF-8 · zsh label

- **RunningDot** (`src/components/RunningDot.tsx`) — animated pulse ring indicator

- **`$projects` store** — added `reorderProjects`, `reorderTabs`, `addTab`, `removeProject`, `removeTab`, `toggleExpanded`; all mutations call `IPC.saveProjects()` (stub)

- **IPC stub** (`src/modules/ipc/commands.ts`) — `IPC.saveProjects` is a no-op; real Tauri commands in PR 3

- **`src/lib/utils.ts`** — `cn()` helper (clsx + tailwind-merge), force-tracked past global gitignore

### Not in this PR
- Real Tauri IPC / persistence (PR 3)
- Terminal pane / session management (PR 4+)
- Add-project dialog (future)