### PR TITLE
feat(data): tab labels from CWD + full process metadata in tabMeta

### DIFF
--- a/src/modules/mods/mod-listener.ts
+++ b/src/modules/mods/mod-listener.ts
@@ -2,6 +2,7 @@ import { listen } from '@tauri-apps/api/event'
 import {
   clearTabMeta,
   type GitInfo,
+  type ProcessInfo,
   type TabStatus,
   type TabType,
   updateTabMeta,
@@ -71,12 +72,12 @@ function dispatch({
       break
     }
     case 'process_info': {
-      // Enriched process scan — extract listening ports from all processes for now
-      const { processes } = data as {
-        processes: Array<{ listeningPorts: number[] }>
-      }
+      const { processes } = data as { processes: ProcessInfo[] }
       const ports = processes.flatMap((p) => p.listeningPorts ?? [])
-      updateTabMeta(tabId, { listeningPorts: [...new Set(ports)] })
+      updateTabMeta(tabId, {
+        processes,
+        listeningPorts: [...new Set(ports)],
+      })
       break
     }
     case 'listening_ports': {

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -168,7 +168,9 @@ export function renameTab(
     return {
       ...p,
       tabs: p.tabs.map((t) =>
-        t.id === tabId ? { ...t, label: newLabel.trim() } : t,
+        t.id === tabId
+          ? { ...t, label: newLabel.trim(), userRenamed: true }
+          : t,
       ),
     }
   })

--- a/src/modules/stores/$tabMeta.ts
+++ b/src/modules/stores/$tabMeta.ts
@@ -12,6 +12,26 @@ export type GitInfo = {
   pr?: { number: number; title: string; state: string; url: string }
 }
 
+/**
+ * A single process entry as emitted by ProcessInspectorMod.
+ * Mirrors the Rust `ProcessEntry` struct serialised over IPC.
+ *
+ * Note: `cpuPercent` is a sysinfo lifetime average — not a real-time sample.
+ * Do not display it in the UI; it is intentionally omitted here.
+ */
+export type ProcessInfo = {
+  pid: number
+  name: string
+  /** Full command string including args (from `ps -o args=`). */
+  command: string
+  /** Resident memory in kilobytes (from sysinfo). */
+  memoryKb: number
+  /** Elapsed wall-clock time formatted as `mm:ss` or `h:mm:ss` or `d-hh:mm`. */
+  elapsedTime: string
+  /** TCP ports this process is listening on (from lsof). */
+  listeningPorts: number[]
+}
+
 export type TabMeta = {
   /** Shell or agent process state — driven by ProcessTrackerMod (OSC 133). */
   status: TabStatus
@@ -27,7 +47,16 @@ export type TabMeta = {
   agentName?: string
   /** Full command used to launch the agent — set by ClaudeCodeMod / CodexMod. */
   agentCmd?: string
-  /** TCP ports the agent process tree is listening on — set by ProcessInspectorMod. */
+  /**
+   * Live process list for this tab — set by ProcessInspectorMod every 2s.
+   * Only agent processes (claude, codex) that are direct children of the
+   * tab's shell PID are included. Empty for shell-only tabs.
+   */
+  processes?: ProcessInfo[]
+  /**
+   * Convenience: TCP ports across all tracked processes.
+   * Derived from `processes` in the mod-listener; kept for backwards compat.
+   */
   listeningPorts?: number[]
 }
 

--- a/src/screens/workspace/workspace.helpers.ts
+++ b/src/screens/workspace/workspace.helpers.ts
@@ -23,3 +23,35 @@ export function slugify(name: string): string {
 export function randomSuffix(): string {
   return Math.random().toString(16).slice(2, 6)
 }
+
+/**
+ * Returns the last path segment of a CWD with a leading slash.
+ * e.g. "/Users/dani/code/agent-terminal" → "/agent-terminal"
+ *      "/Users/dani"                      → "/dani"
+ *      "/"                                → "/"
+ */
+export function cwdBasename(cwd: string): string {
+  const trimmed = cwd.replace(/\/$/, '')
+  const slash = trimmed.lastIndexOf('/')
+  const last = trimmed.slice(slash + 1)
+  return last ? `/${last}` : '/'
+}
+
+/**
+ * Resolves the display label for a tab.
+ *
+ * - If the user has explicitly renamed the tab (`userRenamed === true`),
+ *   the stored `label` is always used verbatim.
+ * - Otherwise the label is derived from the live CWD so it updates
+ *   automatically as the user navigates between directories.
+ * - Falls back to the stored `label` (usually `"shell"`) when the CWD
+ *   is not yet known (e.g. before the first OSC 7 sequence).
+ */
+export function resolveTabLabel(
+  tab: { label: string; userRenamed?: boolean },
+  cwd: string | undefined,
+): string {
+  if (tab.userRenamed) return tab.label
+  if (cwd) return cwdBasename(cwd)
+  return tab.label
+}

--- a/src/screens/workspace/workspace.types.ts
+++ b/src/screens/workspace/workspace.types.ts
@@ -1,9 +1,17 @@
 export type Tab = {
   id: string
+  /**
+   * Deduplication key and display name.
+   * When `userRenamed` is true this is always shown as-is.
+   * When `userRenamed` is absent/false the UI derives the display label from
+   * the tab's live CWD instead (see `resolveTabLabel`).
+   */
   label: string
   cmd: string
   pinned: boolean
   lastCwd?: string
+  /** True once the user has explicitly renamed this tab via the inline editor. */
+  userRenamed?: boolean
 }
 
 export type Project = {


### PR DESCRIPTION
## Summary

- **`Tab.userRenamed?: boolean`** — `renameTab()` now sets this flag so the UI knows when to honour the stored label vs. derive from CWD
- **`cwdBasename(cwd)`** — extracts the last directory segment with a leading slash (`/agent-terminal`)
- **`resolveTabLabel(tab, cwd)`** — single helper components will use to get the right display label: user label when renamed, `cwdBasename(cwd)` when CWD is known, stored label as fallback
- **`ProcessInfo` type** — mirrors the Rust `ProcessEntry` struct; added to `$tabMeta` so the status bar and sidebar can read pid, name, elapsedTime, memoryKb, listeningPorts per tab
- **`mod-listener.ts`** — `process_info` now stores the full `processes[]` array; `listeningPorts` is derived from it (kept for backwards compat)

`cpuPercent` is intentionally not included in `ProcessInfo` — sysinfo returns a lifetime average, not a real-time sample, so it would be misleading in the UI.

## Test plan

- [ ] No TypeScript errors (`bunx tsc --noEmit` — existing deprecation warning only, unrelated)
- [ ] Biome clean on all 5 changed files
- [ ] `renameTab()` sets `userRenamed: true` on the renamed tab
- [ ] `resolveTabLabel` returns the CWD basename for a tab with no rename
- [ ] `resolveTabLabel` returns `tab.label` when `userRenamed` is true, regardless of CWD
- [ ] `resolveTabLabel` falls back to `tab.label` when CWD is undefined