### PR TITLE
perf(ipc): Channel API + 256KB read buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@ node_modules
 dist
 dist-ssr
 *.local
-public/wterm.wasm
-
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,8 @@
-use crate::pty_manager::{spawn_pty, PtyMap};
+use crate::pty_manager::{spawn_pty, PtyDataPayload, PtyMap};
 use portable_pty::PtySize;
 use std::io::Write;
 use tauri::{AppHandle, State};
+use tauri::ipc::Channel;
 
 #[tauri::command]
 pub async fn open_tab(
@@ -10,6 +11,7 @@ pub async fn open_tab(
     tab_id: String,
     cwd: Option<String>,
     shell: Option<String>,
+    on_data: Channel<PtyDataPayload>,
 ) -> Result<bool, String> {
     // Returns true if a new pty was spawned, false if one was already running.
     // The frontend uses this to decide whether to wait for the initial prompt
@@ -17,7 +19,7 @@ pub async fn open_tab(
     if pty_map.lock().unwrap().contains_key(&tab_id) {
         return Ok(false);
     }
-    spawn_pty(app, &pty_map, tab_id, cwd, shell)?;
+    spawn_pty(app, &pty_map, tab_id, cwd, shell, on_data)?;
     Ok(true)
 }
 

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -28,15 +28,14 @@ pub struct PtyHandle {
 
 pub type PtyMap = Arc<Mutex<HashMap<String, PtyHandle>>>;
 
-/// 256 KB — captures a full burst of output in a single read() call on most
-/// shells. Reduces Channel message count by ~64× vs the old 4 KB buffer for
-/// high-throughput output (cat, build tools, find).
+/// 256 KB read buffer. A single read() call can return up to this many bytes
+/// when the kernel has burst output ready (build tools, cat, find). This IS
+/// the coalescing — no separate accumulation loop is needed.
+///
+/// For interactive use (prompt, keystroke echo) the kernel returns a small
+/// number of bytes immediately and read() blocks again. Those bytes are sent
+/// right away so the terminal never freezes waiting for a threshold.
 const READ_BUF_SIZE: usize = 256 * 1024;
-
-/// Flush the accumulation buffer once it exceeds this size even if the read
-/// loop has not blocked. Prevents unbounded accumulation during continuous
-/// high-speed streams.
-const FLUSH_THRESHOLD: usize = 32 * 1024;
 
 pub fn spawn_pty(
     app: AppHandle,
@@ -74,17 +73,10 @@ pub fn spawn_pty(
     let tab_id_thread = tab_id.clone();
     std::thread::spawn(move || {
         let mut buf = [0u8; READ_BUF_SIZE];
-        let mut accumulated = String::new();
 
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => {
-                    // Flush any remaining accumulated data before signalling exit.
-                    if !accumulated.is_empty() {
-                        on_data
-                            .send(PtyDataPayload { data: std::mem::take(&mut accumulated) })
-                            .ok();
-                    }
                     app.emit(
                         "pty:exit",
                         PtyExitPayload { tab_id: tab_id_thread.clone() },
@@ -93,17 +85,15 @@ pub fn spawn_pty(
                     break;
                 }
                 Ok(n) => {
-                    accumulated.push_str(&String::from_utf8_lossy(&buf[..n]));
-
-                    // Flush when the buffer is large enough. For interactive sessions
-                    // (small writes, ~1–64 bytes per keystroke echo) accumulated stays
-                    // well below the threshold and is flushed on the next read block.
-                    // For burst output the threshold caps the message payload at 32 KB.
-                    if accumulated.len() >= FLUSH_THRESHOLD {
-                        on_data
-                            .send(PtyDataPayload { data: std::mem::take(&mut accumulated) })
-                            .ok();
-                    }
+                    // Send immediately — never hold data back. read() blocks until
+                    // the kernel has bytes, so whatever it returns is all that's
+                    // available right now. Waiting for more would freeze the terminal
+                    // for interactive output (prompts, keystroke echoes).
+                    on_data
+                        .send(PtyDataPayload {
+                            data: String::from_utf8_lossy(&buf[..n]).into_owned(),
+                        })
+                        .ok();
                 }
             }
         }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -89,11 +89,18 @@ pub fn spawn_pty(
                     // the kernel has bytes, so whatever it returns is all that's
                     // available right now. Waiting for more would freeze the terminal
                     // for interactive output (prompts, keystroke echoes).
-                    on_data
+                    //
+                    // Break on send error: the Channel is dropped when the JS side
+                    // is GC'd (tab closed). Continuing to read and silently discard
+                    // output would leak the thread. Exit cleanly instead.
+                    if on_data
                         .send(PtyDataPayload {
                             data: String::from_utf8_lossy(&buf[..n]).into_owned(),
                         })
-                        .ok();
+                        .is_err()
+                    {
+                        break;
+                    }
                 }
             }
         }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -4,14 +4,17 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter};
+use tauri::ipc::Channel;
 
+/// Sent directly to the frontend via the per-tab Channel.
+/// No tabId field — the channel is already bound to a specific tab.
 #[derive(Serialize, Clone)]
 pub struct PtyDataPayload {
-    #[serde(rename = "tabId")]
-    pub tab_id: String,
     pub data: String,
 }
 
+/// Emitted as a global event on shell exit. Fires rarely so the event bus
+/// overhead is acceptable; no Channel needed.
 #[derive(Serialize, Clone)]
 pub struct PtyExitPayload {
     #[serde(rename = "tabId")]
@@ -25,12 +28,23 @@ pub struct PtyHandle {
 
 pub type PtyMap = Arc<Mutex<HashMap<String, PtyHandle>>>;
 
+/// 256 KB — captures a full burst of output in a single read() call on most
+/// shells. Reduces Channel message count by ~64× vs the old 4 KB buffer for
+/// high-throughput output (cat, build tools, find).
+const READ_BUF_SIZE: usize = 256 * 1024;
+
+/// Flush the accumulation buffer once it exceeds this size even if the read
+/// loop has not blocked. Prevents unbounded accumulation during continuous
+/// high-speed streams.
+const FLUSH_THRESHOLD: usize = 32 * 1024;
+
 pub fn spawn_pty(
     app: AppHandle,
     pty_map: &PtyMap,
     tab_id: String,
     cwd: Option<String>,
     shell: Option<String>,
+    on_data: Channel<PtyDataPayload>,
 ) -> Result<(), String> {
     let pty_system = native_pty_system();
     let pair = pty_system
@@ -52,32 +66,44 @@ pub fn spawn_pty(
         cmd.cwd(dir);
     }
 
-    pair.slave
-        .spawn_command(cmd)
-        .map_err(|e| e.to_string())?;
+    pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
 
     let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
 
     let tab_id_thread = tab_id.clone();
     std::thread::spawn(move || {
-        let mut buf = [0u8; 4096];
+        let mut buf = [0u8; READ_BUF_SIZE];
+        let mut accumulated = String::new();
+
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => {
-                    app.emit("pty:exit", PtyExitPayload { tab_id: tab_id_thread.clone() })
-                        .ok();
+                    // Flush any remaining accumulated data before signalling exit.
+                    if !accumulated.is_empty() {
+                        on_data
+                            .send(PtyDataPayload { data: std::mem::take(&mut accumulated) })
+                            .ok();
+                    }
+                    app.emit(
+                        "pty:exit",
+                        PtyExitPayload { tab_id: tab_id_thread.clone() },
+                    )
+                    .ok();
                     break;
                 }
                 Ok(n) => {
-                    app.emit(
-                        "pty:data",
-                        PtyDataPayload {
-                            tab_id: tab_id_thread.clone(),
-                            data: String::from_utf8_lossy(&buf[..n]).into_owned(),
-                        },
-                    )
-                    .ok();
+                    accumulated.push_str(&String::from_utf8_lossy(&buf[..n]));
+
+                    // Flush when the buffer is large enough. For interactive sessions
+                    // (small writes, ~1–64 bytes per keystroke echo) accumulated stays
+                    // well below the threshold and is flushed on the next read block.
+                    // For burst output the threshold caps the message payload at 32 KB.
+                    if accumulated.len() >= FLUSH_THRESHOLD {
+                        on_data
+                            .send(PtyDataPayload { data: std::mem::take(&mut accumulated) })
+                            .ok();
+                    }
                 }
             }
         }

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -73,7 +73,6 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
     <Terminal
       ref={ref}
       autoResize
-      wasmUrl="/wterm.wasm"
       className="h-full min-h-0 w-full"
       onReady={handleReady}
       onData={(input) => IPC.writePty(tabKey, input)}

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -1,7 +1,7 @@
 import { Terminal, useTerminal } from '@wterm/react'
 import { useCallback, useEffect, useRef } from 'react'
 import { IPC } from '@/modules/ipc/commands'
-import { onPtyData, onPtyExit } from '@/modules/ipc/events'
+import { onPtyExit } from '@/modules/ipc/events'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
 // Tracks in-flight openTab calls per tabKey. Prevents concurrent calls
@@ -19,9 +19,8 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
   const { ref, write } = useTerminal()
   const tabKey = makeTabKey(projectId, tabId)
 
-  // Keep write in a ref so the IPC effect doesn't re-run when the
-  // function reference changes between renders, which would register
-  // duplicate onPtyData listeners and double every output byte.
+  // Keep write in a ref so the Channel callback captures it by reference
+  // rather than closing over a stale value from the first render.
   const writeRef = useRef(write)
   useEffect(() => {
     writeRef.current = write
@@ -33,15 +32,19 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
   //   - openTab is idempotent — returns true if a new pty was spawned,
   //     false if one is already running for this tabKey.
   //   - If a call is already in-flight for this tabKey (StrictMode fires
-  //     onReady twice when WASM is cached), skip it. The first call's pty
-  //     will send the initial prompt through the listeners below.
+  //     onReady twice when WASM is cached), skip it.
   //   - If the pty is already running (returning to a tab), send \r to make
   //     the shell re-display the prompt on the fresh terminal.
+  //
+  // Data arrives via the per-tab Channel passed to openTab — no global event
+  // bus listener, no fan-out to other tabs.
   const handleReady = useCallback(() => {
     if (pendingOpens.has(tabKey)) return
     pendingOpens.add(tabKey)
 
-    IPC.openTab(tabKey, cwd)
+    IPC.openTab(tabKey, cwd, (data) => {
+      writeRef.current(data)
+    })
       .then((isNew) => {
         pendingOpens.delete(tabKey)
         if (!isNew) {
@@ -54,22 +57,17 @@ export function TerminalPane({ projectId, tabId, cwd }: Props) {
   }, [tabKey, cwd])
 
   useEffect(() => {
-    const unlistenData = onPtyData((id, data) => {
-      if (id === tabKey) writeRef.current(data)
-    })
-
     const unlistenExit = onPtyExit((id) => {
       if (id === tabKey) writeRef.current('\r\n[Process exited]\r\n')
     })
 
     return () => {
-      unlistenData.then((fn) => fn())
       unlistenExit.then((fn) => fn())
       // Do NOT close the pty here. Pty lifetime is tied to the tab's
       // existence in the store. removeTab() calls IPC.closeTab() when
       // the user explicitly closes the tab.
     }
-  }, [tabKey]) // intentionally excludes write — use writeRef instead
+  }, [tabKey])
 
   return (
     <Terminal

--- a/src/modules/ipc/commands.ts
+++ b/src/modules/ipc/commands.ts
@@ -10,9 +10,10 @@ export type PtyDataCallback = (data: string) => void
  * The onData callback is called directly by the Channel — no global event bus,
  * no fan-out to other tabs' listeners.
  *
- * The Channel lifetime is tied to the JS closure. When the TerminalPane
- * unmounts (tab closed), the closure is GC'd and the Rust reader thread
- * receives a send error, causing it to exit cleanly.
+ * When the tab is closed, IPC.closeTab() removes the pty from the map. The
+ * reader thread detects a Channel send error on the next write and exits.
+ * Do not rely on GC of the JS closure alone to stop the thread — always call
+ * IPC.closeTab() explicitly when tearing down a tab.
  */
 export function openTab(
   tabId: string,

--- a/src/modules/ipc/commands.ts
+++ b/src/modules/ipc/commands.ts
@@ -1,12 +1,31 @@
-import { invoke } from '@tauri-apps/api/core'
+import { Channel, invoke } from '@tauri-apps/api/core'
 import type { Project } from '@/screens/workspace/workspace.types'
 
-export const IPC = {
-  // Milestone 3: writes to ~/.config/agent-terminal/projects.json
-  saveProjects(_: Project[]): void {},
+export type PtyDataCallback = (data: string) => void
 
-  openTab: (tabId: string, cwd?: string, shell?: string) =>
-    invoke<boolean>('open_tab', { tabId, cwd, shell }),
+/**
+ * Opens a pty for the given tabId and wires a direct Channel for PTY output.
+ *
+ * Returns true if a new pty was spawned, false if one was already running.
+ * The onData callback is called directly by the Channel — no global event bus,
+ * no fan-out to other tabs' listeners.
+ *
+ * The Channel lifetime is tied to the JS closure. When the TerminalPane
+ * unmounts (tab closed), the closure is GC'd and the Rust reader thread
+ * receives a send error, causing it to exit cleanly.
+ */
+export function openTab(
+  tabId: string,
+  cwd: string | undefined,
+  onData: PtyDataCallback,
+): Promise<boolean> {
+  const channel = new Channel<{ data: string }>()
+  channel.onmessage = (payload) => onData(payload.data)
+  return invoke<boolean>('open_tab', { tabId, cwd, onData: channel })
+}
+
+export const IPC = {
+  openTab,
 
   writePty: (tabId: string, data: string) =>
     invoke<void>('write_pty', { tabId, data }),
@@ -15,6 +34,9 @@ export const IPC = {
     invoke<void>('resize_pty', { tabId, cols, rows }),
 
   closeTab: (tabId: string) => invoke<void>('close_tab', { tabId }),
+
+  // Milestone 3: writes to ~/.config/agent-terminal/projects.json
+  saveProjects(_: Project[]): void {},
 
   listProjects: () => invoke<unknown[]>('list_projects'),
 }

--- a/src/modules/ipc/events.ts
+++ b/src/modules/ipc/events.ts
@@ -1,9 +1,7 @@
 import { listen } from '@tauri-apps/api/event'
 
-export const onPtyData = (cb: (tabId: string, data: string) => void) =>
-  listen<{ tabId: string; data: string }>('pty:data', (e) =>
-    cb(e.payload.tabId, e.payload.data),
-  )
+// onPtyData has been removed. PTY output is now delivered via a per-tab
+// Channel passed to IPC.openTab — no global event bus, no fan-out.
 
 export const onPtyExit = (cb: (tabId: string) => void) =>
   listen<{ tabId: string }>('pty:exit', (e) => cb(e.payload.tabId))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,28 +1,14 @@
-import { copyFileSync } from 'node:fs'
 import path from 'node:path'
 import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 import react from '@vitejs/plugin-react'
-import { defineConfig, type Plugin } from 'vite'
-
-function wtermWasmPlugin(): Plugin {
-  return {
-    name: 'wterm-wasm',
-    buildStart() {
-      copyFileSync(
-        path.resolve(__dirname, 'node_modules/@wterm/core/wasm/wterm.wasm'),
-        path.resolve(__dirname, 'public/wterm.wasm'),
-      )
-    },
-  }
-}
+import { defineConfig } from 'vite'
 
 const host = process.env.TAURI_DEV_HOST
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [
-    wtermWasmPlugin(),
     TanStackRouterVite({ routesDirectory: './src/routes' }),
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary

- **Tauri Channel API** replaces `app.emit("pty:data")`. Each tab gets a direct `Channel<PtyDataPayload>` created at `openTab` time — data goes straight to that tab's callback with no global event bus broadcast and no fan-out to other tabs' listeners.
- **256 KB read buffer** replaces 4 KB. A single `read()` call can now capture a full burst of shell output in one shot, reducing Channel message count for high-throughput scenarios (build tools, `cat`, `find /`). The large buffer IS the coalescing — no accumulation loop needed.
- **Send immediately after every read** — never hold data back behind a threshold. `read()` blocks until the kernel has bytes; whatever it returns is everything available at that moment. Accumulating across reads would freeze the terminal for interactive output (prompts, keystroke echoes).
- **Break on Channel send error** — if the JS Channel is dropped (tab closed), the reader thread detects the send error and exits cleanly rather than running forever and silently discarding output.
- `onPtyData` removed from `events.ts` — data delivery is fully Channel-based. `onPtyExit` remains as a global event (fires rarely, Channel overhead not worth it).
- `PtyDataPayload` no longer includes `tabId` — the Channel is already bound to a specific tab.

## What changes

| File | Change |
|------|--------|
| `src-tauri/src/pty_manager.rs` | 256 KB buffer, send immediately after each read, break on send error, `Channel<PtyDataPayload>` instead of `app.emit()` |
| `src-tauri/src/commands.rs` | `open_tab` accepts `on_data: Channel<PtyDataPayload>` |
| `src/modules/ipc/commands.ts` | `openTab` creates a `Channel`, wraps the `onData` callback |
| `src/modules/ipc/events.ts` | Remove `onPtyData`, keep `onPtyExit` |
| `src/components/TerminalPane/TerminalPane.tsx` | Pass inline Channel callback to `IPC.openTab`, remove `wasmUrl` prop |
| `vite.config.ts` | Remove `wtermWasmPlugin` (was copying wterm WASM to public/) |
| `.gitignore` | Remove `public/wterm.wasm` entry |

## Test plan

- [ ] Terminals open and display output correctly
- [ ] Fast output (`cat /usr/share/dict/words`) streams smoothly
- [ ] Interactive output (prompt, keystroke echo) appears immediately — no freezing
- [ ] Multiple open tabs — each tab receives only its own output
- [ ] Tab close stops data flow — reader thread exits on next send error
- [ ] `pty:exit` fires correctly when shell exits (Cmd+D or `exit`)
- [ ] `bun run lint` clean (biome + cargo clippy)
- [ ] `bun run typecheck` clean