### PR TITLE
refactor(mod-engine): stateless mods — replace CwdRegistry with on_cwd_changed push model

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "root": true,
   "vcs": {
     "enabled": true,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -14,26 +14,14 @@ version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
  "portable-pty",
- "rusqlite",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tokio",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -587,6 +575,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,18 +992,6 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1513,15 +1514,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1534,15 +1526,6 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
@@ -2089,17 +2072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2273,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-conv"
@@ -3066,6 +3047,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,20 +3202,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
-dependencies = [
- "bitflags 2.11.1",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]
@@ -3819,6 +3806,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,7 +3864,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3934,7 +3935,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4077,7 +4078,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -4103,7 +4104,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4128,7 +4129,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4687,12 +4688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4949,10 +4944,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4973,7 +4968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5025,6 +5020,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5047,12 +5052,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -5064,8 +5081,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -5084,9 +5101,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5124,6 +5163,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5652,7 +5700,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,5 +23,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 dirs = "5"
-rusqlite = { version = "0.31", features = ["bundled"] }
+sysinfo = "0.33"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,7 +42,7 @@ pub fn run() {
                 .with_mod(ClaudeCodeMod::new(cwd_registry.clone()))
                 .with_mod(CodexMod::new(cwd_registry.clone()))
                 .with_mod(ProcessInspectorMod::new(cwd_registry.clone()))
-                .with_mod(GitMonitorMod::new(cwd_registry.clone()))
+                .with_mod(GitMonitorMod::new())
                 .build(app.handle().clone());
             app.manage(mod_engine);
             Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,7 +41,7 @@ pub fn run() {
                 .with_mod(ProcessTrackerMod::new())
                 .with_mod(ClaudeCodeMod::new(cwd_registry.clone()))
                 .with_mod(CodexMod::new(cwd_registry.clone()))
-                .with_mod(ProcessInspectorMod::new(cwd_registry.clone()))
+                .with_mod(ProcessInspectorMod::new())
                 .with_mod(GitMonitorMod::new())
                 .build(app.handle().clone());
             app.manage(mod_engine);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,6 @@ mod pty_manager;
 mod shell_integration;
 
 use mod_engine::{
-    CwdRegistry,
     ModEngine,
     mods::{
         ClaudeCodeMod,
@@ -34,13 +33,11 @@ pub fn run() {
                 eprintln!("[agent-terminal] shell integration setup failed: {e}");
             }
 
-            let cwd_registry = CwdRegistry::default();
-
             let mod_engine = ModEngine::builder()
-                .with_mod(DirTrackerMod::new(cwd_registry.clone()))
+                .with_mod(DirTrackerMod::new())
                 .with_mod(ProcessTrackerMod::new())
-                .with_mod(ClaudeCodeMod::new(cwd_registry.clone()))
-                .with_mod(CodexMod::new(cwd_registry.clone()))
+                .with_mod(ClaudeCodeMod::new())
+                .with_mod(CodexMod::new())
                 .with_mod(ProcessInspectorMod::new())
                 .with_mod(GitMonitorMod::new())
                 .build(app.handle().clone());

--- a/src-tauri/src/mod_engine/context.rs
+++ b/src-tauri/src/mod_engine/context.rs
@@ -14,15 +14,30 @@ pub struct ModEvent {
     pub data: serde_json::Value,
 }
 
+/// Sent by `DirTrackerMod` via `ctx.set_cwd()` to notify the engine of a CWD change.
+/// The engine drains these after each `on_output` round and dispatches `on_cwd_changed`.
+pub struct CwdUpdate {
+    pub tab_id: String,
+    pub cwd: String,
+}
+
 /// Context passed to every MOD callback. Provides tab identity and event emission.
 pub struct ModContext<'a> {
     pub tab_id: &'a str,
     event_tx: &'a mpsc::Sender<ModEvent>,
+    cwd_tx: &'a mpsc::Sender<CwdUpdate>,
+    /// The engine's current CWD for this tab, as of the start of this dispatch cycle.
+    pub current_cwd: Option<String>,
 }
 
 impl<'a> ModContext<'a> {
-    pub fn new(tab_id: &'a str, event_tx: &'a mpsc::Sender<ModEvent>) -> Self {
-        Self { tab_id, event_tx }
+    pub fn new(
+        tab_id: &'a str,
+        event_tx: &'a mpsc::Sender<ModEvent>,
+        cwd_tx: &'a mpsc::Sender<CwdUpdate>,
+        current_cwd: Option<String>,
+    ) -> Self {
+        Self { tab_id, event_tx, cwd_tx, current_cwd }
     }
 
     /// Emit a typed event to the frontend. Non-blocking — silently drops if the
@@ -34,6 +49,21 @@ impl<'a> ModContext<'a> {
             event: event.to_string(),
             data,
         });
+    }
+
+    /// Signal the engine that this tab's CWD has changed. The engine will call
+    /// `on_cwd_changed` on all mods after the current `on_output` round completes.
+    pub fn set_cwd(&self, cwd: &str) {
+        let _ = self.cwd_tx.try_send(CwdUpdate {
+            tab_id: self.tab_id.to_string(),
+            cwd: cwd.to_string(),
+        });
+    }
+
+    /// Returns the engine's current CWD for this tab (set by the most recent
+    /// `on_cwd_changed` dispatch). `None` until the first OSC 7 fires.
+    pub fn current_cwd(&self) -> Option<&str> {
+        self.current_cwd.as_deref()
     }
 
     /// Returns a cloneable emitter that can be moved into async tasks.
@@ -68,8 +98,11 @@ impl AsyncEmitter {
 
 /// Shared registry of the current working directory per tab.
 ///
-/// `DirTrackerMod` (PR 8) writes on each OSC 7 sequence. Other MODs
+/// `DirTrackerMod` writes on each OSC 7 sequence. Other MODs
 /// (`GitMonitorMod`, `ClaudeCodeMod`, `CodexMod`) read this to know where to
 /// look for session files and git context without re-parsing OSC themselves.
+///
+/// **Deprecated** — being migrated to the `on_cwd_changed` push model.
+/// Will be removed once all consumers use `on_cwd_changed`.
 #[allow(dead_code)]
 pub type CwdRegistry = Arc<RwLock<HashMap<String, String>>>;

--- a/src-tauri/src/mod_engine/context.rs
+++ b/src-tauri/src/mod_engine/context.rs
@@ -47,6 +47,9 @@ pub struct ModContext<'a> {
     agent_tx: &'a mpsc::Sender<AgentSignal>,
     /// The engine's current CWD for this tab, as of the start of this dispatch cycle.
     pub current_cwd: Option<String>,
+    /// PID of the shell process for this tab's PTY. Used by ProcessInspectorMod
+    /// to detect only agent processes that are children of this shell.
+    pub shell_pid: u32,
 }
 
 impl<'a> ModContext<'a> {
@@ -56,8 +59,9 @@ impl<'a> ModContext<'a> {
         cwd_tx: &'a mpsc::Sender<CwdUpdate>,
         agent_tx: &'a mpsc::Sender<AgentSignal>,
         current_cwd: Option<String>,
+        shell_pid: u32,
     ) -> Self {
-        Self { tab_id, event_tx, cwd_tx, agent_tx, current_cwd }
+        Self { tab_id, event_tx, cwd_tx, agent_tx, current_cwd, shell_pid }
     }
 
     /// Emit a typed event to the frontend. Non-blocking — silently drops if the

--- a/src-tauri/src/mod_engine/context.rs
+++ b/src-tauri/src/mod_engine/context.rs
@@ -1,6 +1,4 @@
 use serde::Serialize;
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc;
 
 /// A structured event emitted by a MOD and forwarded to the frontend via `mod:event`.
@@ -151,9 +149,3 @@ impl AsyncAgentSignaler {
     }
 }
 
-/// Shared registry of the current working directory per tab.
-///
-/// **Deprecated** — being migrated to the `on_cwd_changed` push model.
-/// Will be removed once all consumers use `on_cwd_changed` (commit 7).
-#[allow(dead_code)]
-pub type CwdRegistry = Arc<RwLock<HashMap<String, String>>>;

--- a/src-tauri/src/mod_engine/context.rs
+++ b/src-tauri/src/mod_engine/context.rs
@@ -44,7 +44,7 @@ pub struct ModContext<'a> {
     pub tab_id: &'a str,
     event_tx: &'a mpsc::Sender<ModEvent>,
     cwd_tx: &'a mpsc::Sender<CwdUpdate>,
-    agent_tx: &'a mpsc::Sender<AgentSignal>,
+    agent_tx: &'a mpsc::UnboundedSender<AgentSignal>,
     /// PID of the shell process for this tab's PTY. Used by ProcessInspectorMod
     /// to detect only agent processes that are children of this shell.
     pub shell_pid: u32,
@@ -55,7 +55,7 @@ impl<'a> ModContext<'a> {
         tab_id: &'a str,
         event_tx: &'a mpsc::Sender<ModEvent>,
         cwd_tx: &'a mpsc::Sender<CwdUpdate>,
-        agent_tx: &'a mpsc::Sender<AgentSignal>,
+        agent_tx: &'a mpsc::UnboundedSender<AgentSignal>,
         _current_cwd: Option<String>,
         shell_pid: u32,
     ) -> Self {
@@ -103,6 +103,7 @@ impl<'a> ModContext<'a> {
     }
 }
 
+
 /// A `Clone + Send` emitter for use inside `tokio::spawn` tasks.
 #[derive(Clone)]
 pub struct AsyncEmitter {
@@ -125,12 +126,12 @@ impl AsyncEmitter {
 #[derive(Clone)]
 pub struct AsyncAgentSignaler {
     pub tab_id: String,
-    agent_tx: mpsc::Sender<AgentSignal>,
+    agent_tx: mpsc::UnboundedSender<AgentSignal>,
 }
 
 impl AsyncAgentSignaler {
     pub fn agent_detected(&self, agent: &str, cwd: &str, cmd: &str) {
-        let _ = self.agent_tx.try_send(AgentSignal {
+        let _ = self.agent_tx.send(AgentSignal {
             tab_id: self.tab_id.clone(),
             agent: agent.to_string(),
             cwd: cwd.to_string(),
@@ -140,7 +141,7 @@ impl AsyncAgentSignaler {
     }
 
     pub fn agent_cleared(&self, agent: &str) {
-        let _ = self.agent_tx.try_send(AgentSignal {
+        let _ = self.agent_tx.send(AgentSignal {
             tab_id: self.tab_id.clone(),
             agent: agent.to_string(),
             cwd: String::new(),

--- a/src-tauri/src/mod_engine/context.rs
+++ b/src-tauri/src/mod_engine/context.rs
@@ -45,8 +45,6 @@ pub struct ModContext<'a> {
     event_tx: &'a mpsc::Sender<ModEvent>,
     cwd_tx: &'a mpsc::Sender<CwdUpdate>,
     agent_tx: &'a mpsc::Sender<AgentSignal>,
-    /// The engine's current CWD for this tab, as of the start of this dispatch cycle.
-    pub current_cwd: Option<String>,
     /// PID of the shell process for this tab's PTY. Used by ProcessInspectorMod
     /// to detect only agent processes that are children of this shell.
     pub shell_pid: u32,
@@ -58,10 +56,10 @@ impl<'a> ModContext<'a> {
         event_tx: &'a mpsc::Sender<ModEvent>,
         cwd_tx: &'a mpsc::Sender<CwdUpdate>,
         agent_tx: &'a mpsc::Sender<AgentSignal>,
-        current_cwd: Option<String>,
+        _current_cwd: Option<String>,
         shell_pid: u32,
     ) -> Self {
-        Self { tab_id, event_tx, cwd_tx, agent_tx, current_cwd, shell_pid }
+        Self { tab_id, event_tx, cwd_tx, agent_tx, shell_pid }
     }
 
     /// Emit a typed event to the frontend. Non-blocking — silently drops if the
@@ -82,12 +80,6 @@ impl<'a> ModContext<'a> {
             tab_id: self.tab_id.to_string(),
             cwd: cwd.to_string(),
         });
-    }
-
-    /// Returns the engine's current CWD for this tab (set by the most recent
-    /// `on_cwd_changed` dispatch). `None` until the first OSC 7 fires.
-    pub fn current_cwd(&self) -> Option<&str> {
-        self.current_cwd.as_deref()
     }
 
     /// Returns a cloneable emitter that can be moved into async tasks.

--- a/src-tauri/src/mod_engine/context.rs
+++ b/src-tauri/src/mod_engine/context.rs
@@ -21,11 +21,29 @@ pub struct CwdUpdate {
     pub cwd: String,
 }
 
+pub enum AgentSignalKind {
+    Detected,
+    Cleared,
+}
+
+/// Sent by `ProcessInspectorMod`'s timer task to signal an agent appearing or
+/// disappearing. The engine drains these and routes to `on_agent_detected` /
+/// `on_agent_cleared` on all mods.
+pub struct AgentSignal {
+    pub tab_id: String,
+    /// Binary name: `"claude"` or `"codex"`.
+    pub agent: String,
+    /// Non-empty for `Detected`; empty string for `Cleared`.
+    pub cwd: String,
+    pub kind: AgentSignalKind,
+}
+
 /// Context passed to every MOD callback. Provides tab identity and event emission.
 pub struct ModContext<'a> {
     pub tab_id: &'a str,
     event_tx: &'a mpsc::Sender<ModEvent>,
     cwd_tx: &'a mpsc::Sender<CwdUpdate>,
+    agent_tx: &'a mpsc::Sender<AgentSignal>,
     /// The engine's current CWD for this tab, as of the start of this dispatch cycle.
     pub current_cwd: Option<String>,
 }
@@ -35,9 +53,10 @@ impl<'a> ModContext<'a> {
         tab_id: &'a str,
         event_tx: &'a mpsc::Sender<ModEvent>,
         cwd_tx: &'a mpsc::Sender<CwdUpdate>,
+        agent_tx: &'a mpsc::Sender<AgentSignal>,
         current_cwd: Option<String>,
     ) -> Self {
-        Self { tab_id, event_tx, cwd_tx, current_cwd }
+        Self { tab_id, event_tx, cwd_tx, agent_tx, current_cwd }
     }
 
     /// Emit a typed event to the frontend. Non-blocking — silently drops if the
@@ -76,6 +95,15 @@ impl<'a> ModContext<'a> {
             event_tx: self.event_tx.clone(),
         }
     }
+
+    /// Returns a cloneable signaler that async tasks (e.g. ProcessInspectorMod's
+    /// timer) can use to notify the engine of agent lifecycle events.
+    pub fn async_agent_signaler(&self) -> AsyncAgentSignaler {
+        AsyncAgentSignaler {
+            tab_id: self.tab_id.to_string(),
+            agent_tx: self.agent_tx.clone(),
+        }
+    }
 }
 
 /// A `Clone + Send` emitter for use inside `tokio::spawn` tasks.
@@ -96,13 +124,36 @@ impl AsyncEmitter {
     }
 }
 
+/// A `Clone + Send` agent lifecycle signaler for use inside `tokio::spawn` tasks.
+#[derive(Clone)]
+pub struct AsyncAgentSignaler {
+    pub tab_id: String,
+    agent_tx: mpsc::Sender<AgentSignal>,
+}
+
+impl AsyncAgentSignaler {
+    pub fn agent_detected(&self, agent: &str, cwd: &str) {
+        let _ = self.agent_tx.try_send(AgentSignal {
+            tab_id: self.tab_id.clone(),
+            agent: agent.to_string(),
+            cwd: cwd.to_string(),
+            kind: AgentSignalKind::Detected,
+        });
+    }
+
+    pub fn agent_cleared(&self, agent: &str) {
+        let _ = self.agent_tx.try_send(AgentSignal {
+            tab_id: self.tab_id.clone(),
+            agent: agent.to_string(),
+            cwd: String::new(),
+            kind: AgentSignalKind::Cleared,
+        });
+    }
+}
+
 /// Shared registry of the current working directory per tab.
 ///
-/// `DirTrackerMod` writes on each OSC 7 sequence. Other MODs
-/// (`GitMonitorMod`, `ClaudeCodeMod`, `CodexMod`) read this to know where to
-/// look for session files and git context without re-parsing OSC themselves.
-///
 /// **Deprecated** — being migrated to the `on_cwd_changed` push model.
-/// Will be removed once all consumers use `on_cwd_changed`.
+/// Will be removed once all consumers use `on_cwd_changed` (commit 7).
 #[allow(dead_code)]
 pub type CwdRegistry = Arc<RwLock<HashMap<String, String>>>;

--- a/src-tauri/src/mod_engine/context.rs
+++ b/src-tauri/src/mod_engine/context.rs
@@ -33,6 +33,9 @@ pub struct AgentSignal {
     pub agent: String,
     /// Non-empty for `Detected`; empty string for `Cleared`.
     pub cwd: String,
+    /// Full command string for `Detected` (e.g. `"claude --dangerously-skip-permissions"`).
+    /// Empty string for `Cleared`.
+    pub cmd: String,
     pub kind: AgentSignalKind,
 }
 
@@ -130,11 +133,12 @@ pub struct AsyncAgentSignaler {
 }
 
 impl AsyncAgentSignaler {
-    pub fn agent_detected(&self, agent: &str, cwd: &str) {
+    pub fn agent_detected(&self, agent: &str, cwd: &str, cmd: &str) {
         let _ = self.agent_tx.try_send(AgentSignal {
             tab_id: self.tab_id.clone(),
             agent: agent.to_string(),
             cwd: cwd.to_string(),
+            cmd: cmd.to_string(),
             kind: AgentSignalKind::Detected,
         });
     }
@@ -144,6 +148,7 @@ impl AsyncAgentSignaler {
             tab_id: self.tab_id.clone(),
             agent: agent.to_string(),
             cwd: String::new(),
+            cmd: String::new(),
             kind: AgentSignalKind::Cleared,
         });
     }

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::context::{CwdUpdate, ModContext, ModEvent};
+use super::context::{AgentSignal, AgentSignalKind, CwdUpdate, ModContext, ModEvent};
 use super::Mod;
 use tauri::{AppHandle, Emitter, async_runtime};
 use tokio::sync::mpsc;
@@ -93,25 +93,20 @@ impl ModEngine {
 
     fn start(mods: Vec<Box<dyn Mod>>, app: AppHandle) -> Self {
         // Bounded channel for data messages (Output/Input/Resize).
-        // try_send drops when full so the PTY thread is never blocked.
         let (msg_tx, mut msg_rx) = mpsc::channel::<ModMessage>(512);
         // Unbounded channel for lifecycle messages (Open/Close) — never dropped.
         let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel::<ModMessage>();
         // Outbound event buffer to the frontend.
         let (event_tx, mut event_rx) = mpsc::channel::<ModEvent>(256);
         // CWD update channel: DirTrackerMod calls ctx.set_cwd() which sends here.
-        // The engine drains this after each dispatch round and calls on_cwd_changed.
         let (cwd_tx, mut cwd_rx) = mpsc::channel::<CwdUpdate>(64);
+        // Agent lifecycle channel: ProcessInspectorMod's timer sends here.
+        let (agent_tx, mut agent_rx) = mpsc::channel::<AgentSignal>(64);
 
-        // Task 1: dispatch PTY messages to every MOD in registration order.
-        // `biased` select gives lifecycle messages priority over data messages so
-        // Open/Close are always processed before any buffered Output/Input/Resize
-        // for the same tab.
         let event_tx_dispatch = event_tx.clone();
         async_runtime::spawn(async move {
             let mut mods = mods;
-            // Internal CWD table: tab_id → current cwd. Never exposed to mods directly;
-            // they receive it via on_cwd_changed or ctx.current_cwd().
+            // Internal CWD table: tab_id → current cwd.
             let mut cwd_table: HashMap<String, String> = HashMap::new();
 
             loop {
@@ -130,42 +125,59 @@ impl ModEngine {
                 match msg {
                     ModMessage::Open { tab_id } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
                         for m in &mut mods { m.on_open(&ctx); }
                     }
                     ModMessage::Close { tab_id } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
                         for m in &mut mods { m.on_close(&ctx); }
                         cwd_table.remove(&tab_id);
                     }
                     ModMessage::Output { tab_id, data } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
                         for m in &mut mods { m.on_output(&data, &ctx); }
                     }
                     ModMessage::Input { tab_id, data } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
                         for m in &mut mods { m.on_input(&data, &ctx); }
                     }
                     ModMessage::Resize { tab_id, cols, rows } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
                         for m in &mut mods { m.on_resize(cols, rows, &ctx); }
                     }
                 }
 
                 // Drain CWD updates produced during this dispatch round.
-                // Update the internal table and call on_cwd_changed on all mods.
                 let mut cwd_updates: Vec<(String, String)> = Vec::new();
                 while let Ok(upd) = cwd_rx.try_recv() {
                     cwd_table.insert(upd.tab_id.clone(), upd.cwd.clone());
                     cwd_updates.push((upd.tab_id, upd.cwd));
                 }
                 for (tab_id, cwd) in &cwd_updates {
-                    let ctx = ModContext::new(tab_id, &event_tx_dispatch, &cwd_tx, Some(cwd.clone()));
+                    let ctx = ModContext::new(tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, Some(cwd.clone()));
                     for m in &mut mods { m.on_cwd_changed(cwd, &ctx); }
+                }
+
+                // Drain agent lifecycle signals produced by ProcessInspectorMod's timer.
+                let mut agent_signals: Vec<AgentSignal> = Vec::new();
+                while let Ok(sig) = agent_rx.try_recv() {
+                    agent_signals.push(sig);
+                }
+                for sig in &agent_signals {
+                    let current_cwd = cwd_table.get(&sig.tab_id).cloned();
+                    let ctx = ModContext::new(&sig.tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
+                    match sig.kind {
+                        AgentSignalKind::Detected => {
+                            for m in &mut mods { m.on_agent_detected(&sig.agent, &sig.cwd, &ctx); }
+                        }
+                        AgentSignalKind::Cleared => {
+                            for m in &mut mods { m.on_agent_cleared(&sig.agent, &ctx); }
+                        }
+                    }
                 }
             }
         });

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -172,7 +172,7 @@ impl ModEngine {
                     let ctx = ModContext::new(&sig.tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
                     match sig.kind {
                         AgentSignalKind::Detected => {
-                            for m in &mut mods { m.on_agent_detected(&sig.agent, &sig.cwd, &ctx); }
+                            for m in &mut mods { m.on_agent_detected(&sig.agent, &sig.cwd, &sig.cmd, &ctx); }
                         }
                         AgentSignalKind::Cleared => {
                             for m in &mut mods { m.on_agent_cleared(&sig.agent, &ctx); }

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -6,7 +6,7 @@ use tauri::{AppHandle, Emitter, async_runtime};
 use tokio::sync::mpsc;
 
 pub(super) enum ModMessage {
-    Open { tab_id: String },
+    Open { tab_id: String, shell_pid: u32 },
     Close { tab_id: String },
     Output { tab_id: String, data: Vec<u8> },
     Input { tab_id: String, data: Vec<u8> },
@@ -34,8 +34,8 @@ pub struct ModEngineHandle {
 }
 
 impl ModEngineHandle {
-    pub fn on_tab_open(&self, tab_id: &str) {
-        let _ = self.lifecycle_tx.send(ModMessage::Open { tab_id: tab_id.to_string() });
+    pub fn on_tab_open(&self, tab_id: &str, shell_pid: u32) {
+        let _ = self.lifecycle_tx.send(ModMessage::Open { tab_id: tab_id.to_string(), shell_pid });
     }
 
     pub fn on_tab_close(&self, tab_id: &str) {
@@ -108,6 +108,8 @@ impl ModEngine {
             let mut mods = mods;
             // Internal CWD table: tab_id → current cwd.
             let mut cwd_table: HashMap<String, String> = HashMap::new();
+            // Shell PID table: tab_id → shell process PID.
+            let mut shell_pid_table: HashMap<String, u32> = HashMap::new();
 
             loop {
                 let msg = tokio::select! {
@@ -123,30 +125,36 @@ impl ModEngine {
                 };
 
                 match msg {
-                    ModMessage::Open { tab_id } => {
+                    ModMessage::Open { tab_id, shell_pid } => {
+                        shell_pid_table.insert(tab_id.clone(), shell_pid);
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                         for m in &mut mods { m.on_open(&ctx); }
                     }
                     ModMessage::Close { tab_id } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
+                        let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                         for m in &mut mods { m.on_close(&ctx); }
                         cwd_table.remove(&tab_id);
+                        shell_pid_table.remove(&tab_id);
                     }
                     ModMessage::Output { tab_id, data } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
+                        let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                         for m in &mut mods { m.on_output(&data, &ctx); }
                     }
                     ModMessage::Input { tab_id, data } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
+                        let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                         for m in &mut mods { m.on_input(&data, &ctx); }
                     }
                     ModMessage::Resize { tab_id, cols, rows } => {
                         let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
+                        let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                         for m in &mut mods { m.on_resize(cols, rows, &ctx); }
                     }
                 }
@@ -158,7 +166,8 @@ impl ModEngine {
                     cwd_updates.push((upd.tab_id, upd.cwd));
                 }
                 for (tab_id, cwd) in &cwd_updates {
-                    let ctx = ModContext::new(tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, Some(cwd.clone()));
+                    let shell_pid = shell_pid_table.get(tab_id).copied().unwrap_or(0);
+                    let ctx = ModContext::new(tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, Some(cwd.clone()), shell_pid);
                     for m in &mut mods { m.on_cwd_changed(cwd, &ctx); }
                 }
 
@@ -169,7 +178,8 @@ impl ModEngine {
                 }
                 for sig in &agent_signals {
                     let current_cwd = cwd_table.get(&sig.tab_id).cloned();
-                    let ctx = ModContext::new(&sig.tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd);
+                    let shell_pid = shell_pid_table.get(&sig.tab_id).copied().unwrap_or(0);
+                    let ctx = ModContext::new(&sig.tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                     match sig.kind {
                         AgentSignalKind::Detected => {
                             for m in &mut mods { m.on_agent_detected(&sig.agent, &sig.cwd, &sig.cmd, &ctx); }

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -100,8 +100,8 @@ impl ModEngine {
         let (event_tx, mut event_rx) = mpsc::channel::<ModEvent>(256);
         // CWD update channel: DirTrackerMod calls ctx.set_cwd() which sends here.
         let (cwd_tx, mut cwd_rx) = mpsc::channel::<CwdUpdate>(64);
-        // Agent lifecycle channel: ProcessInspectorMod's timer sends here.
-        let (agent_tx, mut agent_rx) = mpsc::channel::<AgentSignal>(64);
+        // Agent lifecycle channel: unbounded so lifecycle signals are never dropped.
+        let (agent_tx, mut agent_rx) = mpsc::unbounded_channel::<AgentSignal>();
 
         let event_tx_dispatch = event_tx.clone();
         async_runtime::spawn(async move {
@@ -111,81 +111,83 @@ impl ModEngine {
             // Shell PID table: tab_id → shell process PID.
             let mut shell_pid_table: HashMap<String, u32> = HashMap::new();
 
-            loop {
-                let msg = tokio::select! {
-                    biased;
-                    msg = lifecycle_rx.recv() => match msg {
-                        Some(m) => m,
-                        None => break,
-                    },
-                    msg = msg_rx.recv() => match msg {
-                        Some(m) => m,
-                        None => break,
-                    },
-                };
-
-                match msg {
-                    ModMessage::Open { tab_id, shell_pid } => {
-                        shell_pid_table.insert(tab_id.clone(), shell_pid);
-                        let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
-                        for m in &mut mods { m.on_open(&ctx); }
-                    }
-                    ModMessage::Close { tab_id } => {
-                        let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
-                        for m in &mut mods { m.on_close(&ctx); }
-                        cwd_table.remove(&tab_id);
-                        shell_pid_table.remove(&tab_id);
-                    }
-                    ModMessage::Output { tab_id, data } => {
-                        let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
-                        for m in &mut mods { m.on_output(&data, &ctx); }
-                    }
-                    ModMessage::Input { tab_id, data } => {
-                        let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
-                        for m in &mut mods { m.on_input(&data, &ctx); }
-                    }
-                    ModMessage::Resize { tab_id, cols, rows } => {
-                        let current_cwd = cwd_table.get(&tab_id).cloned();
-                        let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
-                        for m in &mut mods { m.on_resize(cols, rows, &ctx); }
-                    }
-                }
-
-                // Drain CWD updates produced during this dispatch round.
-                let mut cwd_updates: Vec<(String, String)> = Vec::new();
-                while let Ok(upd) = cwd_rx.try_recv() {
-                    cwd_table.insert(upd.tab_id.clone(), upd.cwd.clone());
-                    cwd_updates.push((upd.tab_id, upd.cwd));
-                }
-                for (tab_id, cwd) in &cwd_updates {
-                    let shell_pid = shell_pid_table.get(tab_id).copied().unwrap_or(0);
-                    let ctx = ModContext::new(tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, Some(cwd.clone()), shell_pid);
-                    for m in &mut mods { m.on_cwd_changed(cwd, &ctx); }
-                }
-
-                // Drain agent lifecycle signals produced by ProcessInspectorMod's timer.
-                let mut agent_signals: Vec<AgentSignal> = Vec::new();
-                while let Ok(sig) = agent_rx.try_recv() {
-                    agent_signals.push(sig);
-                }
-                for sig in &agent_signals {
-                    let current_cwd = cwd_table.get(&sig.tab_id).cloned();
-                    let shell_pid = shell_pid_table.get(&sig.tab_id).copied().unwrap_or(0);
-                    let ctx = ModContext::new(&sig.tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
-                    match sig.kind {
-                        AgentSignalKind::Detected => {
-                            for m in &mut mods { m.on_agent_detected(&sig.agent, &sig.cwd, &sig.cmd, &ctx); }
+            // Macro to dispatch a ModMessage and drain CWD updates.
+            macro_rules! handle_mod_msg {
+                ($msg:expr) => {{
+                    match $msg {
+                        ModMessage::Open { tab_id, shell_pid } => {
+                            shell_pid_table.insert(tab_id.clone(), shell_pid);
+                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
+                            for m in &mut mods { m.on_open(&ctx); }
                         }
-                        AgentSignalKind::Cleared => {
-                            for m in &mut mods { m.on_agent_cleared(&sig.agent, &ctx); }
+                        ModMessage::Close { tab_id } => {
+                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
+                            let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
+                            for m in &mut mods { m.on_close(&ctx); }
+                            cwd_table.remove(&tab_id);
+                            shell_pid_table.remove(&tab_id);
+                        }
+                        ModMessage::Output { tab_id, data } => {
+                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
+                            let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
+                            for m in &mut mods { m.on_output(&data, &ctx); }
+                        }
+                        ModMessage::Input { tab_id, data } => {
+                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
+                            let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
+                            for m in &mut mods { m.on_input(&data, &ctx); }
+                        }
+                        ModMessage::Resize { tab_id, cols, rows } => {
+                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
+                            let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
+                            for m in &mut mods { m.on_resize(cols, rows, &ctx); }
+                        }
+                    }
+                    // Drain CWD updates produced during this dispatch round.
+                    let mut cwd_updates: Vec<(String, String)> = Vec::new();
+                    while let Ok(upd) = cwd_rx.try_recv() {
+                        cwd_table.insert(upd.tab_id.clone(), upd.cwd.clone());
+                        cwd_updates.push((upd.tab_id, upd.cwd));
+                    }
+                    for (tab_id, cwd) in &cwd_updates {
+                        let shell_pid = shell_pid_table.get(tab_id).copied().unwrap_or(0);
+                        let ctx = ModContext::new(tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, Some(cwd.clone()), shell_pid);
+                        for m in &mut mods { m.on_cwd_changed(cwd, &ctx); }
+                    }
+                }};
+            }
+
+            loop {
+                tokio::select! {
+                    biased;
+                    msg = lifecycle_rx.recv() => {
+                        let Some(msg) = msg else { break };
+                        handle_mod_msg!(msg);
+                    }
+                    msg = msg_rx.recv() => {
+                        let Some(msg) = msg else { break };
+                        handle_mod_msg!(msg);
+                    }
+                    // Agent lifecycle signals from ProcessInspectorMod's timer task.
+                    // Processed immediately so idle tabs (no PTY activity) still get
+                    // state transitions when an agent starts or exits.
+                    sig = agent_rx.recv() => {
+                        let Some(sig) = sig else { break };
+                        let current_cwd = cwd_table.get(&sig.tab_id).cloned();
+                        let shell_pid = shell_pid_table.get(&sig.tab_id).copied().unwrap_or(0);
+                        let ctx = ModContext::new(&sig.tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
+                        match sig.kind {
+                            AgentSignalKind::Detected => {
+                                for m in &mut mods { m.on_agent_detected(&sig.agent, &sig.cwd, &sig.cmd, &ctx); }
+                            }
+                            AgentSignalKind::Cleared => {
+                                for m in &mut mods { m.on_agent_cleared(&sig.agent, &ctx); }
+                            }
                         }
                     }
                 }

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -1,4 +1,6 @@
-use super::context::{ModContext, ModEvent};
+use std::collections::HashMap;
+
+use super::context::{CwdUpdate, ModContext, ModEvent};
 use super::Mod;
 use tauri::{AppHandle, Emitter, async_runtime};
 use tokio::sync::mpsc;
@@ -97,6 +99,9 @@ impl ModEngine {
         let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel::<ModMessage>();
         // Outbound event buffer to the frontend.
         let (event_tx, mut event_rx) = mpsc::channel::<ModEvent>(256);
+        // CWD update channel: DirTrackerMod calls ctx.set_cwd() which sends here.
+        // The engine drains this after each dispatch round and calls on_cwd_changed.
+        let (cwd_tx, mut cwd_rx) = mpsc::channel::<CwdUpdate>(64);
 
         // Task 1: dispatch PTY messages to every MOD in registration order.
         // `biased` select gives lifecycle messages priority over data messages so
@@ -105,6 +110,10 @@ impl ModEngine {
         let event_tx_dispatch = event_tx.clone();
         async_runtime::spawn(async move {
             let mut mods = mods;
+            // Internal CWD table: tab_id → current cwd. Never exposed to mods directly;
+            // they receive it via on_cwd_changed or ctx.current_cwd().
+            let mut cwd_table: HashMap<String, String> = HashMap::new();
+
             loop {
                 let msg = tokio::select! {
                     biased;
@@ -117,27 +126,46 @@ impl ModEngine {
                         None => break,
                     },
                 };
+
                 match msg {
                     ModMessage::Open { tab_id } => {
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch);
+                        let current_cwd = cwd_table.get(&tab_id).cloned();
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
                         for m in &mut mods { m.on_open(&ctx); }
                     }
                     ModMessage::Close { tab_id } => {
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch);
+                        let current_cwd = cwd_table.get(&tab_id).cloned();
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
                         for m in &mut mods { m.on_close(&ctx); }
+                        cwd_table.remove(&tab_id);
                     }
                     ModMessage::Output { tab_id, data } => {
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch);
+                        let current_cwd = cwd_table.get(&tab_id).cloned();
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
                         for m in &mut mods { m.on_output(&data, &ctx); }
                     }
                     ModMessage::Input { tab_id, data } => {
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch);
+                        let current_cwd = cwd_table.get(&tab_id).cloned();
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
                         for m in &mut mods { m.on_input(&data, &ctx); }
                     }
                     ModMessage::Resize { tab_id, cols, rows } => {
-                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch);
+                        let current_cwd = cwd_table.get(&tab_id).cloned();
+                        let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, current_cwd);
                         for m in &mut mods { m.on_resize(cols, rows, &ctx); }
                     }
+                }
+
+                // Drain CWD updates produced during this dispatch round.
+                // Update the internal table and call on_cwd_changed on all mods.
+                let mut cwd_updates: Vec<(String, String)> = Vec::new();
+                while let Ok(upd) = cwd_rx.try_recv() {
+                    cwd_table.insert(upd.tab_id.clone(), upd.cwd.clone());
+                    cwd_updates.push((upd.tab_id, upd.cwd));
+                }
+                for (tab_id, cwd) in &cwd_updates {
+                    let ctx = ModContext::new(tab_id, &event_tx_dispatch, &cwd_tx, Some(cwd.clone()));
+                    for m in &mut mods { m.on_cwd_changed(cwd, &ctx); }
                 }
             }
         });

--- a/src-tauri/src/mod_engine/mod.rs
+++ b/src-tauri/src/mod_engine/mod.rs
@@ -4,7 +4,7 @@ pub mod mods;
 pub mod osc_parser;
 
 #[allow(unused_imports)]
-pub use context::{AsyncEmitter, CwdRegistry, CwdUpdate, ModContext, ModEvent};
+pub use context::{AgentSignal, AgentSignalKind, AsyncAgentSignaler, AsyncEmitter, CwdRegistry, CwdUpdate, ModContext, ModEvent};
 pub use engine::{ModEngine, ModEngineHandle};
 
 /// The trait every MOD implements.
@@ -39,4 +39,13 @@ pub trait Mod: Send + 'static {
     /// Mods that react to directory changes implement this instead of reading
     /// `CwdRegistry` inside `on_output`. Default is a no-op.
     fn on_cwd_changed(&mut self, _cwd: &str, _ctx: &ModContext) {}
+
+    /// Called by the engine when `ProcessInspectorMod` detects a new agent process
+    /// (or a PID change for the same agent name) in this tab's CWD.
+    /// `agent` is the binary name: `"claude"` or `"codex"`. Default is a no-op.
+    fn on_agent_detected(&mut self, _agent: &str, _cwd: &str, _ctx: &ModContext) {}
+
+    /// Called by the engine when `ProcessInspectorMod` no longer sees an agent
+    /// process that was previously detected in this tab's CWD. Default is a no-op.
+    fn on_agent_cleared(&mut self, _agent: &str, _ctx: &ModContext) {}
 }

--- a/src-tauri/src/mod_engine/mod.rs
+++ b/src-tauri/src/mod_engine/mod.rs
@@ -34,4 +34,9 @@ pub trait Mod: Send + 'static {
 
     /// Tab closed — drop any per-tab state here.
     fn on_close(&mut self, _ctx: &ModContext) {}
+
+    /// Called by the engine when `DirTrackerMod` detects a CWD change for this tab.
+    /// Mods that react to directory changes implement this instead of reading
+    /// `CwdRegistry` inside `on_output`. Default is a no-op.
+    fn on_cwd_changed(&mut self, _cwd: &str, _ctx: &ModContext) {}
 }

--- a/src-tauri/src/mod_engine/mod.rs
+++ b/src-tauri/src/mod_engine/mod.rs
@@ -4,7 +4,7 @@ pub mod mods;
 pub mod osc_parser;
 
 #[allow(unused_imports)]
-pub use context::{AgentSignal, AgentSignalKind, AsyncAgentSignaler, AsyncEmitter, CwdRegistry, CwdUpdate, ModContext, ModEvent};
+pub use context::{AgentSignal, AgentSignalKind, AsyncAgentSignaler, AsyncEmitter, CwdUpdate, ModContext, ModEvent};
 pub use engine::{ModEngine, ModEngineHandle};
 
 /// The trait every MOD implements.

--- a/src-tauri/src/mod_engine/mod.rs
+++ b/src-tauri/src/mod_engine/mod.rs
@@ -4,7 +4,7 @@ pub mod mods;
 pub mod osc_parser;
 
 #[allow(unused_imports)]
-pub use context::{AsyncEmitter, CwdRegistry, ModContext, ModEvent};
+pub use context::{AsyncEmitter, CwdRegistry, CwdUpdate, ModContext, ModEvent};
 pub use engine::{ModEngine, ModEngineHandle};
 
 /// The trait every MOD implements.

--- a/src-tauri/src/mod_engine/mod.rs
+++ b/src-tauri/src/mod_engine/mod.rs
@@ -42,8 +42,10 @@ pub trait Mod: Send + 'static {
 
     /// Called by the engine when `ProcessInspectorMod` detects a new agent process
     /// (or a PID change for the same agent name) in this tab's CWD.
-    /// `agent` is the binary name: `"claude"` or `"codex"`. Default is a no-op.
-    fn on_agent_detected(&mut self, _agent: &str, _cwd: &str, _ctx: &ModContext) {}
+    /// `agent` is the binary name: `"claude"` or `"codex"`.
+    /// `cmd` is the full command string used to launch the process (e.g. `"claude --dangerously-skip-permissions"`).
+    /// Default is a no-op.
+    fn on_agent_detected(&mut self, _agent: &str, _cwd: &str, _cmd: &str, _ctx: &ModContext) {}
 
     /// Called by the engine when `ProcessInspectorMod` no longer sees an agent
     /// process that was previously detected in this tab's CWD. Default is a no-op.

--- a/src-tauri/src/mod_engine/mods/claude_code.rs
+++ b/src-tauri/src/mod_engine/mods/claude_code.rs
@@ -1,27 +1,18 @@
-use std::collections::HashMap;
-
 use crate::mod_engine::{Mod, ModContext};
 
-struct ClaudeTabState {
-    /// True once the session file has been read for the current process instance.
-    /// Reset to false on `on_agent_cleared` so the next invocation scans again.
-    session_scanned: bool,
-}
-
-/// Reads Claude Code session metadata from `~/.claude/projects/` when
-/// `ProcessInspectorMod` confirms a `claude` process is running in the tab's CWD.
+/// Emits tab type changes when `ProcessInspectorMod` detects or loses a `claude` process.
+///
+/// No session file scanning. No per-tab state. The process cmd line carries the
+/// launch flags; git info comes from `GitMonitorMod`.
 ///
 /// Emits:
-/// - `claude_session`         — session metadata on detection
-/// - `claude_session_cleared` — session gone (agent process ended)
-/// - `tab_type_changed`       — `{ type: "agent", agent: "claude-code" }` / `{ type: "shell" }`
-pub struct ClaudeCodeMod {
-    tabs: HashMap<String, ClaudeTabState>,
-}
+/// - `tab_type_changed` `{ type: "agent", agent: "claude-code", cmd: "..." }` on detection
+/// - `tab_type_changed` `{ type: "shell" }` on process exit
+pub struct ClaudeCodeMod;
 
 impl ClaudeCodeMod {
     pub fn new() -> Self {
-        Self { tabs: HashMap::new() }
+        Self
     }
 }
 
@@ -30,182 +21,21 @@ impl Mod for ClaudeCodeMod {
         "claude_code"
     }
 
-    fn on_open(&mut self, ctx: &ModContext) {
-        self.tabs.insert(ctx.tab_id.to_string(), ClaudeTabState { session_scanned: false });
-    }
-
-    fn on_agent_detected(&mut self, agent: &str, cwd: &str, ctx: &ModContext) {
+    fn on_agent_detected(&mut self, agent: &str, _cwd: &str, cmd: &str, ctx: &ModContext) {
         if agent != "claude" {
             return;
         }
-        let Some(state) = self.tabs.get_mut(ctx.tab_id) else { return };
-        if state.session_scanned {
-            return;
-        }
-        state.session_scanned = true;
-
-        let emitter = ctx.async_emitter();
-        let cwd = cwd.to_string();
-        tokio::spawn(async move {
-            match scan_claude_session(&cwd).await {
-                Some(data) => {
-                    emitter.emit("claude_code", "claude_session", data);
-                    emitter.emit(
-                        "claude_code",
-                        "tab_type_changed",
-                        serde_json::json!({ "type": "agent", "agent": "claude-code" }),
-                    );
-                }
-                None => {
-                    // Session file not found yet (may not be written yet); will retry on next detection.
-                    // Reset so next on_agent_detected can try again.
-                    // Note: state is not accessible here; the reset happens in on_agent_cleared.
-                }
-            }
-        });
+        ctx.emit(
+            "claude_code",
+            "tab_type_changed",
+            serde_json::json!({ "type": "agent", "agent": "claude-code", "cmd": cmd }),
+        );
     }
 
     fn on_agent_cleared(&mut self, agent: &str, ctx: &ModContext) {
         if agent != "claude" {
             return;
         }
-        if let Some(state) = self.tabs.get_mut(ctx.tab_id) {
-            state.session_scanned = false;
-        }
-        ctx.emit("claude_code", "claude_session_cleared", serde_json::json!({}));
-        ctx.emit(
-            "claude_code",
-            "tab_type_changed",
-            serde_json::json!({ "type": "shell" }),
-        );
-    }
-
-    fn on_close(&mut self, ctx: &ModContext) {
-        self.tabs.remove(ctx.tab_id);
+        ctx.emit("claude_code", "tab_type_changed", serde_json::json!({ "type": "shell" }));
     }
 }
-
-/// Scan `~/.claude/projects/<encoded-cwd>/` for an active session JSONL file.
-/// Returns `Some(session_data)` if a session file is found, `None` otherwise.
-/// No freshness check — only called when the claude process is confirmed live.
-async fn scan_claude_session(cwd: &str) -> Option<serde_json::Value> {
-    let home = dirs::home_dir()?;
-
-    // Encode cwd: replace all '/' with '-' (Claude keeps the leading '-')
-    let encoded = cwd.replace('/', "-");
-    let dir = home.join(".claude").join("projects").join(&encoded);
-    if !dir.exists() {
-        return None;
-    }
-
-    // Find the most recently modified .jsonl file
-    let mut best: Option<(std::path::PathBuf, std::time::SystemTime)> = None;
-    let entries = std::fs::read_dir(&dir).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        if let Ok(meta) = path.metadata() {
-            if let Ok(mtime) = meta.modified() {
-                match &best {
-                    None => best = Some((path, mtime)),
-                    Some((_, best_t)) if mtime > *best_t => best = Some((path, mtime)),
-                    _ => {}
-                }
-            }
-        }
-    }
-
-    let (jsonl_path, _mtime) = best?;
-
-    // sessionId = filename stem
-    let session_id = jsonl_path.file_stem()?.to_str()?.to_string();
-
-    // Read first 64 KB
-    let content = read_first_bytes(&jsonl_path, 65536).await?;
-    let text = std::str::from_utf8(&content).ok()?;
-
-    // Parse JSONL for session metadata
-    let mut title: Option<String> = None;
-    let mut git_branch: Option<String> = None;
-    let mut permission_mode: Option<String> = None;
-    let mut model: Option<String> = None;
-    let mut pr_number: Option<u64> = None;
-    let mut pr_url: Option<String> = None;
-    let mut found_user = false;
-
-    for line in text.lines() {
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else { continue };
-        let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
-
-        match msg_type {
-            "user" if !found_user => {
-                found_user = true;
-                if let Some(b) = v.get("gitBranch").and_then(|b| b.as_str()) {
-                    git_branch = Some(b.to_string());
-                }
-                if let Some(pm) = v.get("permissionMode").and_then(|p| p.as_str()) {
-                    permission_mode = Some(pm.to_string());
-                }
-                if let Some(content) = v.get("message").and_then(|m| m.get("content")) {
-                    if let Some(s) = content.as_str() {
-                        title = Some(truncate(s, 80));
-                    } else if let Some(arr) = content.as_array() {
-                        for item in arr {
-                            if item.get("type").and_then(|t| t.as_str()) == Some("text") {
-                                if let Some(s) = item.get("text").and_then(|t| t.as_str()) {
-                                    title = Some(truncate(s, 80));
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            "assistant" if model.is_none() => {
-                if let Some(m) = v
-                    .get("message")
-                    .and_then(|m| m.get("model"))
-                    .and_then(|m| m.as_str())
-                {
-                    model = Some(m.to_string());
-                }
-            }
-            "pr-link" => {
-                pr_number = v.get("prNumber").and_then(|n| n.as_u64());
-                pr_url = v.get("prUrl").and_then(|u| u.as_str()).map(|s| s.to_string());
-            }
-            _ => {}
-        }
-    }
-
-    Some(serde_json::json!({
-        "sessionId": session_id,
-        "gitBranch": git_branch,
-        "model": model,
-        "permissionMode": permission_mode,
-        "title": title,
-        "prNumber": pr_number,
-        "prUrl": pr_url,
-    }))
-}
-
-async fn read_first_bytes(path: &std::path::Path, limit: usize) -> Option<Vec<u8>> {
-    use tokio::io::AsyncReadExt;
-    let mut file = tokio::fs::File::open(path).await.ok()?;
-    let mut buf = vec![0u8; limit];
-    let n = file.read(&mut buf).await.ok()?;
-    buf.truncate(n);
-    Some(buf)
-}
-
-fn truncate(s: &str, max_chars: usize) -> String {
-    let mut chars = s.chars();
-    let mut result: String = chars.by_ref().take(max_chars).collect();
-    if chars.next().is_some() {
-        result.push('…');
-    }
-    result
-}
-

--- a/src-tauri/src/mod_engine/mods/claude_code.rs
+++ b/src-tauri/src/mod_engine/mods/claude_code.rs
@@ -1,61 +1,27 @@
 use std::collections::HashMap;
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
-use crate::mod_engine::{AsyncEmitter, CwdRegistry, Mod, ModContext};
-use crate::mod_engine::osc_parser::OscParser;
+use crate::mod_engine::{Mod, ModContext};
 
 struct ClaudeTabState {
-    parser: OscParser,
-    last_cwd: Option<String>,
-    /// Shared with async scan tasks — set true when a live session is found, false when cleared.
-    session_active: Arc<AtomicBool>,
-    awaiting_agent: bool,
-    /// Rolling input buffer — cleared on Enter, used to detect "claude" typed across keystrokes.
-    input_buf: Vec<u8>,
+    /// True once the session file has been read for the current process instance.
+    /// Reset to false on `on_agent_cleared` so the next invocation scans again.
+    session_scanned: bool,
 }
 
-/// Monitors `~/.claude/projects/` for active Claude Code sessions in the tab's cwd.
+/// Reads Claude Code session metadata from `~/.claude/projects/` when
+/// `ProcessInspectorMod` confirms a `claude` process is running in the tab's CWD.
 ///
-/// Detection is triggered by:
-/// 1. cwd change (compared against `CwdRegistry`)
-/// 2. `claude` appearing in user input
-/// 3. OSC 133;A (prompt returned) → staleness check to clear session
+/// Emits:
+/// - `claude_session`         — session metadata on detection
+/// - `claude_session_cleared` — session gone (agent process ended)
+/// - `tab_type_changed`       — `{ type: "agent", agent: "claude-code" }` / `{ type: "shell" }`
 pub struct ClaudeCodeMod {
-    cwd_registry: CwdRegistry,
     tabs: HashMap<String, ClaudeTabState>,
 }
 
 impl ClaudeCodeMod {
-    pub fn new(cwd_registry: CwdRegistry) -> Self {
-        Self {
-            cwd_registry,
-            tabs: HashMap::new(),
-        }
-    }
-
-    fn trigger_scan(&self, cwd: String, awaiting: bool, session_active: Arc<AtomicBool>, emitter: AsyncEmitter) {
-        tokio::spawn(async move {
-            match scan_claude_session(&cwd, awaiting).await {
-                Some(data) => {
-                    session_active.store(true, Ordering::Relaxed);
-                    emitter.emit("claude_code", "claude_session", data);
-                    emitter.emit(
-                        "claude_code",
-                        "tab_type_changed",
-                        serde_json::json!({ "type": "agent", "agent": "claude-code" }),
-                    );
-                }
-                None => {
-                    session_active.store(false, Ordering::Relaxed);
-                    emitter.emit("claude_code", "claude_session_cleared", serde_json::json!({}));
-                    emitter.emit(
-                        "claude_code",
-                        "tab_type_changed",
-                        serde_json::json!({ "type": "shell" }),
-                    );
-                }
-            }
-        });
+    pub fn new() -> Self {
+        Self { tabs: HashMap::new() }
     }
 }
 
@@ -65,109 +31,53 @@ impl Mod for ClaudeCodeMod {
     }
 
     fn on_open(&mut self, ctx: &ModContext) {
-        self.tabs.insert(
-            ctx.tab_id.to_string(),
-            ClaudeTabState {
-                parser: OscParser::new(),
-                last_cwd: None,
-                session_active: Arc::new(AtomicBool::new(false)),
-                awaiting_agent: false,
-                input_buf: Vec::new(),
-            },
+        self.tabs.insert(ctx.tab_id.to_string(), ClaudeTabState { session_scanned: false });
+    }
+
+    fn on_agent_detected(&mut self, agent: &str, cwd: &str, ctx: &ModContext) {
+        if agent != "claude" {
+            return;
+        }
+        let Some(state) = self.tabs.get_mut(ctx.tab_id) else { return };
+        if state.session_scanned {
+            return;
+        }
+        state.session_scanned = true;
+
+        let emitter = ctx.async_emitter();
+        let cwd = cwd.to_string();
+        tokio::spawn(async move {
+            match scan_claude_session(&cwd).await {
+                Some(data) => {
+                    emitter.emit("claude_code", "claude_session", data);
+                    emitter.emit(
+                        "claude_code",
+                        "tab_type_changed",
+                        serde_json::json!({ "type": "agent", "agent": "claude-code" }),
+                    );
+                }
+                None => {
+                    // Session file not found yet (may not be written yet); will retry on next detection.
+                    // Reset so next on_agent_detected can try again.
+                    // Note: state is not accessible here; the reset happens in on_agent_cleared.
+                }
+            }
+        });
+    }
+
+    fn on_agent_cleared(&mut self, agent: &str, ctx: &ModContext) {
+        if agent != "claude" {
+            return;
+        }
+        if let Some(state) = self.tabs.get_mut(ctx.tab_id) {
+            state.session_scanned = false;
+        }
+        ctx.emit("claude_code", "claude_session_cleared", serde_json::json!({}));
+        ctx.emit(
+            "claude_code",
+            "tab_type_changed",
+            serde_json::json!({ "type": "shell" }),
         );
-    }
-
-    fn on_output(&mut self, data: &[u8], ctx: &ModContext) {
-        let (scan_trigger, clear_session, session_active): (Option<(String, bool)>, bool, Arc<AtomicBool>) = {
-            let Some(state) = self.tabs.get_mut(ctx.tab_id) else {
-                return;
-            };
-            let seqs = state.parser.feed(data);
-
-            let current_cwd = {
-                let reg = self.cwd_registry.read().unwrap();
-                reg.get(ctx.tab_id).cloned()
-            };
-
-            // CWD change → only scan if we're already awaiting Claude (user typed "claude").
-            // Scanning on every cd causes false positives from recently-exited sessions.
-            let scan_trigger = if let Some(ref cwd) = current_cwd {
-                if state.last_cwd.as_deref() != Some(cwd.as_str()) {
-                    let awaiting = state.awaiting_agent;
-                    state.last_cwd = Some(cwd.clone());
-                    if awaiting { Some((cwd.clone(), true)) } else { None }
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
-            // OSC 133;A = shell prompt drawn = Claude has exited (works for /exit and Ctrl+C).
-            // Do NOT use 133;B — that fires on command start, before Claude even runs.
-            let has_osc_a = seqs.iter().any(|s| s.code == 133 && s.arg.starts_with('A'));
-            let clear_session = has_osc_a && state.session_active.load(Ordering::Relaxed);
-            if clear_session {
-                state.session_active.store(false, Ordering::Relaxed);
-                state.awaiting_agent = false;
-            }
-
-            (scan_trigger, clear_session, Arc::clone(&state.session_active))
-        };
-
-        if let Some((cwd, awaiting)) = scan_trigger {
-            self.trigger_scan(cwd, awaiting, Arc::clone(&session_active), ctx.async_emitter());
-        }
-        if clear_session {
-            let emitter = ctx.async_emitter();
-            tokio::spawn(async move {
-                emitter.emit("claude_code", "claude_session_cleared", serde_json::json!({}));
-                emitter.emit(
-                    "claude_code",
-                    "tab_type_changed",
-                    serde_json::json!({ "type": "shell" }),
-                );
-            });
-        }
-    }
-
-    fn on_input(&mut self, data: &[u8], ctx: &ModContext) {
-        // Phase 1: update buffer state, extract what we need (mutable borrow ends here)
-        let scan_info: Option<(String, Arc<AtomicBool>)> = {
-            let Some(state) = self.tabs.get_mut(ctx.tab_id) else {
-                return;
-            };
-
-            let mut trigger = false;
-            for &b in data {
-                if b == b'\r' || b == b'\n' {
-                    let line = String::from_utf8_lossy(&state.input_buf).to_lowercase();
-                    if line.contains("claude") {
-                        state.awaiting_agent = true;
-                        trigger = true;
-                    }
-                    state.input_buf.clear();
-                } else if b == 0x7f || b == 0x08 {
-                    state.input_buf.pop();
-                } else if b >= 0x20 {
-                    state.input_buf.push(b);
-                    if state.input_buf.len() > 256 {
-                        state.input_buf.drain(..128);
-                    }
-                }
-            }
-
-            if trigger {
-                state.last_cwd.clone().map(|cwd| (cwd, Arc::clone(&state.session_active)))
-            } else {
-                None
-            }
-        };
-
-        // Phase 2: trigger scan outside the mutable borrow
-        if let Some((cwd, session_active)) = scan_info {
-            self.trigger_scan(cwd, true, session_active, ctx.async_emitter());
-        }
     }
 
     fn on_close(&mut self, ctx: &ModContext) {
@@ -176,13 +86,13 @@ impl Mod for ClaudeCodeMod {
 }
 
 /// Scan `~/.claude/projects/<encoded-cwd>/` for an active session JSONL file.
-/// Returns `Some(session_data)` if a recent session is found, `None` otherwise.
-async fn scan_claude_session(cwd: &str, awaiting_agent: bool) -> Option<serde_json::Value> {
+/// Returns `Some(session_data)` if a session file is found, `None` otherwise.
+/// No freshness check — only called when the claude process is confirmed live.
+async fn scan_claude_session(cwd: &str) -> Option<serde_json::Value> {
     let home = dirs::home_dir()?;
 
     // Encode cwd: replace all '/' with '-' (Claude keeps the leading '-')
     let encoded = cwd.replace('/', "-");
-
     let dir = home.join(".claude").join("projects").join(&encoded);
     if !dir.exists() {
         return None;
@@ -207,15 +117,7 @@ async fn scan_claude_session(cwd: &str, awaiting_agent: bool) -> Option<serde_js
         }
     }
 
-    let (jsonl_path, mtime) = best?;
-
-    // Check freshness: if older than 120s and not awaiting, skip
-    let age = std::time::SystemTime::now()
-        .duration_since(mtime)
-        .unwrap_or_default();
-    if age.as_secs() > 120 && !awaiting_agent {
-        return None;
-    }
+    let (jsonl_path, _mtime) = best?;
 
     // sessionId = filename stem
     let session_id = jsonl_path.file_stem()?.to_str()?.to_string();
@@ -234,9 +136,7 @@ async fn scan_claude_session(cwd: &str, awaiting_agent: bool) -> Option<serde_js
     let mut found_user = false;
 
     for line in text.lines() {
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else { continue };
         let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
         match msg_type {
@@ -248,7 +148,6 @@ async fn scan_claude_session(cwd: &str, awaiting_agent: bool) -> Option<serde_js
                 if let Some(pm) = v.get("permissionMode").and_then(|p| p.as_str()) {
                     permission_mode = Some(pm.to_string());
                 }
-                // Extract first content string as title
                 if let Some(content) = v.get("message").and_then(|m| m.get("content")) {
                     if let Some(s) = content.as_str() {
                         title = Some(truncate(s, 80));
@@ -309,3 +208,4 @@ fn truncate(s: &str, max_chars: usize) -> String {
     }
     result
 }
+

--- a/src-tauri/src/mod_engine/mods/codex.rs
+++ b/src-tauri/src/mod_engine/mods/codex.rs
@@ -1,27 +1,18 @@
-use std::collections::HashMap;
-
 use crate::mod_engine::{Mod, ModContext};
 
-struct CodexTabState {
-    /// True once the session file has been read for the current process instance.
-    /// Reset to false on `on_agent_cleared` so the next invocation scans again.
-    session_scanned: bool,
-}
-
-/// Reads Codex session metadata from `~/.codex/state_5.sqlite` (or JSONL fallback)
-/// when `ProcessInspectorMod` confirms a `codex` process is running in the tab's CWD.
+/// Emits tab type changes when `ProcessInspectorMod` detects or loses a `codex` process.
+///
+/// No session file scanning. No per-tab state. The process cmd line carries the
+/// launch flags; git info comes from `GitMonitorMod`.
 ///
 /// Emits:
-/// - `codex_session`         — session metadata on detection
-/// - `codex_session_cleared` — session gone (agent process ended)
-/// - `tab_type_changed`      — `{ type: "agent", agent: "codex" }` / `{ type: "shell" }`
-pub struct CodexMod {
-    tabs: HashMap<String, CodexTabState>,
-}
+/// - `tab_type_changed` `{ type: "agent", agent: "codex", cmd: "..." }` on detection
+/// - `tab_type_changed` `{ type: "shell" }` on process exit
+pub struct CodexMod;
 
 impl CodexMod {
     pub fn new() -> Self {
-        Self { tabs: HashMap::new() }
+        Self
     }
 }
 
@@ -30,198 +21,21 @@ impl Mod for CodexMod {
         "codex"
     }
 
-    fn on_open(&mut self, ctx: &ModContext) {
-        self.tabs.insert(ctx.tab_id.to_string(), CodexTabState { session_scanned: false });
-    }
-
-    fn on_agent_detected(&mut self, agent: &str, cwd: &str, ctx: &ModContext) {
+    fn on_agent_detected(&mut self, agent: &str, _cwd: &str, cmd: &str, ctx: &ModContext) {
         if agent != "codex" {
             return;
         }
-        let Some(state) = self.tabs.get_mut(ctx.tab_id) else { return };
-        if state.session_scanned {
-            return;
-        }
-        state.session_scanned = true;
-
-        let emitter = ctx.async_emitter();
-        let cwd = cwd.to_string();
-        tokio::spawn(async move {
-            match scan_codex_session(&cwd).await {
-                Some(data) => {
-                    emitter.emit("codex", "codex_session", data);
-                    emitter.emit(
-                        "codex",
-                        "tab_type_changed",
-                        serde_json::json!({ "type": "agent", "agent": "codex" }),
-                    );
-                }
-                None => {
-                    // Session not found yet; on_agent_cleared will reset session_scanned.
-                }
-            }
-        });
+        ctx.emit(
+            "codex",
+            "tab_type_changed",
+            serde_json::json!({ "type": "agent", "agent": "codex", "cmd": cmd }),
+        );
     }
 
     fn on_agent_cleared(&mut self, agent: &str, ctx: &ModContext) {
         if agent != "codex" {
             return;
         }
-        if let Some(state) = self.tabs.get_mut(ctx.tab_id) {
-            state.session_scanned = false;
-        }
-        ctx.emit("codex", "codex_session_cleared", serde_json::json!({}));
-        ctx.emit(
-            "codex",
-            "tab_type_changed",
-            serde_json::json!({ "type": "shell" }),
-        );
+        ctx.emit("codex", "tab_type_changed", serde_json::json!({ "type": "shell" }));
     }
-
-    fn on_close(&mut self, ctx: &ModContext) {
-        self.tabs.remove(ctx.tab_id);
-    }
-}
-
-async fn scan_codex_session(cwd: &str) -> Option<serde_json::Value> {
-    let home = dirs::home_dir()?;
-
-    // Try SQLite first
-    if let Some(result) = scan_via_sqlite(&home, cwd).await {
-        return Some(result);
-    }
-
-    // Fallback: scan ~/.codex/sessions/*.jsonl
-    scan_via_jsonl(&home, cwd).await
-}
-
-async fn scan_via_sqlite(home: &std::path::Path, cwd: &str) -> Option<serde_json::Value> {
-    let db_path = home.join(".codex").join("state_5.sqlite");
-    if !db_path.exists() {
-        return None;
-    }
-
-    // Copy DB to temp file to avoid WAL contention
-    let tmp = std::env::temp_dir().join(format!(
-        "codex_snap_{}.sqlite",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .subsec_nanos()
-    ));
-
-    std::fs::copy(&db_path, &tmp).ok()?;
-
-    let cwd_owned = cwd.to_string();
-    let tmp_clone = tmp.clone();
-
-    let result = tokio::task::spawn_blocking(move || {
-        query_codex_sqlite(&tmp_clone, &cwd_owned)
-    })
-    .await
-    .ok()??;
-
-    std::fs::remove_file(&tmp).ok();
-    Some(result)
-}
-
-type ThreadRow = (
-    String,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    i64,
-);
-
-fn query_codex_sqlite(db_path: &std::path::Path, cwd: &str) -> Option<serde_json::Value> {
-    let conn = rusqlite::Connection::open(db_path).ok()?;
-
-    let row: Option<ThreadRow> = conn
-        .query_row(
-            "SELECT id, title, git_branch, model, approval_mode, sandbox_policy, reasoning_effort, updated_at_ms
-             FROM threads WHERE archived = 0 AND cwd = ?1 ORDER BY updated_at_ms DESC LIMIT 1",
-            rusqlite::params![cwd],
-            |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, Option<String>>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                    row.get::<_, Option<String>>(3)?,
-                    row.get::<_, Option<String>>(4)?,
-                    row.get::<_, Option<String>>(5)?,
-                    row.get::<_, Option<String>>(6)?,
-                    row.get::<_, i64>(7)?,
-                ))
-            },
-        )
-        .ok();
-
-    let (id, title, git_branch, model, approval_mode, sandbox_policy_json, reasoning_effort, _updated_at_ms) =
-        row?;
-
-    let sandbox_mode = sandbox_policy_json.as_deref().and_then(|json| {
-        serde_json::from_str::<serde_json::Value>(json)
-            .ok()
-            .and_then(|v| v.get("type").and_then(|t| t.as_str()).map(|s| s.to_string()))
-    });
-
-    Some(serde_json::json!({
-        "sessionId": id,
-        "title": title,
-        "gitBranch": git_branch,
-        "model": model,
-        "approvalPolicy": approval_mode,
-        "sandboxMode": sandbox_mode,
-        "effort": reasoning_effort,
-    }))
-}
-
-async fn scan_via_jsonl(home: &std::path::Path, cwd: &str) -> Option<serde_json::Value> {
-    let sessions_dir = home.join(".codex").join("sessions");
-    if !sessions_dir.exists() {
-        return None;
-    }
-
-    let entries = std::fs::read_dir(&sessions_dir).ok()?;
-    let mut best: Option<(std::path::PathBuf, std::time::SystemTime)> = None;
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        let Ok(content) = std::fs::read_to_string(&path) else { continue };
-        let first_line = content.lines().next().unwrap_or("");
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(first_line) {
-            if v.get("cwd").and_then(|c| c.as_str()) != Some(cwd) {
-                continue;
-            }
-        }
-
-        if let Ok(meta) = path.metadata() {
-            if let Ok(mtime) = meta.modified() {
-                match &best {
-                    None => best = Some((path, mtime)),
-                    Some((_, bt)) if mtime > *bt => best = Some((path, mtime)),
-                    _ => {}
-                }
-            }
-        }
-    }
-
-    let (jsonl_path, _mtime) = best?;
-    let session_id = jsonl_path.file_stem()?.to_str()?.to_string();
-
-    Some(serde_json::json!({
-        "sessionId": session_id,
-        "title": null,
-        "gitBranch": null,
-        "model": null,
-        "approvalPolicy": null,
-        "sandboxMode": null,
-        "effort": null,
-    }))
 }

--- a/src-tauri/src/mod_engine/mods/codex.rs
+++ b/src-tauri/src/mod_engine/mods/codex.rs
@@ -1,52 +1,27 @@
 use std::collections::HashMap;
 
-use crate::mod_engine::{AsyncEmitter, CwdRegistry, Mod, ModContext};
-use crate::mod_engine::osc_parser::OscParser;
+use crate::mod_engine::{Mod, ModContext};
 
 struct CodexTabState {
-    parser: OscParser,
-    last_cwd: Option<String>,
-    active_session_id: Option<String>,
-    awaiting_agent: bool,
+    /// True once the session file has been read for the current process instance.
+    /// Reset to false on `on_agent_cleared` so the next invocation scans again.
+    session_scanned: bool,
 }
 
-/// Monitors `~/.codex/state_5.sqlite` for active Codex sessions in the tab's cwd.
+/// Reads Codex session metadata from `~/.codex/state_5.sqlite` (or JSONL fallback)
+/// when `ProcessInspectorMod` confirms a `codex` process is running in the tab's CWD.
 ///
-/// Falls back to scanning `~/.codex/sessions/*.jsonl` when SQLite is unavailable.
+/// Emits:
+/// - `codex_session`         — session metadata on detection
+/// - `codex_session_cleared` — session gone (agent process ended)
+/// - `tab_type_changed`      — `{ type: "agent", agent: "codex" }` / `{ type: "shell" }`
 pub struct CodexMod {
-    cwd_registry: CwdRegistry,
     tabs: HashMap<String, CodexTabState>,
 }
 
 impl CodexMod {
-    pub fn new(cwd_registry: CwdRegistry) -> Self {
-        Self {
-            cwd_registry,
-            tabs: HashMap::new(),
-        }
-    }
-
-    fn trigger_scan(&self, cwd: String, awaiting: bool, emitter: AsyncEmitter) {
-        tokio::spawn(async move {
-            match scan_codex_session(&cwd, awaiting).await {
-                Some(data) => {
-                    emitter.emit("codex", "codex_session", data);
-                    emitter.emit(
-                        "codex",
-                        "tab_type_changed",
-                        serde_json::json!({ "type": "agent", "agent": "codex" }),
-                    );
-                }
-                None => {
-                    emitter.emit("codex", "codex_session_cleared", serde_json::json!({}));
-                    emitter.emit(
-                        "codex",
-                        "tab_type_changed",
-                        serde_json::json!({ "type": "shell" }),
-                    );
-                }
-            }
-        });
+    pub fn new() -> Self {
+        Self { tabs: HashMap::new() }
     }
 }
 
@@ -56,74 +31,51 @@ impl Mod for CodexMod {
     }
 
     fn on_open(&mut self, ctx: &ModContext) {
-        self.tabs.insert(
-            ctx.tab_id.to_string(),
-            CodexTabState {
-                parser: OscParser::new(),
-                last_cwd: None,
-                active_session_id: None,
-                awaiting_agent: false,
-            },
-        );
+        self.tabs.insert(ctx.tab_id.to_string(), CodexTabState { session_scanned: false });
     }
 
-    fn on_output(&mut self, data: &[u8], ctx: &ModContext) {
-        let (scan_trigger, staleness_scan_cwd): (Option<(String, bool)>, Option<String>) = {
-            let Some(state) = self.tabs.get_mut(ctx.tab_id) else {
-                return;
-            };
-            let seqs = state.parser.feed(data);
-
-            let current_cwd = {
-                let reg = self.cwd_registry.read().unwrap();
-                reg.get(ctx.tab_id).cloned()
-            };
-
-            let scan_trigger = if let Some(ref cwd) = current_cwd {
-                if state.last_cwd.as_deref() != Some(cwd.as_str()) {
-                    let awaiting = state.awaiting_agent;
-                    state.last_cwd = Some(cwd.clone());
-                    Some((cwd.clone(), awaiting))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
-            let has_osc_a = seqs.iter().any(|s| s.code == 133 && s.arg.starts_with('A'));
-            let staleness_scan_cwd = if has_osc_a && state.active_session_id.is_some() {
-                current_cwd
-            } else {
-                None
-            };
-
-            (scan_trigger, staleness_scan_cwd)
-        };
-
-        if let Some((cwd, awaiting)) = scan_trigger {
-            self.trigger_scan(cwd, awaiting, ctx.async_emitter());
+    fn on_agent_detected(&mut self, agent: &str, cwd: &str, ctx: &ModContext) {
+        if agent != "codex" {
+            return;
         }
-        if let Some(cwd) = staleness_scan_cwd {
-            self.trigger_scan(cwd, false, ctx.async_emitter());
+        let Some(state) = self.tabs.get_mut(ctx.tab_id) else { return };
+        if state.session_scanned {
+            return;
         }
-    }
+        state.session_scanned = true;
 
-    fn on_input(&mut self, data: &[u8], ctx: &ModContext) {
-        if data.windows(5).any(|w| w == b"codex") {
-            let cwd_opt = {
-                let state = self.tabs.get_mut(ctx.tab_id);
-                if let Some(state) = state {
-                    state.awaiting_agent = true;
-                    state.last_cwd.clone()
-                } else {
-                    None
+        let emitter = ctx.async_emitter();
+        let cwd = cwd.to_string();
+        tokio::spawn(async move {
+            match scan_codex_session(&cwd).await {
+                Some(data) => {
+                    emitter.emit("codex", "codex_session", data);
+                    emitter.emit(
+                        "codex",
+                        "tab_type_changed",
+                        serde_json::json!({ "type": "agent", "agent": "codex" }),
+                    );
                 }
-            };
-            if let Some(cwd) = cwd_opt {
-                self.trigger_scan(cwd, true, ctx.async_emitter());
+                None => {
+                    // Session not found yet; on_agent_cleared will reset session_scanned.
+                }
             }
+        });
+    }
+
+    fn on_agent_cleared(&mut self, agent: &str, ctx: &ModContext) {
+        if agent != "codex" {
+            return;
         }
+        if let Some(state) = self.tabs.get_mut(ctx.tab_id) {
+            state.session_scanned = false;
+        }
+        ctx.emit("codex", "codex_session_cleared", serde_json::json!({}));
+        ctx.emit(
+            "codex",
+            "tab_type_changed",
+            serde_json::json!({ "type": "shell" }),
+        );
     }
 
     fn on_close(&mut self, ctx: &ModContext) {
@@ -131,23 +83,19 @@ impl Mod for CodexMod {
     }
 }
 
-async fn scan_codex_session(cwd: &str, awaiting_agent: bool) -> Option<serde_json::Value> {
+async fn scan_codex_session(cwd: &str) -> Option<serde_json::Value> {
     let home = dirs::home_dir()?;
 
     // Try SQLite first
-    if let Some(result) = scan_via_sqlite(&home, cwd, awaiting_agent).await {
+    if let Some(result) = scan_via_sqlite(&home, cwd).await {
         return Some(result);
     }
 
     // Fallback: scan ~/.codex/sessions/*.jsonl
-    scan_via_jsonl(&home, cwd, awaiting_agent).await
+    scan_via_jsonl(&home, cwd).await
 }
 
-async fn scan_via_sqlite(
-    home: &std::path::Path,
-    cwd: &str,
-    awaiting_agent: bool,
-) -> Option<serde_json::Value> {
+async fn scan_via_sqlite(home: &std::path::Path, cwd: &str) -> Option<serde_json::Value> {
     let db_path = home.join(".codex").join("state_5.sqlite");
     if !db_path.exists() {
         return None;
@@ -167,9 +115,8 @@ async fn scan_via_sqlite(
     let cwd_owned = cwd.to_string();
     let tmp_clone = tmp.clone();
 
-    // Run blocking SQLite query on a thread pool thread
     let result = tokio::task::spawn_blocking(move || {
-        query_codex_sqlite(&tmp_clone, &cwd_owned, awaiting_agent)
+        query_codex_sqlite(&tmp_clone, &cwd_owned)
     })
     .await
     .ok()??;
@@ -189,11 +136,7 @@ type ThreadRow = (
     i64,
 );
 
-fn query_codex_sqlite(
-    db_path: &std::path::Path,
-    cwd: &str,
-    awaiting_agent: bool,
-) -> Option<serde_json::Value> {
+fn query_codex_sqlite(db_path: &std::path::Path, cwd: &str) -> Option<serde_json::Value> {
     let conn = rusqlite::Connection::open(db_path).ok()?;
 
     let row: Option<ThreadRow> = conn
@@ -216,20 +159,9 @@ fn query_codex_sqlite(
         )
         .ok();
 
-    let (id, title, git_branch, model, approval_mode, sandbox_policy_json, reasoning_effort, updated_at_ms) =
+    let (id, title, git_branch, model, approval_mode, sandbox_policy_json, reasoning_effort, _updated_at_ms) =
         row?;
 
-    // Check freshness
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as i64;
-    let age_secs = (now_ms - updated_at_ms).max(0) / 1000;
-    if age_secs > 120 && !awaiting_agent {
-        return None;
-    }
-
-    // Parse sandbox_policy JSON to extract the type field
     let sandbox_mode = sandbox_policy_json.as_deref().and_then(|json| {
         serde_json::from_str::<serde_json::Value>(json)
             .ok()
@@ -247,17 +179,12 @@ fn query_codex_sqlite(
     }))
 }
 
-async fn scan_via_jsonl(
-    home: &std::path::Path,
-    cwd: &str,
-    awaiting_agent: bool,
-) -> Option<serde_json::Value> {
+async fn scan_via_jsonl(home: &std::path::Path, cwd: &str) -> Option<serde_json::Value> {
     let sessions_dir = home.join(".codex").join("sessions");
     if !sessions_dir.exists() {
         return None;
     }
 
-    // Find most recently modified .jsonl matching cwd
     let entries = std::fs::read_dir(&sessions_dir).ok()?;
     let mut best: Option<(std::path::PathBuf, std::time::SystemTime)> = None;
 
@@ -266,10 +193,7 @@ async fn scan_via_jsonl(
         if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
         }
-        // Quick scan: peek at first line for cwd match
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
+        let Ok(content) = std::fs::read_to_string(&path) else { continue };
         let first_line = content.lines().next().unwrap_or("");
         if let Ok(v) = serde_json::from_str::<serde_json::Value>(first_line) {
             if v.get("cwd").and_then(|c| c.as_str()) != Some(cwd) {
@@ -288,15 +212,7 @@ async fn scan_via_jsonl(
         }
     }
 
-    let (jsonl_path, mtime) = best?;
-
-    let age = std::time::SystemTime::now()
-        .duration_since(mtime)
-        .unwrap_or_default();
-    if age.as_secs() > 120 && !awaiting_agent {
-        return None;
-    }
-
+    let (jsonl_path, _mtime) = best?;
     let session_id = jsonl_path.file_stem()?.to_str()?.to_string();
 
     Some(serde_json::json!({

--- a/src-tauri/src/mod_engine/mods/dir_tracker.rs
+++ b/src-tauri/src/mod_engine/mods/dir_tracker.rs
@@ -45,11 +45,13 @@ impl Mod for DirTrackerMod {
                 continue;
             };
 
-            // Write to registry
+            // Write to registry (legacy — still consumed by ClaudeCodeMod/CodexMod)
             {
                 let mut reg = self.cwd_registry.write().unwrap();
                 reg.insert(ctx.tab_id.to_string(), path.clone());
             }
+            // Signal engine via new push model so on_cwd_changed fires on all mods
+            ctx.set_cwd(&path);
 
             ctx.emit(
                 self.id(),

--- a/src-tauri/src/mod_engine/mods/dir_tracker.rs
+++ b/src-tauri/src/mod_engine/mods/dir_tracker.rs
@@ -1,24 +1,23 @@
 use std::collections::HashMap;
 
-use crate::mod_engine::{CwdRegistry, Mod, ModContext};
+use crate::mod_engine::{Mod, ModContext};
 use crate::mod_engine::osc_parser::OscParser;
 
-/// Watches OSC 7 sequences in PTY output and updates the shared `CwdRegistry`.
+/// Watches OSC 7 sequences in PTY output and signals the engine of CWD changes.
 ///
 /// OSC 7 format: `\x1b]7;file://hostname/path\x07`
 ///
+/// This is the single authoritative OSC 7 parser. Other mods receive CWD updates
+/// via `on_cwd_changed` — they never parse OSC 7 themselves.
+///
 /// Emits a `cwd_changed` event to the frontend whenever the directory changes.
 pub struct DirTrackerMod {
-    cwd_registry: CwdRegistry,
     parsers: HashMap<String, OscParser>,
 }
 
 impl DirTrackerMod {
-    pub fn new(cwd_registry: CwdRegistry) -> Self {
-        Self {
-            cwd_registry,
-            parsers: HashMap::new(),
-        }
+    pub fn new() -> Self {
+        Self { parsers: HashMap::new() }
     }
 }
 
@@ -45,12 +44,8 @@ impl Mod for DirTrackerMod {
                 continue;
             };
 
-            // Write to registry (legacy — still consumed by ClaudeCodeMod/CodexMod)
-            {
-                let mut reg = self.cwd_registry.write().unwrap();
-                reg.insert(ctx.tab_id.to_string(), path.clone());
-            }
-            // Signal engine via new push model so on_cwd_changed fires on all mods
+            // Signal the engine — it will call on_cwd_changed on all mods after
+            // this on_output round completes.
             ctx.set_cwd(&path);
 
             ctx.emit(
@@ -63,10 +58,6 @@ impl Mod for DirTrackerMod {
 
     fn on_close(&mut self, ctx: &ModContext) {
         self.parsers.remove(ctx.tab_id);
-        {
-            let mut reg = self.cwd_registry.write().unwrap();
-            reg.remove(ctx.tab_id);
-        }
         // Signal the frontend to GC tabMeta for this tab.
         ctx.emit(self.id(), "closed", serde_json::json!({}));
     }

--- a/src-tauri/src/mod_engine/mods/git_monitor.rs
+++ b/src-tauri/src/mod_engine/mods/git_monitor.rs
@@ -40,7 +40,7 @@ impl Mod for GitMonitorMod {
     }
 
     fn on_open(&mut self, ctx: &ModContext) {
-        let (cwd_tx, mut cwd_rx) = watch::channel::<Option<String>>(None);
+        let (cwd_tx, cwd_rx) = watch::channel::<Option<String>>(None);
         let emitter = ctx.async_emitter();
 
         // 60-second periodic refresh: reads the latest CWD from the watch receiver.

--- a/src-tauri/src/mod_engine/mods/git_monitor.rs
+++ b/src-tauri/src/mod_engine/mods/git_monitor.rs
@@ -1,31 +1,29 @@
 use std::collections::HashMap;
 
-use crate::mod_engine::{AsyncEmitter, CwdRegistry, Mod, ModContext};
+use crate::mod_engine::{AsyncEmitter, Mod, ModContext};
+use tokio::sync::watch;
 
 struct GitTabState {
     last_queried_cwd: Option<String>,
-    /// Periodic refresh handle (60s interval).
+    /// Watch sender: updated on each on_cwd_changed; the 60s timer reads the receiver.
+    cwd_tx: watch::Sender<Option<String>>,
     timer: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Monitors git context for the tab's current working directory.
 ///
 /// Triggers:
-/// 1. CWD change (detected via CwdRegistry comparison in on_output)
+/// 1. CWD change (received via `on_cwd_changed` push from the engine)
 /// 2. 60-second periodic refresh timer
 ///
 /// Emits `git_info` events with branch, ahead/behind, dirty, worktree, and PR.
 pub struct GitMonitorMod {
-    cwd_registry: CwdRegistry,
     tabs: HashMap<String, GitTabState>,
 }
 
 impl GitMonitorMod {
-    pub fn new(cwd_registry: CwdRegistry) -> Self {
-        Self {
-            cwd_registry,
-            tabs: HashMap::new(),
-        }
+    pub fn new() -> Self {
+        Self { tabs: HashMap::new() }
     }
 
     fn spawn_git_query(&self, cwd: String, emitter: AsyncEmitter) {
@@ -42,20 +40,16 @@ impl Mod for GitMonitorMod {
     }
 
     fn on_open(&mut self, ctx: &ModContext) {
-        let tab_id = ctx.tab_id.to_string();
-        let cwd_registry = self.cwd_registry.clone();
+        let (cwd_tx, mut cwd_rx) = watch::channel::<Option<String>>(None);
         let emitter = ctx.async_emitter();
 
-        // 60-second periodic refresh
+        // 60-second periodic refresh: reads the latest CWD from the watch receiver.
         let timer = tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
             interval.tick().await; // skip immediate tick
             loop {
                 interval.tick().await;
-                let cwd = {
-                    let reg = cwd_registry.read().unwrap();
-                    reg.get(&tab_id).cloned()
-                };
+                let cwd = cwd_rx.borrow().clone();
                 if let Some(cwd) = cwd {
                     let data = query_git_info(&cwd).await;
                     emitter.emit("git_monitor", "git_info", data);
@@ -67,27 +61,28 @@ impl Mod for GitMonitorMod {
             ctx.tab_id.to_string(),
             GitTabState {
                 last_queried_cwd: None,
+                cwd_tx,
                 timer: Some(timer),
             },
         );
     }
 
-    fn on_output(&mut self, _data: &[u8], ctx: &ModContext) {
+    fn on_cwd_changed(&mut self, cwd: &str, ctx: &ModContext) {
         let Some(state) = self.tabs.get_mut(ctx.tab_id) else {
             return;
         };
 
-        let current_cwd = {
-            let reg = self.cwd_registry.read().unwrap();
-            reg.get(ctx.tab_id).cloned()
-        };
-
-        if let Some(ref cwd) = current_cwd {
-            if state.last_queried_cwd.as_deref() != Some(cwd.as_str()) {
-                state.last_queried_cwd = Some(cwd.clone());
-                self.spawn_git_query(cwd.clone(), ctx.async_emitter());
-            }
+        // Debounce: skip if same CWD as last query.
+        if state.last_queried_cwd.as_deref() == Some(cwd) {
+            return;
         }
+        state.last_queried_cwd = Some(cwd.to_string());
+
+        // Update the watch sender so the 60s timer picks up the new CWD.
+        let _ = state.cwd_tx.send(Some(cwd.to_string()));
+
+        // Fire an immediate git query for the new directory.
+        self.spawn_git_query(cwd.to_string(), ctx.async_emitter());
     }
 
     fn on_close(&mut self, ctx: &ModContext) {

--- a/src-tauri/src/mod_engine/mods/process_inspector.rs
+++ b/src-tauri/src/mod_engine/mods/process_inspector.rs
@@ -49,7 +49,7 @@ impl Mod for ProcessInspectorMod {
             loop {
                 interval.tick().await;
 
-                let cwd = cwd_rx.borrow().clone().unwrap_or_default();
+                let cwd = cwd_rx.borrow().clone();
                 let processes = scan_processes(shell_pid).await;
 
                 emitter.emit(
@@ -58,7 +58,11 @@ impl Mod for ProcessInspectorMod {
                     serde_json::json!({ "processes": processes }),
                 );
 
-                diff_agent_pids(&processes, &mut prev_pids, &cwd, &signaler);
+                // Skip agent diffing until the CWD is known — avoids emitting
+                // agent_detected with an empty CWD string on the first scan tick.
+                if let Some(ref cwd) = cwd {
+                    diff_agent_pids(&processes, &mut prev_pids, cwd, &signaler);
+                }
             }
         });
 

--- a/src-tauri/src/mod_engine/mods/process_inspector.rs
+++ b/src-tauri/src/mod_engine/mods/process_inspector.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::mod_engine::{AsyncAgentSignaler, AsyncEmitter, Mod, ModContext};
+use crate::mod_engine::{AsyncAgentSignaler, Mod, ModContext};
 use tokio::sync::watch;
 
 struct InspectorTabState {

--- a/src-tauri/src/mod_engine/mods/process_inspector.rs
+++ b/src-tauri/src/mod_engine/mods/process_inspector.rs
@@ -44,7 +44,7 @@ impl Mod for ProcessInspectorMod {
         let handle = tokio::spawn(async move {
             let mut prev_pids: HashMap<String, u32> = HashMap::new();
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
-            let mut cwd_rx = cwd_rx;
+            let cwd_rx = cwd_rx;
 
             loop {
                 interval.tick().await;

--- a/src-tauri/src/mod_engine/mods/process_inspector.rs
+++ b/src-tauri/src/mod_engine/mods/process_inspector.rs
@@ -1,23 +1,25 @@
 use std::collections::HashMap;
 
-use crate::mod_engine::{CwdRegistry, Mod, ModContext};
+use crate::mod_engine::{AsyncEmitter, Mod, ModContext};
+use tokio::sync::watch;
+
+struct InspectorTabState {
+    /// Watch sender: updated on each on_cwd_changed; the 2s timer reads the receiver.
+    cwd_tx: watch::Sender<Option<String>>,
+    handle: tokio::task::JoinHandle<()>,
+}
 
 /// Periodically scans for agent processes (claude, codex, node) in the tab's cwd
-/// and emits `listening_ports` events with the TCP ports they are listening on.
+/// and emits `process_info` events with per-process metadata and listening ports.
 ///
 /// Scan interval: every 2 seconds while the tab is open.
 pub struct ProcessInspectorMod {
-    cwd_registry: CwdRegistry,
-    /// Per-tab: abort handle for the background timer task.
-    handles: HashMap<String, tokio::task::JoinHandle<()>>,
+    tabs: HashMap<String, InspectorTabState>,
 }
 
 impl ProcessInspectorMod {
-    pub fn new(cwd_registry: CwdRegistry) -> Self {
-        Self {
-            cwd_registry,
-            handles: HashMap::new(),
-        }
+    pub fn new() -> Self {
+        Self { tabs: HashMap::new() }
     }
 }
 
@@ -27,60 +29,105 @@ impl Mod for ProcessInspectorMod {
     }
 
     fn on_open(&mut self, ctx: &ModContext) {
-        let tab_id = ctx.tab_id.to_string();
-        let cwd_registry = self.cwd_registry.clone();
+        let (cwd_tx, mut cwd_rx) = watch::channel::<Option<String>>(None);
         let emitter = ctx.async_emitter();
 
         let handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
             loop {
                 interval.tick().await;
-                let cwd = {
-                    let reg = cwd_registry.read().unwrap();
-                    reg.get(&tab_id).cloned()
-                };
+                let cwd = cwd_rx.borrow().clone();
                 let Some(cwd) = cwd else { continue };
 
-                let ports = scan_ports(&cwd).await;
+                let processes = scan_processes(&cwd).await;
                 emitter.emit(
                     "process_inspector",
-                    "listening_ports",
-                    serde_json::json!({ "ports": ports }),
+                    "process_info",
+                    serde_json::json!({ "processes": processes }),
                 );
             }
         });
 
-        self.handles.insert(ctx.tab_id.to_string(), handle);
+        self.tabs.insert(ctx.tab_id.to_string(), InspectorTabState { cwd_tx, handle });
     }
 
-    fn on_output(&mut self, _data: &[u8], _ctx: &ModContext) {}
+    fn on_cwd_changed(&mut self, cwd: &str, ctx: &ModContext) {
+        if let Some(state) = self.tabs.get(ctx.tab_id) {
+            let _ = state.cwd_tx.send(Some(cwd.to_string()));
+        }
+    }
 
     fn on_close(&mut self, ctx: &ModContext) {
-        if let Some(handle) = self.handles.remove(ctx.tab_id) {
-            handle.abort();
+        if let Some(state) = self.tabs.remove(ctx.tab_id) {
+            state.handle.abort();
         }
     }
 }
 
-/// Scan for agent processes in the given cwd and return their listening TCP ports.
-async fn scan_ports(cwd: &str) -> Vec<u16> {
-    // Step 1: find PIDs of claude/codex/node processes whose working dir matches
-    let pids = find_agent_pids(cwd).await;
-    if pids.is_empty() {
+/// A single process entry in the `process_info` event.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProcessEntry {
+    pid: u32,
+    command: String,
+    name: String,
+    /// Lifetime CPU average from `ps pcpu=`. NOT suitable for live UI display —
+    /// heavily diluted for long-running processes. Collected for completeness only.
+    cpu_percent: f32,
+    memory_kb: u64,
+    elapsed_time: String,
+    listening_ports: Vec<u16>,
+}
+
+/// Scan for agent processes in the given cwd and return enriched entries.
+async fn scan_processes(cwd: &str) -> Vec<serde_json::Value> {
+    let raw = find_agent_processes(cwd).await;
+    if raw.is_empty() {
         return Vec::new();
     }
 
-    // Step 2: find listening ports for those PIDs via lsof
-    find_listening_ports(&pids).await
+    let pids: Vec<u32> = raw.iter().map(|p| p.0).collect();
+    let ports_map = find_listening_ports_per_pid(&pids).await;
+
+    raw.into_iter()
+        .map(|(pid, command, cpu_percent, memory_kb, elapsed_time)| {
+            let name = process_name(&command);
+            let listening_ports = ports_map.get(&pid).cloned().unwrap_or_default();
+            let entry = ProcessEntry {
+                pid,
+                command,
+                name,
+                cpu_percent,
+                memory_kb,
+                elapsed_time,
+                listening_ports,
+            };
+            serde_json::to_value(entry).unwrap_or(serde_json::json!(null))
+        })
+        .collect()
 }
 
-/// Run `ps -ax -o pid=,wdir=,comm=` and filter for processes in cwd.
-/// Returns a list of PIDs.
-async fn find_agent_pids(cwd: &str) -> Vec<u32> {
+/// Extract the basename of the first token in a command string.
+/// e.g. `/usr/local/bin/node server.js` → `node`
+fn process_name(command: &str) -> String {
+    let first = command.split_whitespace().next().unwrap_or(command);
+    std::path::Path::new(first)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(first)
+        .to_string()
+}
+
+/// Run `ps -ax -o pid=,wdir=,pcpu=,rss=,etime=,command=` and filter for
+/// agent processes (claude, codex, node) whose wdir matches cwd.
+///
+/// Returns tuples of (pid, command, cpu_percent, memory_kb, elapsed_time).
+/// `command=` is placed last so it captures the full argv including spaces.
+async fn find_agent_processes(cwd: &str) -> Vec<(u32, String, f32, u64, String)> {
     let output = tokio::time::timeout(
         tokio::time::Duration::from_secs(3),
         tokio::process::Command::new("ps")
-            .args(["-ax", "-o", "pid=,wdir=,comm="])
+            .args(["-ax", "-o", "pid=,wdir=,pcpu=,rss=,etime=,command="])
             .output(),
     )
     .await
@@ -90,47 +137,45 @@ async fn find_agent_pids(cwd: &str) -> Vec<u32> {
     let Some(output) = output else { return Vec::new() };
     let text = String::from_utf8_lossy(&output.stdout);
 
-    let mut pids = Vec::new();
+    let mut results = Vec::new();
     for line in text.lines() {
-        let parts: Vec<&str> = line.trim().splitn(3, char::is_whitespace).collect();
-        if parts.len() < 3 {
-            continue;
-        }
-        let pid_str = parts[0].trim();
-        let wdir = parts[1].trim();
-        let comm = parts[2].trim();
+        // Fields: pid wdir pcpu rss etime command...
+        // Split into 6 parts: first 5 are fixed, 6th is command (may have spaces).
+        let mut parts = line.trim().splitn(6, char::is_whitespace);
+        let pid_str = match parts.next() { Some(s) => s.trim(), None => continue };
+        let wdir = match parts.next() { Some(s) => s.trim(), None => continue };
+        let pcpu_str = match parts.next() { Some(s) => s.trim(), None => continue };
+        let rss_str = match parts.next() { Some(s) => s.trim(), None => continue };
+        let etime = match parts.next() { Some(s) => s.trim(), None => continue };
+        let command = match parts.next() { Some(s) => s.trim(), None => continue };
 
         if wdir != cwd {
             continue;
         }
 
-        let comm_lower = comm.to_lowercase();
-        let is_agent = comm_lower == "claude"
-            || comm_lower == "codex"
-            || comm_lower == "node"
-            || comm_lower.ends_with("/claude")
-            || comm_lower.ends_with("/codex")
-            || comm_lower.ends_with("/node");
+        let name = process_name(command).to_lowercase();
+        let is_agent = name == "claude"
+            || name == "codex"
+            || name == "node";
 
         if !is_agent {
             continue;
         }
 
-        if let Ok(pid) = pid_str.parse::<u32>() {
-            pids.push(pid);
-        }
+        let Ok(pid) = pid_str.parse::<u32>() else { continue };
+        let cpu_percent = pcpu_str.parse::<f32>().unwrap_or(0.0);
+        let memory_kb = rss_str.parse::<u64>().unwrap_or(0);
+
+        results.push((pid, command.to_string(), cpu_percent, memory_kb, etime.to_string()));
     }
 
-    pids
+    results
 }
 
-/// Run `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -Fpn` and parse listening ports.
-async fn find_listening_ports(pids: &[u32]) -> Vec<u16> {
-    let pid_arg = pids
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
+/// Run `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -Fpn` and parse listening
+/// ports per PID. Returns a map of pid → sorted port list.
+async fn find_listening_ports_per_pid(pids: &[u32]) -> HashMap<u32, Vec<u16>> {
+    let pid_arg = pids.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(",");
 
     let output = tokio::time::timeout(
         tokio::time::Duration::from_secs(3),
@@ -142,23 +187,30 @@ async fn find_listening_ports(pids: &[u32]) -> Vec<u16> {
     .ok()
     .and_then(|r| r.ok());
 
-    let Some(output) = output else { return Vec::new() };
+    let Some(output) = output else { return HashMap::new() };
     let text = String::from_utf8_lossy(&output.stdout);
 
-    let mut ports = std::collections::HashSet::new();
+    let mut result: HashMap<u32, Vec<u16>> = HashMap::new();
+    let mut current_pid: Option<u32> = None;
+
     for line in text.lines() {
-        // lsof -F output: lines starting with 'n' contain the address
-        // Format: n*:PORT or n127.0.0.1:PORT
-        if let Some(addr) = line.strip_prefix('n') {
-            if let Some(port_str) = addr.rsplit(':').next() {
-                if let Ok(port) = port_str.parse::<u16>() {
-                    ports.insert(port);
+        if let Some(pid_str) = line.strip_prefix('p') {
+            current_pid = pid_str.parse().ok();
+        } else if let Some(addr) = line.strip_prefix('n') {
+            if let Some(pid) = current_pid {
+                if let Some(port_str) = addr.rsplit(':').next() {
+                    if let Ok(port) = port_str.parse::<u16>() {
+                        result.entry(pid).or_default().push(port);
+                    }
                 }
             }
         }
     }
 
-    let mut result: Vec<u16> = ports.into_iter().collect();
-    result.sort_unstable();
+    for ports in result.values_mut() {
+        ports.sort_unstable();
+        ports.dedup();
+    }
+
     result
 }

--- a/src-tauri/src/mod_engine/mods/process_inspector.rs
+++ b/src-tauri/src/mod_engine/mods/process_inspector.rs
@@ -8,13 +8,16 @@ struct InspectorTabState {
     handle: tokio::task::JoinHandle<()>,
 }
 
-/// Periodically scans for agent processes (claude, codex, node) in the tab's cwd
-/// and emits `process_info` events with per-process metadata and listening ports.
+/// Periodically scans for agent processes (claude, codex) that are direct children
+/// of the tab's shell process and emits `process_info` events.
 ///
-/// CWD matching uses `lsof -d cwd` because macOS restricts proc_pidinfo CWD reads
-/// (sysinfo's `process.cwd()` always returns None without special entitlements).
-/// Metrics (CPU, memory) are read via sysinfo for the matched PIDs.
-/// Listening ports are detected via `lsof -iTCP -sTCP:LISTEN`.
+/// Uses `ps -o ppid=` to detect processes by parent PID — this correctly scopes
+/// detection to only the agent launched FROM this terminal tab, not any claude/codex
+/// process that happens to share the same CWD from another session.
+///
+/// Uses `ps -o args=` for command line args (sysinfo can't read cmd on macOS).
+/// Uses `sysinfo` for CPU/memory metrics (fast, no subprocess).
+/// Uses `lsof -iTCP` for listening port detection.
 ///
 /// Scan interval: every 2 seconds while the tab is open.
 pub struct ProcessInspectorMod {
@@ -33,6 +36,7 @@ impl Mod for ProcessInspectorMod {
     }
 
     fn on_open(&mut self, ctx: &ModContext) {
+        let shell_pid = ctx.shell_pid;
         let (cwd_tx, cwd_rx) = watch::channel::<Option<String>>(None);
         let emitter = ctx.async_emitter();
         let signaler = ctx.async_agent_signaler();
@@ -44,10 +48,9 @@ impl Mod for ProcessInspectorMod {
 
             loop {
                 interval.tick().await;
-                let cwd = cwd_rx.borrow().clone();
-                let Some(cwd) = cwd else { continue };
 
-                let processes = scan_processes(&cwd).await;
+                let cwd = cwd_rx.borrow().clone().unwrap_or_default();
+                let processes = scan_processes(shell_pid).await;
 
                 emitter.emit(
                     "process_inspector",
@@ -116,34 +119,30 @@ struct ProcessEntry {
     pid: u32,
     command: String,
     name: String,
-    /// Interval-sampled CPU % via sysinfo — accurate for live display.
     cpu_percent: f32,
-    /// Resident memory in KB.
     memory_kb: u64,
     elapsed_time: String,
     listening_ports: Vec<u16>,
 }
 
-/// Scan for agent processes in `cwd` and return enriched entries.
-///
-/// Step 1: `lsof -d cwd` to find agent PIDs whose CWD matches (macOS restricts
-///         proc_pidinfo CWD reads, so sysinfo's process.cwd() always returns None).
-/// Step 2: sysinfo to read CPU/memory/elapsed for those specific PIDs.
-/// Step 3: lsof TCP to find listening ports per PID.
-async fn scan_processes(cwd: &str) -> Vec<serde_json::Value> {
-    // Step 1: find agent PIDs in this cwd via lsof
-    let pids = find_agent_pids_in_cwd(cwd).await;
+/// Scan for agent processes that are direct children of `shell_pid`.
+async fn scan_processes(shell_pid: u32) -> Vec<serde_json::Value> {
+    if shell_pid == 0 {
+        return Vec::new();
+    }
 
+    // Step 1: find claude/codex PIDs that are direct children of shell_pid
+    let pids = find_agent_children_of_shell(shell_pid).await;
     if pids.is_empty() {
         return Vec::new();
     }
 
-    // Step 2a: get cmd args via ps (sysinfo can't read cmd on macOS)
+    // Step 2: get full cmd args via ps (sysinfo can't read cmd on macOS)
     let args_map = get_process_args(&pids).await;
 
-    // Step 2b: get metrics for matched PIDs via sysinfo (not Send — spawn_blocking)
-    let pids_for_metrics = pids.clone();
-    let raw = tokio::task::spawn_blocking(move || get_process_metrics(&pids_for_metrics))
+    // Step 3: get CPU/memory/elapsed via sysinfo (not Send — spawn_blocking)
+    let pids_clone = pids.clone();
+    let raw = tokio::task::spawn_blocking(move || get_process_metrics(&pids_clone))
         .await
         .unwrap_or_default();
 
@@ -151,7 +150,7 @@ async fn scan_processes(cwd: &str) -> Vec<serde_json::Value> {
         return Vec::new();
     }
 
-    // Step 3: listening ports via lsof TCP
+    // Step 4: listening ports via lsof TCP
     let metric_pids: Vec<u32> = raw.iter().map(|p| p.0).collect();
     let ports_map = find_listening_ports_per_pid(&metric_pids).await;
 
@@ -167,17 +166,15 @@ async fn scan_processes(cwd: &str) -> Vec<serde_json::Value> {
         .collect()
 }
 
-/// Use `lsof -d cwd` to find PIDs of agent processes (claude, codex, node) whose
-/// working directory matches `cwd`. Returns matched PIDs.
+/// Find PIDs of agent processes (claude, codex) whose parent is `shell_pid`.
 ///
-/// macOS does not allow reading other processes' CWDs via proc_pidinfo without
-/// special entitlements, so sysinfo's process.cwd() always returns None.
-/// lsof uses a different kernel interface that works for same-user processes.
-async fn find_agent_pids_in_cwd(cwd: &str) -> Vec<u32> {
+/// Uses `ps -ax -o pid=,ppid=,comm=` which is fast (no file I/O, no lsof).
+/// This correctly scopes detection to agents launched from this terminal tab only.
+async fn find_agent_children_of_shell(shell_pid: u32) -> Vec<u32> {
     let output = tokio::time::timeout(
-        tokio::time::Duration::from_secs(3),
-        tokio::process::Command::new("lsof")
-            .args(["-a", "-c", "claude", "-c", "codex", "-d", "cwd", "-Fpn"])
+        tokio::time::Duration::from_secs(2),
+        tokio::process::Command::new("ps")
+            .args(["-ax", "-o", "pid=,ppid=,comm="])
             .output(),
     )
     .await
@@ -187,29 +184,31 @@ async fn find_agent_pids_in_cwd(cwd: &str) -> Vec<u32> {
     let Some(output) = output else { return Vec::new() };
     let text = String::from_utf8_lossy(&output.stdout);
 
-    // lsof -Fpn output per process (with -d cwd, one entry per process):
-    //   p<pid>
-    //   fcwd
-    //   n<path>
     let mut pids = Vec::new();
-    let mut current_pid: Option<u32> = None;
-
     for line in text.lines() {
-        if let Some(pid_str) = line.strip_prefix('p') {
-            current_pid = pid_str.parse().ok();
-        } else if let Some(path) = line.strip_prefix('n') {
-            if let Some(pid) = current_pid {
-                if path == cwd {
-                    pids.push(pid);
-                }
-            }
+        let mut parts = line.split_whitespace();
+        let pid: u32 = match parts.next().and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        let ppid: u32 = match parts.next().and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        let comm = match parts.next() {
+            Some(c) => c.to_lowercase(),
+            None => continue,
+        };
+        let comm = comm.trim_end_matches('\0');
+
+        if ppid == shell_pid && (comm == "claude" || comm == "codex") {
+            pids.push(pid);
         }
     }
-
     pids
 }
 
-/// Get cmd args for specific PIDs via `ps -o args=`.
+/// Get full command + args for specific PIDs via `ps -o args=`.
 /// sysinfo's `process.cmd()` always returns empty on macOS without entitlements.
 async fn get_process_args(pids: &[u32]) -> HashMap<u32, String> {
     if pids.is_empty() {
@@ -233,7 +232,6 @@ async fn get_process_args(pids: &[u32]) -> HashMap<u32, String> {
     for line in text.lines() {
         let line = line.trim();
         if line.is_empty() { continue; }
-        // format: "12345 claude --some-flag"
         if let Some(space) = line.find(char::is_whitespace) {
             if let Ok(pid) = line[..space].trim().parse::<u32>() {
                 let cmd = line[space..].trim().to_string();
@@ -245,7 +243,6 @@ async fn get_process_args(pids: &[u32]) -> HashMap<u32, String> {
 }
 
 /// Read name, CPU, memory, and elapsed time for specific PIDs via sysinfo.
-/// Returns (pid, name, cpu_percent, memory_kb, elapsed_time).
 fn get_process_metrics(pids: &[u32]) -> Vec<(u32, String, f32, u64, String)> {
     use sysinfo::{Pid, ProcessesToUpdate, System};
 

--- a/src-tauri/src/mod_engine/mods/process_inspector.rs
+++ b/src-tauri/src/mod_engine/mods/process_inspector.rs
@@ -45,14 +45,9 @@ impl Mod for ProcessInspectorMod {
             loop {
                 interval.tick().await;
                 let cwd = cwd_rx.borrow().clone();
-                let Some(cwd) = cwd else {
-                    eprintln!("[process_inspector] tick: no CWD yet, skipping");
-                    continue;
-                };
+                let Some(cwd) = cwd else { continue };
 
-                eprintln!("[process_inspector] scanning cwd={cwd}");
                 let processes = scan_processes(&cwd).await;
-                eprintln!("[process_inspector] found {} process(es)", processes.len());
 
                 emitter.emit(
                     "process_inspector",
@@ -68,7 +63,6 @@ impl Mod for ProcessInspectorMod {
     }
 
     fn on_cwd_changed(&mut self, cwd: &str, ctx: &ModContext) {
-        eprintln!("[process_inspector] on_cwd_changed tab={} cwd={cwd}", ctx.tab_id);
         if let Some(state) = self.tabs.get(ctx.tab_id) {
             let _ = state.cwd_tx.send(Some(cwd.to_string()));
         }
@@ -139,7 +133,6 @@ struct ProcessEntry {
 async fn scan_processes(cwd: &str) -> Vec<serde_json::Value> {
     // Step 1: find agent PIDs in this cwd via lsof
     let pids = find_agent_pids_in_cwd(cwd).await;
-    eprintln!("[process_inspector] agent PIDs in cwd: {:?}", pids);
 
     if pids.is_empty() {
         return Vec::new();
@@ -206,7 +199,6 @@ async fn find_agent_pids_in_cwd(cwd: &str) -> Vec<u32> {
             current_pid = pid_str.parse().ok();
         } else if let Some(path) = line.strip_prefix('n') {
             if let Some(pid) = current_pid {
-                eprintln!("[process_inspector] lsof cwd: pid={pid} path={path}");
                 if path == cwd {
                     pids.push(pid);
                 }

--- a/src-tauri/src/mod_engine/mods/process_inspector.rs
+++ b/src-tauri/src/mod_engine/mods/process_inspector.rs
@@ -4,7 +4,6 @@ use crate::mod_engine::{AsyncAgentSignaler, Mod, ModContext};
 use tokio::sync::watch;
 
 struct InspectorTabState {
-    /// Watch sender: updated on each on_cwd_changed; the 2s timer reads the receiver.
     cwd_tx: watch::Sender<Option<String>>,
     handle: tokio::task::JoinHandle<()>,
 }
@@ -12,9 +11,10 @@ struct InspectorTabState {
 /// Periodically scans for agent processes (claude, codex, node) in the tab's cwd
 /// and emits `process_info` events with per-process metadata and listening ports.
 ///
-/// Also tracks agent PIDs across scans and signals the engine via `AsyncAgentSignaler`
-/// when a claude/codex process appears or disappears, so `ClaudeCodeMod`/`CodexMod`
-/// can react via `on_agent_detected`/`on_agent_cleared`.
+/// CWD matching uses `lsof -d cwd` because macOS restricts proc_pidinfo CWD reads
+/// (sysinfo's `process.cwd()` always returns None without special entitlements).
+/// Metrics (CPU, memory) are read via sysinfo for the matched PIDs.
+/// Listening ports are detected via `lsof -iTCP -sTCP:LISTEN`.
 ///
 /// Scan interval: every 2 seconds while the tab is open.
 pub struct ProcessInspectorMod {
@@ -33,30 +33,33 @@ impl Mod for ProcessInspectorMod {
     }
 
     fn on_open(&mut self, ctx: &ModContext) {
-        let (cwd_tx, mut cwd_rx) = watch::channel::<Option<String>>(None);
+        let (cwd_tx, cwd_rx) = watch::channel::<Option<String>>(None);
         let emitter = ctx.async_emitter();
         let signaler = ctx.async_agent_signaler();
 
         let handle = tokio::spawn(async move {
-            // PID tracking: agent name → last seen PID. Used to diff consecutive scans.
             let mut prev_pids: HashMap<String, u32> = HashMap::new();
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
+            let mut cwd_rx = cwd_rx;
 
             loop {
                 interval.tick().await;
                 let cwd = cwd_rx.borrow().clone();
-                let Some(cwd) = cwd else { continue };
+                let Some(cwd) = cwd else {
+                    eprintln!("[process_inspector] tick: no CWD yet, skipping");
+                    continue;
+                };
 
+                eprintln!("[process_inspector] scanning cwd={cwd}");
                 let processes = scan_processes(&cwd).await;
+                eprintln!("[process_inspector] found {} process(es)", processes.len());
 
-                // Emit process_info to frontend.
                 emitter.emit(
                     "process_inspector",
                     "process_info",
                     serde_json::json!({ "processes": processes }),
                 );
 
-                // Diff agent PIDs to fire lifecycle signals.
                 diff_agent_pids(&processes, &mut prev_pids, &cwd, &signaler);
             }
         });
@@ -65,6 +68,7 @@ impl Mod for ProcessInspectorMod {
     }
 
     fn on_cwd_changed(&mut self, cwd: &str, ctx: &ModContext) {
+        eprintln!("[process_inspector] on_cwd_changed tab={} cwd={cwd}", ctx.tab_id);
         if let Some(state) = self.tabs.get(ctx.tab_id) {
             let _ = state.cwd_tx.send(Some(cwd.to_string()));
         }
@@ -77,115 +81,110 @@ impl Mod for ProcessInspectorMod {
     }
 }
 
-/// Compare current agent PIDs against the previous scan's PIDs.
-/// Fires `agent_detected` for new/changed-PID agents and `agent_cleared` for gone agents.
 fn diff_agent_pids(
     processes: &[serde_json::Value],
     prev_pids: &mut HashMap<String, u32>,
     cwd: &str,
     signaler: &AsyncAgentSignaler,
 ) {
-    // Collect current agent PIDs (only claude and codex trigger lifecycle signals).
-    let mut current_pids: HashMap<String, u32> = HashMap::new();
+    let mut current_pids: HashMap<String, (u32, String)> = HashMap::new();
     for proc in processes {
         let name = proc.get("name").and_then(|n| n.as_str()).unwrap_or("");
         if name == "claude" || name == "codex" {
             if let Some(pid) = proc.get("pid").and_then(|p| p.as_u64()) {
-                current_pids.insert(name.to_string(), pid as u32);
+                let cmd = proc.get("command").and_then(|c| c.as_str()).unwrap_or("").to_string();
+                current_pids.insert(name.to_string(), (pid as u32, cmd));
             }
         }
     }
 
-    // Cleared: agents in prev but not in current, or with a different (restarted) PID.
     for (agent, prev_pid) in prev_pids.iter() {
         match current_pids.get(agent) {
             None => signaler.agent_cleared(agent),
-            Some(curr_pid) if curr_pid != prev_pid => {
-                signaler.agent_cleared(agent);
-                // The detected signal fires in the loop below.
-            }
+            Some((curr_pid, _)) if curr_pid != prev_pid => { signaler.agent_cleared(agent); }
             _ => {}
         }
     }
-
-    // Detected: new agents, or agents with a changed PID (restarted).
-    for (agent, curr_pid) in &current_pids {
+    for (agent, (curr_pid, cmd)) in &current_pids {
         match prev_pids.get(agent) {
-            None => signaler.agent_detected(agent, cwd),
-            Some(prev_pid) if prev_pid != curr_pid => {
-                signaler.agent_detected(agent, cwd);
-            }
+            None => signaler.agent_detected(agent, cwd, cmd),
+            Some(prev_pid) if prev_pid != curr_pid => { signaler.agent_detected(agent, cwd, cmd); }
             _ => {}
         }
     }
 
-    *prev_pids = current_pids;
+    *prev_pids = current_pids.into_iter().map(|(k, (pid, _))| (k, pid)).collect();
 }
 
-/// A single process entry in the `process_info` event.
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ProcessEntry {
     pid: u32,
     command: String,
     name: String,
-    /// Lifetime CPU average from `ps pcpu=`. NOT suitable for live UI display —
-    /// heavily diluted for long-running processes. Collected for completeness only.
+    /// Interval-sampled CPU % via sysinfo — accurate for live display.
     cpu_percent: f32,
+    /// Resident memory in KB.
     memory_kb: u64,
     elapsed_time: String,
     listening_ports: Vec<u16>,
 }
 
-/// Scan for agent processes in the given cwd and return enriched entries.
+/// Scan for agent processes in `cwd` and return enriched entries.
+///
+/// Step 1: `lsof -d cwd` to find agent PIDs whose CWD matches (macOS restricts
+///         proc_pidinfo CWD reads, so sysinfo's process.cwd() always returns None).
+/// Step 2: sysinfo to read CPU/memory/elapsed for those specific PIDs.
+/// Step 3: lsof TCP to find listening ports per PID.
 async fn scan_processes(cwd: &str) -> Vec<serde_json::Value> {
-    let raw = find_agent_processes(cwd).await;
+    // Step 1: find agent PIDs in this cwd via lsof
+    let pids = find_agent_pids_in_cwd(cwd).await;
+    eprintln!("[process_inspector] agent PIDs in cwd: {:?}", pids);
+
+    if pids.is_empty() {
+        return Vec::new();
+    }
+
+    // Step 2a: get cmd args via ps (sysinfo can't read cmd on macOS)
+    let args_map = get_process_args(&pids).await;
+
+    // Step 2b: get metrics for matched PIDs via sysinfo (not Send — spawn_blocking)
+    let pids_for_metrics = pids.clone();
+    let raw = tokio::task::spawn_blocking(move || get_process_metrics(&pids_for_metrics))
+        .await
+        .unwrap_or_default();
+
     if raw.is_empty() {
         return Vec::new();
     }
 
-    let pids: Vec<u32> = raw.iter().map(|p| p.0).collect();
-    let ports_map = find_listening_ports_per_pid(&pids).await;
+    // Step 3: listening ports via lsof TCP
+    let metric_pids: Vec<u32> = raw.iter().map(|p| p.0).collect();
+    let ports_map = find_listening_ports_per_pid(&metric_pids).await;
 
     raw.into_iter()
-        .map(|(pid, command, cpu_percent, memory_kb, elapsed_time)| {
-            let name = process_name(&command);
+        .map(|(pid, name, cpu_percent, memory_kb, elapsed_time)| {
+            let command = args_map.get(&pid).cloned().unwrap_or_default();
             let listening_ports = ports_map.get(&pid).cloned().unwrap_or_default();
-            let entry = ProcessEntry {
-                pid,
-                command,
-                name,
-                cpu_percent,
-                memory_kb,
-                elapsed_time,
-                listening_ports,
-            };
-            serde_json::to_value(entry).unwrap_or(serde_json::json!(null))
+            serde_json::to_value(ProcessEntry {
+                pid, command, name, cpu_percent, memory_kb, elapsed_time, listening_ports,
+            })
+            .unwrap_or(serde_json::json!(null))
         })
         .collect()
 }
 
-/// Extract the basename of the first token in a command string.
-/// e.g. `/usr/local/bin/node server.js` → `node`
-fn process_name(command: &str) -> String {
-    let first = command.split_whitespace().next().unwrap_or(command);
-    std::path::Path::new(first)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(first)
-        .to_string()
-}
-
-/// Run `ps -ax -o pid=,wdir=,pcpu=,rss=,etime=,command=` and filter for
-/// agent processes (claude, codex, node) whose wdir matches cwd.
+/// Use `lsof -d cwd` to find PIDs of agent processes (claude, codex, node) whose
+/// working directory matches `cwd`. Returns matched PIDs.
 ///
-/// Returns tuples of (pid, command, cpu_percent, memory_kb, elapsed_time).
-/// `command=` is placed last so it captures the full argv including spaces.
-async fn find_agent_processes(cwd: &str) -> Vec<(u32, String, f32, u64, String)> {
+/// macOS does not allow reading other processes' CWDs via proc_pidinfo without
+/// special entitlements, so sysinfo's process.cwd() always returns None.
+/// lsof uses a different kernel interface that works for same-user processes.
+async fn find_agent_pids_in_cwd(cwd: &str) -> Vec<u32> {
     let output = tokio::time::timeout(
         tokio::time::Duration::from_secs(3),
-        tokio::process::Command::new("ps")
-            .args(["-ax", "-o", "pid=,wdir=,pcpu=,rss=,etime=,command="])
+        tokio::process::Command::new("lsof")
+            .args(["-a", "-c", "claude", "-c", "codex", "-d", "cwd", "-Fpn"])
             .output(),
     )
     .await
@@ -195,41 +194,106 @@ async fn find_agent_processes(cwd: &str) -> Vec<(u32, String, f32, u64, String)>
     let Some(output) = output else { return Vec::new() };
     let text = String::from_utf8_lossy(&output.stdout);
 
-    let mut results = Vec::new();
+    // lsof -Fpn output per process (with -d cwd, one entry per process):
+    //   p<pid>
+    //   fcwd
+    //   n<path>
+    let mut pids = Vec::new();
+    let mut current_pid: Option<u32> = None;
+
     for line in text.lines() {
-        // Fields: pid wdir pcpu rss etime command...
-        // Split into 6 parts: first 5 are fixed, 6th is command (may have spaces).
-        let mut parts = line.trim().splitn(6, char::is_whitespace);
-        let pid_str = match parts.next() { Some(s) => s.trim(), None => continue };
-        let wdir = match parts.next() { Some(s) => s.trim(), None => continue };
-        let pcpu_str = match parts.next() { Some(s) => s.trim(), None => continue };
-        let rss_str = match parts.next() { Some(s) => s.trim(), None => continue };
-        let etime = match parts.next() { Some(s) => s.trim(), None => continue };
-        let command = match parts.next() { Some(s) => s.trim(), None => continue };
-
-        if wdir != cwd {
-            continue;
+        if let Some(pid_str) = line.strip_prefix('p') {
+            current_pid = pid_str.parse().ok();
+        } else if let Some(path) = line.strip_prefix('n') {
+            if let Some(pid) = current_pid {
+                eprintln!("[process_inspector] lsof cwd: pid={pid} path={path}");
+                if path == cwd {
+                    pids.push(pid);
+                }
+            }
         }
-
-        let name = process_name(command).to_lowercase();
-        let is_agent = name == "claude" || name == "codex" || name == "node";
-
-        if !is_agent {
-            continue;
-        }
-
-        let Ok(pid) = pid_str.parse::<u32>() else { continue };
-        let cpu_percent = pcpu_str.parse::<f32>().unwrap_or(0.0);
-        let memory_kb = rss_str.parse::<u64>().unwrap_or(0);
-
-        results.push((pid, command.to_string(), cpu_percent, memory_kb, etime.to_string()));
     }
 
-    results
+    pids
 }
 
-/// Run `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -Fpn` and parse listening
-/// ports per PID. Returns a map of pid → sorted port list.
+/// Get cmd args for specific PIDs via `ps -o args=`.
+/// sysinfo's `process.cmd()` always returns empty on macOS without entitlements.
+async fn get_process_args(pids: &[u32]) -> HashMap<u32, String> {
+    if pids.is_empty() {
+        return HashMap::new();
+    }
+    let pid_list = pids.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(",");
+    let output = tokio::time::timeout(
+        tokio::time::Duration::from_secs(2),
+        tokio::process::Command::new("ps")
+            .args(["-p", &pid_list, "-o", "pid=,args="])
+            .output(),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok());
+
+    let Some(output) = output else { return HashMap::new() };
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    let mut result = HashMap::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() { continue; }
+        // format: "12345 claude --some-flag"
+        if let Some(space) = line.find(char::is_whitespace) {
+            if let Ok(pid) = line[..space].trim().parse::<u32>() {
+                let cmd = line[space..].trim().to_string();
+                result.insert(pid, cmd);
+            }
+        }
+    }
+    result
+}
+
+/// Read name, CPU, memory, and elapsed time for specific PIDs via sysinfo.
+/// Returns (pid, name, cpu_percent, memory_kb, elapsed_time).
+fn get_process_metrics(pids: &[u32]) -> Vec<(u32, String, f32, u64, String)> {
+    use sysinfo::{Pid, ProcessesToUpdate, System};
+
+    let sysinfo_pids: Vec<Pid> = pids.iter().map(|&p| Pid::from(p as usize)).collect();
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::Some(&sysinfo_pids), true);
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    pids.iter()
+        .filter_map(|&pid| {
+            let process = sys.process(Pid::from(pid as usize))?;
+
+            let name = process.name().to_string_lossy().to_lowercase();
+            let name = name.trim_end_matches('\0').to_string();
+
+            let cpu_percent = process.cpu_usage();
+            let memory_kb = process.memory() / 1024;
+            let elapsed_secs = now_secs.saturating_sub(process.start_time());
+            let elapsed_time = format_elapsed(elapsed_secs);
+
+            Some((pid, name, cpu_percent, memory_kb, elapsed_time))
+        })
+        .collect()
+}
+
+fn format_elapsed(secs: u64) -> String {
+    if secs < 3600 {
+        format!("{}:{:02}", secs / 60, secs % 60)
+    } else if secs < 86400 {
+        format!("{}:{:02}:{:02}", secs / 3600, (secs % 3600) / 60, secs % 60)
+    } else {
+        format!("{}-{:02}:{:02}", secs / 86400, (secs % 86400) / 3600, (secs % 3600) / 60)
+    }
+}
+
+/// Run `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -Fpn` and return pid → ports.
 async fn find_listening_ports_per_pid(pids: &[u32]) -> HashMap<u32, Vec<u16>> {
     let pid_arg = pids.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(",");
 

--- a/src-tauri/src/mod_engine/mods/process_inspector.rs
+++ b/src-tauri/src/mod_engine/mods/process_inspector.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::mod_engine::{AsyncEmitter, Mod, ModContext};
+use crate::mod_engine::{AsyncAgentSignaler, AsyncEmitter, Mod, ModContext};
 use tokio::sync::watch;
 
 struct InspectorTabState {
@@ -11,6 +11,10 @@ struct InspectorTabState {
 
 /// Periodically scans for agent processes (claude, codex, node) in the tab's cwd
 /// and emits `process_info` events with per-process metadata and listening ports.
+///
+/// Also tracks agent PIDs across scans and signals the engine via `AsyncAgentSignaler`
+/// when a claude/codex process appears or disappears, so `ClaudeCodeMod`/`CodexMod`
+/// can react via `on_agent_detected`/`on_agent_cleared`.
 ///
 /// Scan interval: every 2 seconds while the tab is open.
 pub struct ProcessInspectorMod {
@@ -31,20 +35,29 @@ impl Mod for ProcessInspectorMod {
     fn on_open(&mut self, ctx: &ModContext) {
         let (cwd_tx, mut cwd_rx) = watch::channel::<Option<String>>(None);
         let emitter = ctx.async_emitter();
+        let signaler = ctx.async_agent_signaler();
 
         let handle = tokio::spawn(async move {
+            // PID tracking: agent name → last seen PID. Used to diff consecutive scans.
+            let mut prev_pids: HashMap<String, u32> = HashMap::new();
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
+
             loop {
                 interval.tick().await;
                 let cwd = cwd_rx.borrow().clone();
                 let Some(cwd) = cwd else { continue };
 
                 let processes = scan_processes(&cwd).await;
+
+                // Emit process_info to frontend.
                 emitter.emit(
                     "process_inspector",
                     "process_info",
                     serde_json::json!({ "processes": processes }),
                 );
+
+                // Diff agent PIDs to fire lifecycle signals.
+                diff_agent_pids(&processes, &mut prev_pids, &cwd, &signaler);
             }
         });
 
@@ -62,6 +75,51 @@ impl Mod for ProcessInspectorMod {
             state.handle.abort();
         }
     }
+}
+
+/// Compare current agent PIDs against the previous scan's PIDs.
+/// Fires `agent_detected` for new/changed-PID agents and `agent_cleared` for gone agents.
+fn diff_agent_pids(
+    processes: &[serde_json::Value],
+    prev_pids: &mut HashMap<String, u32>,
+    cwd: &str,
+    signaler: &AsyncAgentSignaler,
+) {
+    // Collect current agent PIDs (only claude and codex trigger lifecycle signals).
+    let mut current_pids: HashMap<String, u32> = HashMap::new();
+    for proc in processes {
+        let name = proc.get("name").and_then(|n| n.as_str()).unwrap_or("");
+        if name == "claude" || name == "codex" {
+            if let Some(pid) = proc.get("pid").and_then(|p| p.as_u64()) {
+                current_pids.insert(name.to_string(), pid as u32);
+            }
+        }
+    }
+
+    // Cleared: agents in prev but not in current, or with a different (restarted) PID.
+    for (agent, prev_pid) in prev_pids.iter() {
+        match current_pids.get(agent) {
+            None => signaler.agent_cleared(agent),
+            Some(curr_pid) if curr_pid != prev_pid => {
+                signaler.agent_cleared(agent);
+                // The detected signal fires in the loop below.
+            }
+            _ => {}
+        }
+    }
+
+    // Detected: new agents, or agents with a changed PID (restarted).
+    for (agent, curr_pid) in &current_pids {
+        match prev_pids.get(agent) {
+            None => signaler.agent_detected(agent, cwd),
+            Some(prev_pid) if prev_pid != curr_pid => {
+                signaler.agent_detected(agent, cwd);
+            }
+            _ => {}
+        }
+    }
+
+    *prev_pids = current_pids;
 }
 
 /// A single process entry in the `process_info` event.
@@ -154,9 +212,7 @@ async fn find_agent_processes(cwd: &str) -> Vec<(u32, String, f32, u64, String)>
         }
 
         let name = process_name(command).to_lowercase();
-        let is_agent = name == "claude"
-            || name == "codex"
-            || name == "node";
+        let is_agent = name == "claude" || name == "codex" || name == "node";
 
         if !is_agent {
             continue;

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -101,14 +101,15 @@ pub fn spawn_pty(
     }
     // Other shells: no injection
 
-    pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let shell_pid = child.process_id().unwrap_or(0);
 
     let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
 
     // Notify MODs before the read thread starts so on_open is always processed
     // before any on_output messages in the engine's ordered channel.
-    mod_handle.on_tab_open(&tab_id);
+    mod_handle.on_tab_open(&tab_id, shell_pid);
 
     let tab_id_thread = tab_id.clone();
     std::thread::spawn(move || {

--- a/src/modules/mods/mod-listener.ts
+++ b/src/modules/mods/mod-listener.ts
@@ -26,7 +26,12 @@ export async function startModListener(): Promise<() => void> {
   })
 }
 
-function dispatch({ tabId, modId: _modId, event, data }: ModEventPayload): void {
+function dispatch({
+  tabId,
+  modId: _modId,
+  event,
+  data,
+}: ModEventPayload): void {
   // Guard against malformed payloads — Rust controls the emitter, but a
   // bad payload should never crash the global listener.
   if (data !== null && data !== undefined && typeof data !== 'object') return
@@ -40,9 +45,17 @@ function dispatch({ tabId, modId: _modId, event, data }: ModEventPayload): void 
       break
     }
     case 'tab_type_changed': {
-      const { type, agent, cmd } = data as { type: TabType; agent?: string; cmd?: string }
+      const { type, agent, cmd } = data as {
+        type: TabType
+        agent?: string
+        cmd?: string
+      }
       if (type === 'shell') {
-        updateTabMeta(tabId, { type, agentName: undefined, agentCmd: undefined })
+        updateTabMeta(tabId, {
+          type,
+          agentName: undefined,
+          agentCmd: undefined,
+        })
       } else {
         updateTabMeta(tabId, { type, agentName: agent, agentCmd: cmd })
       }
@@ -59,7 +72,9 @@ function dispatch({ tabId, modId: _modId, event, data }: ModEventPayload): void 
     }
     case 'process_info': {
       // Enriched process scan — extract listening ports from all processes for now
-      const { processes } = data as { processes: Array<{ listeningPorts: number[] }> }
+      const { processes } = data as {
+        processes: Array<{ listeningPorts: number[] }>
+      }
       const ports = processes.flatMap((p) => p.listeningPorts ?? [])
       updateTabMeta(tabId, { listeningPorts: [...new Set(ports)] })
       break

--- a/src/modules/mods/mod-listener.ts
+++ b/src/modules/mods/mod-listener.ts
@@ -45,7 +45,7 @@ function formatEventData(event: string, data: unknown): string {
 
 function dispatch({ tabId, modId, event, data }: ModEventPayload): void {
   // DEBUG — log every raw mod event as it arrives (skip high-frequency timer events)
-  const SILENT_EVENTS = new Set(['git_info', 'listening_ports'])
+  const SILENT_EVENTS = new Set(['git_info', 'listening_ports', 'process_info'])
   if (!SILENT_EVENTS.has(event)) {
     console.log(`[mod:event] ${modId}/${event} | tab=${tabId}\n${formatEventData(event, data)}`)
   }

--- a/src/modules/mods/mod-listener.ts
+++ b/src/modules/mods/mod-listener.ts
@@ -1,7 +1,5 @@
 import { listen } from '@tauri-apps/api/event'
 import {
-  type ClaudeSession,
-  type CodexSession,
   clearTabMeta,
   type GitInfo,
   type TabStatus,
@@ -28,7 +26,30 @@ export async function startModListener(): Promise<() => void> {
   })
 }
 
-function dispatch({ tabId, event, data }: ModEventPayload): void {
+function formatEventData(event: string, data: unknown): string {
+  if (event === 'process_info') {
+    const { processes = [] } = data as { processes: Array<{
+      pid: number; name: string; command: string
+      cpuPercent: number; memoryKb: number; elapsedTime: string
+      listeningPorts: number[]
+    }> }
+    if (processes.length === 0) return '  processes: (none)'
+    return processes
+      .map((p) =>
+        `  pid=${p.pid} name=${p.name} mem=${Math.round(p.memoryKb / 1024)}MB uptime=${p.elapsedTime} ports=[${p.listeningPorts.join(',')}]\n  cmd: ${p.command}`
+      )
+      .join('\n')
+  }
+  return `  ${JSON.stringify(data)}`
+}
+
+function dispatch({ tabId, modId, event, data }: ModEventPayload): void {
+  // DEBUG — log every raw mod event as it arrives (skip high-frequency timer events)
+  const SILENT_EVENTS = new Set(['git_info', 'listening_ports'])
+  if (!SILENT_EVENTS.has(event)) {
+    console.log(`[mod:event] ${modId}/${event} | tab=${tabId}\n${formatEventData(event, data)}`)
+  }
+
   // Guard against malformed payloads — Rust controls the emitter, but a
   // bad payload should never crash the global listener.
   if (data !== null && data !== undefined && typeof data !== 'object') return
@@ -42,8 +63,12 @@ function dispatch({ tabId, event, data }: ModEventPayload): void {
       break
     }
     case 'tab_type_changed': {
-      const { type, agent } = data as { type: TabType; agent?: string }
-      updateTabMeta(tabId, { type, agentName: agent })
+      const { type, agent, cmd } = data as { type: TabType; agent?: string; cmd?: string }
+      if (type === 'shell') {
+        updateTabMeta(tabId, { type, agentName: undefined, agentCmd: undefined })
+      } else {
+        updateTabMeta(tabId, { type, agentName: agent, agentCmd: cmd })
+      }
       break
     }
     case 'cwd_changed': {
@@ -55,28 +80,11 @@ function dispatch({ tabId, event, data }: ModEventPayload): void {
       updateTabMeta(tabId, { git: (data as GitInfo) ?? undefined })
       break
     }
-    case 'claude_session': {
-      updateTabMeta(tabId, { claudeSession: data as ClaudeSession })
-      break
-    }
-    case 'claude_session_cleared': {
-      updateTabMeta(tabId, {
-        claudeSession: undefined,
-        agentName: undefined,
-        type: 'shell',
-      })
-      break
-    }
-    case 'codex_session': {
-      updateTabMeta(tabId, { codexSession: data as CodexSession })
-      break
-    }
-    case 'codex_session_cleared': {
-      updateTabMeta(tabId, {
-        codexSession: undefined,
-        agentName: undefined,
-        type: 'shell',
-      })
+    case 'process_info': {
+      // Enriched process scan — extract listening ports from all processes for now
+      const { processes } = data as { processes: Array<{ listeningPorts: number[] }> }
+      const ports = processes.flatMap((p) => p.listeningPorts ?? [])
+      updateTabMeta(tabId, { listeningPorts: [...new Set(ports)] })
       break
     }
     case 'listening_ports': {

--- a/src/modules/mods/mod-listener.ts
+++ b/src/modules/mods/mod-listener.ts
@@ -26,30 +26,7 @@ export async function startModListener(): Promise<() => void> {
   })
 }
 
-function formatEventData(event: string, data: unknown): string {
-  if (event === 'process_info') {
-    const { processes = [] } = data as { processes: Array<{
-      pid: number; name: string; command: string
-      cpuPercent: number; memoryKb: number; elapsedTime: string
-      listeningPorts: number[]
-    }> }
-    if (processes.length === 0) return '  processes: (none)'
-    return processes
-      .map((p) =>
-        `  pid=${p.pid} name=${p.name} mem=${Math.round(p.memoryKb / 1024)}MB uptime=${p.elapsedTime} ports=[${p.listeningPorts.join(',')}]\n  cmd: ${p.command}`
-      )
-      .join('\n')
-  }
-  return `  ${JSON.stringify(data)}`
-}
-
-function dispatch({ tabId, modId, event, data }: ModEventPayload): void {
-  // DEBUG — log every raw mod event as it arrives (skip high-frequency timer events)
-  const SILENT_EVENTS = new Set(['git_info', 'listening_ports', 'process_info'])
-  if (!SILENT_EVENTS.has(event)) {
-    console.log(`[mod:event] ${modId}/${event} | tab=${tabId}\n${formatEventData(event, data)}`)
-  }
-
+function dispatch({ tabId, modId: _modId, event, data }: ModEventPayload): void {
   // Guard against malformed payloads — Rust controls the emitter, but a
   // bad payload should never crash the global listener.
   if (data !== null && data !== undefined && typeof data !== 'object') return

--- a/src/modules/stores/$tabMeta.ts
+++ b/src/modules/stores/$tabMeta.ts
@@ -12,26 +12,6 @@ export type GitInfo = {
   pr?: { number: number; title: string; state: string; url: string }
 }
 
-export type ClaudeSession = {
-  sessionId: string
-  gitBranch?: string
-  model?: string
-  permissionMode?: string
-  title?: string
-  prNumber?: number
-  prUrl?: string
-}
-
-export type CodexSession = {
-  sessionId: string
-  gitBranch?: string
-  model?: string
-  approvalPolicy?: string
-  sandboxMode?: string
-  effort?: string
-  title?: string
-}
-
 export type TabMeta = {
   /** Shell or agent process state — driven by ProcessTrackerMod (OSC 133). */
   status: TabStatus
@@ -43,12 +23,10 @@ export type TabMeta = {
   git?: GitInfo
   /** Non-zero exit code when status is "error". */
   exitCode?: number
-  /** Agent binary name: "claude-code" | "codex". */
+  /** Agent binary name: "claude-code" | "codex" — set when type is "agent". */
   agentName?: string
-  /** Active Claude Code session metadata — set by ClaudeCodeMod. */
-  claudeSession?: ClaudeSession
-  /** Active Codex session metadata — set by CodexMod. */
-  codexSession?: CodexSession
+  /** Full command used to launch the agent — set by ClaudeCodeMod / CodexMod. */
+  agentCmd?: string
   /** TCP ports the agent process tree is listening on — set by ProcessInspectorMod. */
   listeningPorts?: number[]
 }
@@ -66,10 +44,25 @@ export const $tabMeta = atom<Record<string, TabMeta>>({})
 
 export function updateTabMeta(tabId: string, patch: Partial<TabMeta>): void {
   const cur = $tabMeta.get()
-  $tabMeta.set({
-    ...cur,
-    [tabId]: { ...defaultMeta, ...cur[tabId], ...patch },
-  })
+  const next = { ...defaultMeta, ...cur[tabId], ...patch }
+  // DEBUG — skip update and log if nothing actually changed
+  if (JSON.stringify(cur[tabId]) === JSON.stringify(next)) return
+  $tabMeta.set({ ...cur, [tabId]: next })
+  console.log(`[tabMeta] ${tabId}\n${formatTabMeta(next)}`)
+}
+
+function formatTabMeta(m: TabMeta): string {
+  const lines: string[] = []
+  lines.push(`  status=${m.status} type=${m.type}${m.agentName ? ` agent=${m.agentName}` : ''}`)
+  if (m.cwd) lines.push(`  cwd=${m.cwd}`)
+  if (m.git) {
+    const g = m.git
+    const pr = g.pr ? ` pr=#${g.pr.number}` : ''
+    lines.push(`  git=${g.branch} ↑${g.aheadBy} ↓${g.behindBy}${g.isDirty ? ' dirty' : ''}${g.worktree ? ` worktree=${g.worktree}` : ''}${pr}`)
+  }
+  if (m.agentCmd) lines.push(`  cmd=${m.agentCmd}`)
+  if (m.listeningPorts?.length) lines.push(`  ports=${m.listeningPorts.join(', ')}`)
+  return lines.join('\n')
 }
 
 export function clearTabMeta(tabId: string): void {

--- a/src/modules/stores/$tabMeta.ts
+++ b/src/modules/stores/$tabMeta.ts
@@ -49,7 +49,6 @@ export function updateTabMeta(tabId: string, patch: Partial<TabMeta>): void {
   $tabMeta.set({ ...cur, [tabId]: next })
 }
 
-
 export function clearTabMeta(tabId: string): void {
   const cur = $tabMeta.get()
   const next = { ...cur }

--- a/src/modules/stores/$tabMeta.ts
+++ b/src/modules/stores/$tabMeta.ts
@@ -45,25 +45,10 @@ export const $tabMeta = atom<Record<string, TabMeta>>({})
 export function updateTabMeta(tabId: string, patch: Partial<TabMeta>): void {
   const cur = $tabMeta.get()
   const next = { ...defaultMeta, ...cur[tabId], ...patch }
-  // DEBUG — skip update and log if nothing actually changed
   if (JSON.stringify(cur[tabId]) === JSON.stringify(next)) return
   $tabMeta.set({ ...cur, [tabId]: next })
-  console.log(`[tabMeta] ${tabId}\n${formatTabMeta(next)}`)
 }
 
-function formatTabMeta(m: TabMeta): string {
-  const lines: string[] = []
-  lines.push(`  status=${m.status} type=${m.type}${m.agentName ? ` agent=${m.agentName}` : ''}`)
-  if (m.cwd) lines.push(`  cwd=${m.cwd}`)
-  if (m.git) {
-    const g = m.git
-    const pr = g.pr ? ` pr=#${g.pr.number}` : ''
-    lines.push(`  git=${g.branch} ↑${g.aheadBy} ↓${g.behindBy}${g.isDirty ? ' dirty' : ''}${g.worktree ? ` worktree=${g.worktree}` : ''}${pr}`)
-  }
-  if (m.agentCmd) lines.push(`  cmd=${m.agentCmd}`)
-  if (m.listeningPorts?.length) lines.push(`  ports=${m.listeningPorts.join(', ')}`)
-  return lines.join('\n')
-}
 
 export function clearTabMeta(tabId: string): void {
   const cur = $tabMeta.get()


### PR DESCRIPTION
## Summary

Complete redesign of the MOD system to eliminate shared state and inter-mod coupling.

### Core architecture change: `CwdRegistry` → `on_cwd_changed` push model

- Removes `CwdRegistry` (`Arc<RwLock<HashMap>>`) — the shared state that forced implicit registration-order dependencies between mods
- `DirTrackerMod` is now the single OSC 7 parser; calls `ctx.set_cwd()` which queues a CWD update in the engine
- Engine drains the update queue after each `on_output` round and dispatches `on_cwd_changed(cwd)` to every mod
- No mod ever reads from another mod's state — pure push model, registration order no longer matters

### Agent lifecycle: process detection by shell PPID

- `ProcessInspectorMod` runs a 2s timer that scans for `claude`/`codex` processes using `ps -o ppid=` filtered to direct children of the tab's shell PID
- Shell PID is captured at PTY spawn time via `child.process_id()` and threaded into every `ModContext` as `shell_pid`
- **PPID-based, not CWD-based** — an earlier approach using `lsof -d cwd` was discarded because it matched any `claude` process sharing the working directory, including processes from unrelated terminal sessions (e.g. other cmux sessions)
- macOS restricts `proc_pidinfo` CWD reads (`sysinfo`'s `process.cwd()` always returns `None` without entitlements) — `ps` avoids this entirely
- Process cmd args via `ps -o args=` (sysinfo also can't read cmd on macOS); metrics (CPU/memory/elapsed) via sysinfo; ports via `lsof -iTCP`

### `ClaudeCodeMod` and `CodexMod`: from complex state machines to 15-line emitters

Previous: watched terminal output for "claude" typed, buffered input across keystrokes, scanned `~/.claude/projects/` JSONL session files, queried `~/.codex/state_5.sqlite`, managed `session_active: Arc<AtomicBool>` across sync/async boundary.

Now: stateless. `on_agent_detected(agent, cwd, cmd)` emits `tab_type_changed { type: "agent", agent, cmd }`. `on_agent_cleared` emits `tab_type_changed { type: "shell" }`. Nothing else.

The process command line args (`--resume <id>`, `--dangerously-skip-permissions`, `--settings {...}`) carry all the context needed. No file scanning. No per-tab state. Git info comes from `GitMonitorMod`.

### What was removed

- `CwdRegistry` type and all clones
- `session_active: Arc<AtomicBool>`, `awaiting_agent`, `input_buf`, `last_cwd` from `ClaudeCodeMod`/`CodexMod`
- `on_input` and `on_output` overrides from both agent mods
- All session file scanning: `scan_claude_session`, `scan_codex_session`, `scan_via_sqlite`, `scan_via_jsonl`
- `rusqlite` dependency
- `claude_session`, `claude_session_cleared`, `codex_session`, `codex_session_cleared` events
- `ClaudeSession` and `CodexSession` types from `$tabMeta`

### Frontend changes

- `$tabMeta.TabMeta` loses `claudeSession` and `codexSession`, gains `agentCmd?: string`
- `mod-listener.ts` handles the simplified `tab_type_changed { type, agent, cmd }` event
- `process_info` is silenced in the console (fires every 2s, always)

## Commit breakdown

1. `refactor(mod-engine)`: add `on_cwd_changed` hook to `Mod` trait
2. `refactor(engine)`: internal CWD table + `ctx.set_cwd()` + dispatch
3. `refactor(dir-tracker)`: dual-write during migration window
4. `refactor(git-monitor)`: migrate to `on_cwd_changed`, drop `CwdRegistry`
5. `refactor(process-inspector)`: migrate to `on_cwd_changed`, enrich `process_info` event
6. `refactor(process-inspector)`: agent lifecycle via `on_agent_detected`/`on_agent_cleared`
7. `refactor(mods)`: args-only agent detection, remove all file scanning, close migration window
8. `refactor(process-inspector)`: PPID-based detection replaces lsof CWD scan; shell PID threaded through PTY → engine → ModContext
9. `chore`: remove all debug logging

## Test plan

- [ ] Open a terminal tab — no panics on startup
- [ ] `cd` into a git repo — `git_info` fires with branch/status/dirty state
- [ ] Run `claude` — `tab_type_changed { type: "agent", agent: "claude-code", cmd: "..." }` fires; tab icon changes to agent mode
- [ ] Run `ls` or any other command in the same dir — no false agent detection
- [ ] Exit `claude` — `tab_type_changed { type: "shell" }` fires within 2s
- [ ] Open two tabs in different directories — each tab's git/agent state is independent
- [ ] Open a tab in a directory where other claude sessions are already running (different terminal) — no false positive