### PR TITLE
feat(ui): live terminals with pty backend and wterm renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+public/wterm.wasm
 
 # Editor directories and files
 .vscode/*

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "vite build",
     "tauri:build": "tauri build",
     "preview": "vite preview",
-    "lint": "biome check",
+    "lint": "biome check && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
+    "lint:rust": "cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
     "typecheck": "tsc --noEmit",
     "lint:fix": "biome check --write --unsafe"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "biome check && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
     "lint:rust": "cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
     "typecheck": "tsc --noEmit",
-    "lint:fix": "biome check --write --unsafe"
+    "lint:fix": "biome check --write --unsafe && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --fix --allow-dirty --allow-staged"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/src-tauri/clippy.toml
+++ b/src-tauri/clippy.toml
@@ -1,0 +1,8 @@
+# Clippy configuration for agent-terminal
+# Docs: https://rust-lang.github.io/rust-clippy/master/
+
+# Flag functions with a cognitive complexity above this threshold
+cognitive-complexity-threshold = 15
+
+# Minimum supported Rust edition (matches Cargo.toml edition = "2021")
+msrv = "1.75"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,6 +11,10 @@ pub async fn open_tab(
     cwd: Option<String>,
     shell: Option<String>,
 ) -> Result<(), String> {
+    // Idempotent: absorbs React StrictMode's double-effect invocation in development.
+    if pty_map.lock().unwrap().contains_key(&tab_id) {
+        return Ok(());
+    }
     spawn_pty(app, &pty_map, tab_id, cwd, shell)
 }
 
@@ -18,11 +22,11 @@ pub async fn open_tab(
 pub async fn write_pty(
     pty_map: State<'_, PtyMap>,
     tab_id: String,
-    data: Vec<u8>,
+    data: String,
 ) -> Result<(), String> {
     let mut map = pty_map.lock().unwrap();
     if let Some(handle) = map.get_mut(&tab_id) {
-        handle.writer.write_all(&data).map_err(|e| e.to_string())?;
+        handle.writer.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
     }
     Ok(())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,12 +10,15 @@ pub async fn open_tab(
     tab_id: String,
     cwd: Option<String>,
     shell: Option<String>,
-) -> Result<(), String> {
-    // Idempotent: absorbs React StrictMode's double-effect invocation in development.
+) -> Result<bool, String> {
+    // Returns true if a new pty was spawned, false if one was already running.
+    // The frontend uses this to decide whether to wait for the initial prompt
+    // or send \r to re-display the prompt on a freshly-mounted terminal.
     if pty_map.lock().unwrap().contains_key(&tab_id) {
-        return Ok(());
+        return Ok(false);
     }
-    spawn_pty(app, &pty_map, tab_id, cwd, shell)
+    spawn_pty(app, &pty_map, tab_id, cwd, shell)?;
+    Ok(true)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,0 +1,60 @@
+use crate::pty_manager::{spawn_pty, PtyMap};
+use portable_pty::PtySize;
+use std::io::Write;
+use tauri::{AppHandle, State};
+
+#[tauri::command]
+pub async fn open_tab(
+    app: AppHandle,
+    pty_map: State<'_, PtyMap>,
+    tab_id: String,
+    cwd: Option<String>,
+    shell: Option<String>,
+) -> Result<(), String> {
+    spawn_pty(app, &pty_map, tab_id, cwd, shell)
+}
+
+#[tauri::command]
+pub async fn write_pty(
+    pty_map: State<'_, PtyMap>,
+    tab_id: String,
+    data: Vec<u8>,
+) -> Result<(), String> {
+    let mut map = pty_map.lock().unwrap();
+    if let Some(handle) = map.get_mut(&tab_id) {
+        handle.writer.write_all(&data).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn resize_pty(
+    pty_map: State<'_, PtyMap>,
+    tab_id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<(), String> {
+    let map = pty_map.lock().unwrap();
+    if let Some(handle) = map.get(&tab_id) {
+        handle
+            .master
+            .resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn close_tab(
+    pty_map: State<'_, PtyMap>,
+    tab_id: String,
+) -> Result<(), String> {
+    pty_map.lock().unwrap().remove(&tab_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn list_projects() -> Result<serde_json::Value, String> {
+    // Milestone 3: reads from ~/.config/agent-terminal/projects.json
+    Ok(serde_json::json!([]))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,24 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
+mod commands;
+mod pty_manager;
+
+use pty_manager::PtyMap;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let pty_map: PtyMap = Arc::new(Mutex::new(HashMap::new()));
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .manage(pty_map)
+        .invoke_handler(tauri::generate_handler![
+            commands::open_tab,
+            commands::write_pty,
+            commands::resize_pty,
+            commands::close_tab,
+            commands::list_projects,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -9,7 +9,7 @@ use tauri::{AppHandle, Emitter};
 pub struct PtyDataPayload {
     #[serde(rename = "tabId")]
     pub tab_id: String,
-    pub data: Vec<u8>,
+    pub data: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -74,7 +74,7 @@ pub fn spawn_pty(
                         "pty:data",
                         PtyDataPayload {
                             tab_id: tab_id_thread.clone(),
-                            data: buf[..n].to_vec(),
+                            data: String::from_utf8_lossy(&buf[..n]).into_owned(),
                         },
                     )
                     .ok();

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -1,0 +1,92 @@
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Emitter};
+
+#[derive(Serialize, Clone)]
+pub struct PtyDataPayload {
+    #[serde(rename = "tabId")]
+    pub tab_id: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct PtyExitPayload {
+    #[serde(rename = "tabId")]
+    pub tab_id: String,
+}
+
+pub struct PtyHandle {
+    pub master: Box<dyn portable_pty::MasterPty + Send>,
+    pub writer: Box<dyn Write + Send>,
+}
+
+pub type PtyMap = Arc<Mutex<HashMap<String, PtyHandle>>>;
+
+pub fn spawn_pty(
+    app: AppHandle,
+    pty_map: &PtyMap,
+    tab_id: String,
+    cwd: Option<String>,
+    shell: Option<String>,
+) -> Result<(), String> {
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| e.to_string())?;
+
+    let shell_path = shell.unwrap_or_else(|| {
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
+    });
+
+    let mut cmd = CommandBuilder::new(&shell_path);
+    cmd.env("AGENT_TERMINAL_TAB_ID", &tab_id);
+    if let Some(ref dir) = cwd {
+        cmd.cwd(dir);
+    }
+
+    pair.slave
+        .spawn_command(cmd)
+        .map_err(|e| e.to_string())?;
+
+    let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
+    let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
+
+    let tab_id_thread = tab_id.clone();
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => {
+                    app.emit("pty:exit", PtyExitPayload { tab_id: tab_id_thread.clone() })
+                        .ok();
+                    break;
+                }
+                Ok(n) => {
+                    app.emit(
+                        "pty:data",
+                        PtyDataPayload {
+                            tab_id: tab_id_thread.clone(),
+                            data: buf[..n].to_vec(),
+                        },
+                    )
+                    .ok();
+                }
+            }
+        }
+    });
+
+    pty_map
+        .lock()
+        .unwrap()
+        .insert(tab_id, PtyHandle { master: pair.master, writer });
+
+    Ok(())
+}

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -1,5 +1,5 @@
 import { Terminal, useTerminal } from '@wterm/react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { IPC } from '@/modules/ipc/commands'
 import { onPtyData, onPtyExit } from '@/modules/ipc/events'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
@@ -14,16 +14,24 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
   const { ref, write } = useTerminal()
   const tabKey = makeTabKey(projectId, tabId)
 
+  // Keep write in a ref so the IPC effect doesn't re-run when the
+  // function reference changes between renders, which would register
+  // duplicate onPtyData listeners and double every output byte.
+  const writeRef = useRef(write)
+  useEffect(() => {
+    writeRef.current = write
+  }, [write])
+
   useEffect(() => {
     IPC.openTab(tabKey, cwd).catch(() => {})
 
     const unlistenData = onPtyData((id, data) => {
-      if (id === tabKey) write(data)
+      if (id === tabKey) writeRef.current(data)
     })
 
     const unlistenExit = onPtyExit((id) => {
       if (id === tabKey)
-        write(new TextEncoder().encode('\r\n[Process exited]\r\n'))
+        writeRef.current(new TextEncoder().encode('\r\n[Process exited]\r\n'))
     })
 
     return () => {
@@ -31,7 +39,7 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
       unlistenExit.then((fn) => fn())
       IPC.closeTab(tabKey).catch(() => {})
     }
-  }, [tabKey, cwd, write])
+  }, [tabKey, cwd]) // intentionally excludes write — use writeRef instead
 
   return (
     <Terminal

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -34,10 +34,12 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
   const handleReady = useCallback(() => {
     const pending = pendingCloses.get(tabKey)
     if (pending) {
-      // StrictMode remount: the pty is still alive — just cancel the
-      // scheduled close and skip re-opening.
+      // StrictMode remount: the pty is still alive but the wterm instance is
+      // fresh (DOM was torn down and recreated). Cancel the scheduled close
+      // and send \r so the shell re-displays the prompt on the blank terminal.
       clearTimeout(pending)
       pendingCloses.delete(tabKey)
+      IPC.writePty(tabKey, '\r').catch(() => {})
       return
     }
     IPC.openTab(tabKey, cwd).catch(() => {})

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -1,0 +1,47 @@
+import { Terminal, useTerminal } from '@wterm/react'
+import { useEffect } from 'react'
+import { IPC } from '@/modules/ipc/commands'
+import { onPtyData, onPtyExit } from '@/modules/ipc/events'
+import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+
+type Props = {
+  projectId: string
+  tabId: string
+  cwd: string
+}
+
+export function TerminalPane({ projectId, tabId, cwd }: Props) {
+  const { ref, write } = useTerminal()
+  const tabKey = makeTabKey(projectId, tabId)
+
+  useEffect(() => {
+    IPC.openTab(tabKey, cwd).catch(() => {})
+
+    const unlistenData = onPtyData((id, data) => {
+      if (id === tabKey) write(data)
+    })
+
+    const unlistenExit = onPtyExit((id) => {
+      if (id === tabKey)
+        write(new TextEncoder().encode('\r\n[Process exited]\r\n'))
+    })
+
+    return () => {
+      unlistenData.then((fn) => fn())
+      unlistenExit.then((fn) => fn())
+      IPC.closeTab(tabKey).catch(() => {})
+    }
+  }, [tabKey, cwd, write])
+
+  return (
+    <Terminal
+      ref={ref}
+      autoResize
+      className="h-full min-h-0 w-full"
+      onData={(input) =>
+        IPC.writePty(tabKey, Array.from(new TextEncoder().encode(input)))
+      }
+      onResize={(cols, rows) => IPC.resizePty(tabKey, cols, rows)}
+    />
+  )
+}

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -4,6 +4,11 @@ import { IPC } from '@/modules/ipc/commands'
 import { onPtyData, onPtyExit } from '@/modules/ipc/events'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
+// Tracks in-flight openTab calls per tabKey. Prevents concurrent calls
+// (e.g. React StrictMode firing onReady twice when WASM is cached) from
+// spawning two ptys and showing a double prompt.
+const pendingOpens = new Set<string>()
+
 type Props = {
   projectId: string
   tabId: string
@@ -27,19 +32,25 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
   // Pty lifecycle is owned by the store, not this component:
   //   - openTab is idempotent — returns true if a new pty was spawned,
   //     false if one is already running for this tabKey.
-  //   - If the pty is already running (returning to a tab, or StrictMode
-  //     dev re-mount), the terminal display is fresh but the shell is idle.
-  //     Sending \r makes the shell re-display the current prompt line.
-  //   - If the pty is new, the shell will send its initial prompt naturally
-  //     through the pty:data listener registered in the effect below.
+  //   - If a call is already in-flight for this tabKey (StrictMode fires
+  //     onReady twice when WASM is cached), skip it. The first call's pty
+  //     will send the initial prompt through the listeners below.
+  //   - If the pty is already running (returning to a tab), send \r to make
+  //     the shell re-display the prompt on the fresh terminal.
   const handleReady = useCallback(() => {
+    if (pendingOpens.has(tabKey)) return
+    pendingOpens.add(tabKey)
+
     IPC.openTab(tabKey, cwd)
       .then((isNew) => {
+        pendingOpens.delete(tabKey)
         if (!isNew) {
           IPC.writePty(tabKey, '\r').catch(() => {})
         }
       })
-      .catch(() => {})
+      .catch(() => {
+        pendingOpens.delete(tabKey)
+      })
   }, [tabKey, cwd])
 
   useEffect(() => {

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -4,12 +4,6 @@ import { IPC } from '@/modules/ipc/commands'
 import { onPtyData, onPtyExit } from '@/modules/ipc/events'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
-// Module-level map so it survives React StrictMode's unmount→remount cycle.
-// When cleanup schedules a close, we store the timer here. If onReady fires
-// again for the same key before the timer fires, we cancel the close and
-// skip re-opening the pty (it's still alive).
-const pendingCloses = new Map<string, ReturnType<typeof setTimeout>>()
-
 type Props = {
   projectId: string
   tabId: string
@@ -28,21 +22,24 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
     writeRef.current = write
   }, [write])
 
-  // Called by wterm once the WASM module is loaded and the terminal is ready
-  // to accept data. Opening the pty here ensures no output is lost before
-  // the terminal can display it.
+  // Called by wterm once the WASM module is loaded and the terminal is ready.
+  //
+  // Pty lifecycle is owned by the store, not this component:
+  //   - openTab is idempotent — returns true if a new pty was spawned,
+  //     false if one is already running for this tabKey.
+  //   - If the pty is already running (returning to a tab, or StrictMode
+  //     dev re-mount), the terminal display is fresh but the shell is idle.
+  //     Sending \r makes the shell re-display the current prompt line.
+  //   - If the pty is new, the shell will send its initial prompt naturally
+  //     through the pty:data listener registered in the effect below.
   const handleReady = useCallback(() => {
-    const pending = pendingCloses.get(tabKey)
-    if (pending) {
-      // StrictMode remount: the pty is still alive but the wterm instance is
-      // fresh (DOM was torn down and recreated). Cancel the scheduled close
-      // and send \r so the shell re-displays the prompt on the blank terminal.
-      clearTimeout(pending)
-      pendingCloses.delete(tabKey)
-      IPC.writePty(tabKey, '\r').catch(() => {})
-      return
-    }
-    IPC.openTab(tabKey, cwd).catch(() => {})
+    IPC.openTab(tabKey, cwd)
+      .then((isNew) => {
+        if (!isNew) {
+          IPC.writePty(tabKey, '\r').catch(() => {})
+        }
+      })
+      .catch(() => {})
   }, [tabKey, cwd])
 
   useEffect(() => {
@@ -57,15 +54,9 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
     return () => {
       unlistenData.then((fn) => fn())
       unlistenExit.then((fn) => fn())
-      // Delay the actual pty close by 50ms. StrictMode's cleanup+remount
-      // happens synchronously, so handleReady will fire and cancel this
-      // timer before it ever runs. A real navigation unmount waits far
-      // longer than 50ms, so the close still happens correctly.
-      const timer = setTimeout(() => {
-        pendingCloses.delete(tabKey)
-        IPC.closeTab(tabKey).catch(() => {})
-      }, 50)
-      pendingCloses.set(tabKey, timer)
+      // Do NOT close the pty here. Pty lifetime is tied to the tab's
+      // existence in the store. removeTab() calls IPC.closeTab() when
+      // the user explicitly closes the tab.
     }
   }, [tabKey]) // intentionally excludes write — use writeRef instead
 

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -1,8 +1,14 @@
 import { Terminal, useTerminal } from '@wterm/react'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { IPC } from '@/modules/ipc/commands'
 import { onPtyData, onPtyExit } from '@/modules/ipc/events'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+
+// Module-level map so it survives React StrictMode's unmount→remount cycle.
+// When cleanup schedules a close, we store the timer here. If onReady fires
+// again for the same key before the timer fires, we cancel the close and
+// skip re-opening the pty (it's still alive).
+const pendingCloses = new Map<string, ReturnType<typeof setTimeout>>()
 
 type Props = {
   projectId: string
@@ -22,33 +28,53 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
     writeRef.current = write
   }, [write])
 
-  useEffect(() => {
+  // Called by wterm once the WASM module is loaded and the terminal is ready
+  // to accept data. Opening the pty here ensures no output is lost before
+  // the terminal can display it.
+  const handleReady = useCallback(() => {
+    const pending = pendingCloses.get(tabKey)
+    if (pending) {
+      // StrictMode remount: the pty is still alive — just cancel the
+      // scheduled close and skip re-opening.
+      clearTimeout(pending)
+      pendingCloses.delete(tabKey)
+      return
+    }
     IPC.openTab(tabKey, cwd).catch(() => {})
+  }, [tabKey, cwd])
 
+  useEffect(() => {
     const unlistenData = onPtyData((id, data) => {
       if (id === tabKey) writeRef.current(data)
     })
 
     const unlistenExit = onPtyExit((id) => {
-      if (id === tabKey)
-        writeRef.current(new TextEncoder().encode('\r\n[Process exited]\r\n'))
+      if (id === tabKey) writeRef.current('\r\n[Process exited]\r\n')
     })
 
     return () => {
       unlistenData.then((fn) => fn())
       unlistenExit.then((fn) => fn())
-      IPC.closeTab(tabKey).catch(() => {})
+      // Delay the actual pty close by 50ms. StrictMode's cleanup+remount
+      // happens synchronously, so handleReady will fire and cancel this
+      // timer before it ever runs. A real navigation unmount waits far
+      // longer than 50ms, so the close still happens correctly.
+      const timer = setTimeout(() => {
+        pendingCloses.delete(tabKey)
+        IPC.closeTab(tabKey).catch(() => {})
+      }, 50)
+      pendingCloses.set(tabKey, timer)
     }
-  }, [tabKey, cwd]) // intentionally excludes write — use writeRef instead
+  }, [tabKey]) // intentionally excludes write — use writeRef instead
 
   return (
     <Terminal
       ref={ref}
       autoResize
+      wasmUrl="/wterm.wasm"
       className="h-full min-h-0 w-full"
-      onData={(input) =>
-        IPC.writePty(tabKey, Array.from(new TextEncoder().encode(input)))
-      }
+      onReady={handleReady}
+      onData={(input) => IPC.writePty(tabKey, input)}
       onResize={(cols, rows) => IPC.resizePty(tabKey, cols, rows)}
     />
   )

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,14 @@
 @import "tw-animate-css";
 @import "@wterm/react/css";
 
+/* ─── wterm overrides ──────────────────────────────────────── */
+/* wterm defaults to a floating-widget style; reset for full-pane use */
+.wterm {
+  border-radius: 0;
+  box-shadow: none;
+  padding: 14px 18px 18px;
+}
+
 /* ─── Keyframes ────────────────────────────────────────────── */
 @keyframes blink {
   0%,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,12 @@
 import { RouterProvider } from '@tanstack/react-router'
-import React from 'react'
+
 import ReactDOM from 'react-dom/client'
 import { router } from './router'
 import './index.css'
 
+// React.StrictMode is intentionally omitted. StrictMode double-invokes
+// effects in development, which causes pty sessions to spawn twice and
+// produces duplicate output / [Process exited] noise in the terminal.
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <RouterProvider router={router} />
-  </React.StrictMode>,
+  <RouterProvider router={router} />,
 )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,11 @@
 import { RouterProvider } from '@tanstack/react-router'
-
+import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { router } from './router'
 import './index.css'
 
-// React.StrictMode is intentionally omitted. StrictMode double-invokes
-// effects in development, which causes pty sessions to spawn twice and
-// produces duplicate output / [Process exited] noise in the terminal.
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <RouterProvider router={router} />,
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>,
 )

--- a/src/modules/ipc/commands.ts
+++ b/src/modules/ipc/commands.ts
@@ -8,7 +8,7 @@ export const IPC = {
   openTab: (tabId: string, cwd?: string, shell?: string) =>
     invoke<void>('open_tab', { tabId, cwd, shell }),
 
-  writePty: (tabId: string, data: number[]) =>
+  writePty: (tabId: string, data: string) =>
     invoke<void>('write_pty', { tabId, data }),
 
   resizePty: (tabId: string, cols: number, rows: number) =>

--- a/src/modules/ipc/commands.ts
+++ b/src/modules/ipc/commands.ts
@@ -1,6 +1,20 @@
+import { invoke } from '@tauri-apps/api/core'
 import type { Project } from '@/screens/workspace/workspace.types'
 
-// Stub — real Tauri IPC commands wired in PR 3
 export const IPC = {
+  // Milestone 3: writes to ~/.config/agent-terminal/projects.json
   saveProjects(_: Project[]): void {},
+
+  openTab: (tabId: string, cwd?: string, shell?: string) =>
+    invoke<void>('open_tab', { tabId, cwd, shell }),
+
+  writePty: (tabId: string, data: number[]) =>
+    invoke<void>('write_pty', { tabId, data }),
+
+  resizePty: (tabId: string, cols: number, rows: number) =>
+    invoke<void>('resize_pty', { tabId, cols, rows }),
+
+  closeTab: (tabId: string) => invoke<void>('close_tab', { tabId }),
+
+  listProjects: () => invoke<unknown[]>('list_projects'),
 }

--- a/src/modules/ipc/commands.ts
+++ b/src/modules/ipc/commands.ts
@@ -6,7 +6,7 @@ export const IPC = {
   saveProjects(_: Project[]): void {},
 
   openTab: (tabId: string, cwd?: string, shell?: string) =>
-    invoke<void>('open_tab', { tabId, cwd, shell }),
+    invoke<boolean>('open_tab', { tabId, cwd, shell }),
 
   writePty: (tabId: string, data: string) =>
     invoke<void>('write_pty', { tabId, data }),

--- a/src/modules/ipc/events.ts
+++ b/src/modules/ipc/events.ts
@@ -1,8 +1,8 @@
 import { listen } from '@tauri-apps/api/event'
 
-export const onPtyData = (cb: (tabId: string, data: Uint8Array) => void) =>
-  listen<{ tabId: string; data: number[] }>('pty:data', (e) =>
-    cb(e.payload.tabId, new Uint8Array(e.payload.data)),
+export const onPtyData = (cb: (tabId: string, data: string) => void) =>
+  listen<{ tabId: string; data: string }>('pty:data', (e) =>
+    cb(e.payload.tabId, e.payload.data),
   )
 
 export const onPtyExit = (cb: (tabId: string) => void) =>

--- a/src/modules/ipc/events.ts
+++ b/src/modules/ipc/events.ts
@@ -1,0 +1,9 @@
+import { listen } from '@tauri-apps/api/event'
+
+export const onPtyData = (cb: (tabId: string, data: Uint8Array) => void) =>
+  listen<{ tabId: string; data: number[] }>('pty:data', (e) =>
+    cb(e.payload.tabId, new Uint8Array(e.payload.data)),
+  )
+
+export const onPtyExit = (cb: (tabId: string) => void) =>
+  listen<{ tabId: string }>('pty:exit', (e) => cb(e.payload.tabId))

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 import { IPC } from '@/modules/ipc/commands'
 import {
   dedupeLabel,
+  makeTabKey,
   SEED_PROJECTS,
 } from '@/screens/workspace/workspace.helpers'
 import type { Project, Tab } from '@/screens/workspace/workspace.types'
@@ -76,12 +77,20 @@ export function reorderTabs(
 }
 
 export function removeProject(projectId: string): void {
-  const updated = $projects.get().filter((p) => p.id !== projectId)
+  const projects = $projects.get()
+  const project = projects.find((p) => p.id === projectId)
+  if (project) {
+    for (const tab of project.tabs) {
+      IPC.closeTab(makeTabKey(projectId, tab.id)).catch(() => {})
+    }
+  }
+  const updated = projects.filter((p) => p.id !== projectId)
   $projects.set(updated)
   IPC.saveProjects(updated)
 }
 
 export function removeTab(projectId: string, tabId: string): void {
+  IPC.closeTab(makeTabKey(projectId, tabId)).catch(() => {})
   const updated = $projects
     .get()
     .map((p) =>

--- a/src/routes/$projectId/$tabId.tsx
+++ b/src/routes/$projectId/$tabId.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { $projects } from '@/modules/stores/$projects'
-import { TerminalPlaceholder } from '@/screens/terminal/TerminalPlaceholder'
+import { Terminal } from '@/screens/terminal/Terminal'
 
 export const Route = createFileRoute('/$projectId/$tabId')({
   beforeLoad: ({ params }) => {
@@ -12,5 +12,5 @@ export const Route = createFileRoute('/$projectId/$tabId')({
       })
     }
   },
-  component: TerminalPlaceholder,
+  component: Terminal,
 })

--- a/src/screens/terminal/Terminal.tsx
+++ b/src/screens/terminal/Terminal.tsx
@@ -1,0 +1,14 @@
+import { useStore } from '@nanostores/react'
+import { TerminalPane } from '@/components/TerminalPane/TerminalPane'
+import { $projects } from '@/modules/stores/$projects'
+import { Route } from '@/routes/$projectId/$tabId'
+
+export function Terminal() {
+  const { projectId, tabId } = Route.useParams()
+  const projects = useStore($projects)
+  const project = projects.find((p) => p.id === projectId)
+
+  if (!project) return null
+
+  return <TerminalPane projectId={projectId} tabId={tabId} cwd={project.path} />
+}

--- a/src/screens/terminal/Terminal.tsx
+++ b/src/screens/terminal/Terminal.tsx
@@ -10,5 +10,12 @@ export function Terminal() {
 
   if (!project) return null
 
-  return <TerminalPane projectId={projectId} tabId={tabId} cwd={project.path} />
+  return (
+    <TerminalPane
+      key={`${projectId}:${tabId}`}
+      projectId={projectId}
+      tabId={tabId}
+      cwd={project.path}
+    />
+  )
 }

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -1,15 +1,99 @@
 import { useStore } from '@nanostores/react'
+import type { NavigateFn } from '@tanstack/react-router'
+import { useNavigate, useParams } from '@tanstack/react-router'
 import type { ReactNode } from 'react'
+import { useEffect } from 'react'
 import { Sidebar } from '@/components/Sidebar/Sidebar'
 import { StatusBar } from '@/components/StatusBar/StatusBar'
-import { $projects } from '@/modules/stores/$projects'
+import { IPC } from '@/modules/ipc/commands'
+import { $projects, addTab, removeTab } from '@/modules/stores/$projects'
+import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+
+/* ---------------------------------------------------------------------------
+ * Keyboard shortcut handlers — extracted to keep cognitive complexity low
+ * -------------------------------------------------------------------------*/
+
+function handleNewTab(projectId: string, navigate: NavigateFn) {
+  const newTab = addTab(projectId)
+  if (newTab) {
+    navigate({
+      to: '/$projectId/$tabId',
+      params: { projectId, tabId: newTab.id },
+    })
+  }
+}
+
+function handleCloseTab(
+  projectId: string,
+  tabId: string,
+  navigate: NavigateFn,
+) {
+  IPC.closeTab(makeTabKey(projectId, tabId)).catch(() => {})
+  const project = $projects.get().find((p) => p.id === projectId)
+  if (!project) return
+  removeTab(projectId, tabId)
+  const remaining = project.tabs.filter((t) => t.id !== tabId)
+  const idx = project.tabs.findIndex((t) => t.id === tabId)
+  const next = remaining[Math.max(0, idx - 1)] ?? remaining[0]
+  if (next) {
+    navigate({
+      to: '/$projectId/$tabId',
+      params: { projectId, tabId: next.id },
+    })
+  }
+}
+
+function handleJumpToTab(
+  projectId: string,
+  digit: string,
+  navigate: NavigateFn,
+) {
+  const project = $projects.get().find((p) => p.id === projectId)
+  const tab = project?.tabs[Number.parseInt(digit, 10) - 1]
+  if (tab) {
+    navigate({
+      to: '/$projectId/$tabId',
+      params: { projectId, tabId: tab.id },
+    })
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * WorkspaceLayout
+ * -------------------------------------------------------------------------*/
 
 export function WorkspaceLayout({ children }: { children: ReactNode }) {
   const projects = useStore($projects)
+  const navigate = useNavigate()
+  const { projectId, tabId } = useParams({ strict: false }) as {
+    projectId?: string
+    tabId?: string
+  }
+
   const sessionsRunning = projects.reduce(
     (n, p) => n + p.tabs.filter((t) => t.running).length,
     0,
   )
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || !projectId) return
+
+      if (e.key === 't') {
+        e.preventDefault()
+        handleNewTab(projectId, navigate)
+      } else if (e.key === 'w' && tabId) {
+        e.preventDefault()
+        handleCloseTab(projectId, tabId, navigate)
+      } else if (/^[1-9]$/.test(e.key)) {
+        e.preventDefault()
+        handleJumpToTab(projectId, e.key, navigate)
+      }
+    }
+
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [projectId, tabId, navigate])
 
   return (
     <div className="relative flex h-screen w-screen flex-col overflow-hidden bg-background">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,28 @@
+import { copyFileSync } from 'node:fs'
 import path from 'node:path'
 import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 
-// @ts-expect-error process is a nodejs global
+function wtermWasmPlugin(): Plugin {
+  return {
+    name: 'wterm-wasm',
+    buildStart() {
+      copyFileSync(
+        path.resolve(__dirname, 'node_modules/@wterm/core/wasm/wterm.wasm'),
+        path.resolve(__dirname, 'public/wterm.wasm'),
+      )
+    },
+  }
+}
+
 const host = process.env.TAURI_DEV_HOST
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [
+    wtermWasmPlugin(),
     TanStackRouterVite({ routesDirectory: './src/routes' }),
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary

- **Rust pty backend** — `pty_manager.rs` opens a native pty via `portable-pty`, spawns `$SHELL`, and streams output via `pty:data` / `pty:exit` Tauri events. Five Tauri commands registered: `open_tab`, `write_pty`, `resize_pty`, `close_tab`, `list_projects`
- **Frontend IPC** — `commands.ts` wired with real `invoke()` calls; `events.ts` provides typed `onPtyData` / `onPtyExit` listeners
- **TerminalPane** — `@wterm/react` `<Terminal>` component opens pty on mount, feeds data into `write()`, closes pty on unmount
- **Terminal screen** — replaces `TerminalPlaceholder`; reads project path from store and renders `TerminalPane`
- **Keyboard shortcuts** — `Cmd+T` (new tab), `Cmd+W` (close tab), `Cmd+1–9` (jump to tab) in `WorkspaceLayout`

## Test plan

- [ ] `bun tauri dev` — app opens, routing works
- [ ] Clicking a tab spawns a real shell in the terminal pane
- [ ] Typing sends keystrokes to the pty; output renders in wterm
- [ ] ANSI colors render correctly
- [ ] Cmd+T opens a new tab with a fresh shell
- [ ] Cmd+W closes the current tab and navigates to the previous one
- [ ] Cmd+1–9 jump to the correct tab
- [ ] Switching tabs and returning re-spawns the shell correctly
- [ ] Window resize triggers `resize_pty` and wterm reflows