### PR TITLE
feat(ui): agent glyph visual system

### DIFF
--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -13,6 +13,7 @@ function ClaudeMark({ size }: { size: number }) {
       viewBox="0 0 256 257"
       preserveAspectRatio="xMidYMid"
       style={{ display: 'block' }}
+      aria-hidden="true"
     >
       <path
         fill="currentColor"
@@ -31,6 +32,7 @@ function CodexMark({ size }: { size: number }) {
       fill="currentColor"
       fillRule="evenodd"
       style={{ display: 'block' }}
+      aria-hidden="true"
     >
       <path
         clipRule="evenodd"
@@ -123,7 +125,8 @@ export function AgentGlyph({
   const brand = BRAND[agent]
 
   // Unknown agent → backwards-compatible sparkle (respects active state)
-  if (!brand) return <SparkleFallback state={state} size={size} active={active} />
+  if (!brand)
+    return <SparkleFallback state={state} size={size} active={active} />
 
   const { color, glow } = brand
   const Mark = MARKS[agent] ?? ClaudeMark
@@ -211,6 +214,7 @@ export function AgentGlyph({
             strokeWidth="3.5"
             strokeLinecap="round"
             strokeLinejoin="round"
+            aria-hidden="true"
           >
             <path d="M20 6 9 17l-5-5" />
           </svg>
@@ -240,11 +244,30 @@ export function AgentGlyph({
             stroke="var(--background)"
             strokeWidth="1.4"
             strokeLinejoin="round"
+            aria-hidden="true"
           >
             <path d="M3.2 4.5 A 1.8 1.8 0 0 1 5 2.7 h 14 A 1.8 1.8 0 0 1 20.8 4.5 v 10 A 1.8 1.8 0 0 1 19 16.3 H 10.3 l -4.6 3.8 a 0.5 0.5 0 0 1 -0.8 -0.4 v -3.4 H 5 A 1.8 1.8 0 0 1 3.2 14.5 z" />
-            <circle cx="8" cy="9.5" r="1.3" fill="var(--background)" stroke="none" />
-            <circle cx="12" cy="9.5" r="1.3" fill="var(--background)" stroke="none" />
-            <circle cx="16" cy="9.5" r="1.3" fill="var(--background)" stroke="none" />
+            <circle
+              cx="8"
+              cy="9.5"
+              r="1.3"
+              fill="var(--background)"
+              stroke="none"
+            />
+            <circle
+              cx="12"
+              cy="9.5"
+              r="1.3"
+              fill="var(--background)"
+              stroke="none"
+            />
+            <circle
+              cx="16"
+              cy="9.5"
+              r="1.3"
+              fill="var(--background)"
+              stroke="none"
+            />
           </svg>
         </span>
       )}

--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -98,10 +98,12 @@ export function AgentGlyph({
   agent,
   state,
   size = 16,
+  active = false,
 }: {
   agent: string
   state: AgentState
   size?: number
+  active?: boolean
 }) {
   const brand = BRAND[agent]
 
@@ -111,7 +113,7 @@ export function AgentGlyph({
   const { color, glow } = brand
   const Mark = agent === 'codex' ? CodexMark : ClaudeMark
 
-  const markOpacity = state === 'idle' ? 0.45 : 1
+  const markOpacity = state === 'idle' && !active ? 0.45 : 1
   const markFilter =
     state === 'idle'
       ? 'saturate(0.6)'

--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -1,3 +1,4 @@
+import type React from 'react'
 import type { AgentState } from '@/components/agent.helpers'
 
 /* ---------------------------------------------------------------------------
@@ -48,6 +49,16 @@ const BRAND: Record<string, { color: string; glow: string }> = {
   codex: { color: '#e6e8eb', glow: 'rgba(230,232,235,0.45)' },
 }
 
+/**
+ * Maps agent name → its Mark component.
+ * Must stay in sync with BRAND — every key in BRAND needs an entry here.
+ * Adding a new agent: add to BRAND above AND add to MARKS here.
+ */
+const MARKS: Record<string, React.ComponentType<{ size: number }>> = {
+  'claude-code': ClaudeMark,
+  codex: CodexMark,
+}
+
 /* ---------------------------------------------------------------------------
  * Fallback for unknown agents — backwards-compatible violet sparkle
  * -------------------------------------------------------------------------*/
@@ -55,11 +66,15 @@ const BRAND: Record<string, { color: string; glow: string }> = {
 function SparkleFallback({
   state,
   size,
+  active = false,
 }: {
   state: AgentState
   size: number
+  active?: boolean
 }) {
-  const active = state === 'in-progress'
+  // Full opacity when the tab is selected (active) or the agent is running,
+  // matching the same brightness logic used for branded marks.
+  const dim = state === 'idle' && !active
   return (
     <span
       style={{
@@ -72,7 +87,7 @@ function SparkleFallback({
         color: '#c4b5fd',
         fontSize: Math.max(8, size * 0.7),
         lineHeight: 1,
-        opacity: active ? 0.9 : 0.5,
+        opacity: dim ? 0.5 : 0.9,
       }}
       aria-hidden="true"
     >
@@ -107,11 +122,11 @@ export function AgentGlyph({
 }) {
   const brand = BRAND[agent]
 
-  // Unknown agent → backwards-compatible sparkle
-  if (!brand) return <SparkleFallback state={state} size={size} />
+  // Unknown agent → backwards-compatible sparkle (respects active state)
+  if (!brand) return <SparkleFallback state={state} size={size} active={active} />
 
   const { color, glow } = brand
-  const Mark = agent === 'codex' ? CodexMark : ClaudeMark
+  const Mark = MARKS[agent] ?? ClaudeMark
 
   const markOpacity = state === 'idle' && !active ? 0.45 : 1
   const markFilter =

--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -1,0 +1,236 @@
+import type { AgentState } from '@/components/agent.helpers'
+
+/* ---------------------------------------------------------------------------
+ * Brand marks — exact SVG paths from the official brand assets
+ * -------------------------------------------------------------------------*/
+
+function ClaudeMark({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 256 257"
+      preserveAspectRatio="xMidYMid"
+      style={{ display: 'block' }}
+    >
+      <path
+        fill="currentColor"
+        d="m50.228 170.321 50.357-28.257.843-2.463-.843-1.361h-2.462l-8.426-.518-28.775-.778-24.952-1.037-24.175-1.296-6.092-1.297L0 125.796l.583-3.759 5.12-3.434 7.324.648 16.202 1.101 24.304 1.685 17.629 1.037 26.118 2.722h4.148l.583-1.685-1.426-1.037-1.101-1.037-25.147-17.045-27.22-18.017-14.258-10.37-7.713-5.25-3.888-4.925-1.685-10.758 7-7.713 9.397.649 2.398.648 9.527 7.323 20.35 15.75L94.817 91.9l3.889 3.24 1.555-1.102.195-.777-1.75-2.917-14.453-26.118-15.425-26.572-6.87-11.018-1.814-6.61c-.648-2.723-1.102-4.991-1.102-7.778l7.972-10.823L71.42 0 82.05 1.426l4.472 3.888 6.61 15.101 10.694 23.786 16.591 32.34 4.861 9.592 2.592 8.879.973 2.722h1.685v-1.556l1.36-18.211 2.528-22.36 2.463-28.776.843-8.1 4.018-9.722 7.971-5.25 6.222 2.981 5.12 7.324-.713 4.73-3.046 19.768-5.962 30.98-3.889 20.739h2.268l2.593-2.593 10.499-13.934 17.628-22.036 7.778-8.749 9.073-9.657 5.833-4.601h11.018l8.1 12.055-3.628 12.443-11.342 14.388-9.398 12.184-13.48 18.147-8.426 14.518.778 1.166 2.01-.194 30.46-6.481 16.462-2.982 19.637-3.37 8.88 4.148.971 4.213-3.5 8.62-20.998 5.184-24.628 4.926-36.682 8.685-.454.324.519.648 16.526 1.555 7.065.389h17.304l32.21 2.398 8.426 5.574 5.055 6.805-.843 5.184-12.962 6.611-17.498-4.148-40.83-9.721-14-3.5h-1.944v1.167l11.666 11.406 21.387 19.314 26.767 24.887 1.36 6.157-3.434 4.86-3.63-.518-23.526-17.693-9.073-7.972-20.545-17.304h-1.36v1.814l4.73 6.935 25.017 37.59 1.296 11.536-1.814 3.76-6.481 2.268-7.13-1.297-14.647-20.544-15.1-23.138-12.185-20.739-1.49.843-7.194 77.448-3.37 3.953-7.778 2.981-6.48-4.925-3.436-7.972 3.435-15.749 4.148-20.544 3.37-16.333 3.046-20.285 1.815-6.74-.13-.454-1.49.194-15.295 20.999-23.267 31.433-18.406 19.702-4.407 1.75-7.648-3.954.713-7.064 4.277-6.286 25.47-32.405 15.36-20.092 9.917-11.6-.065-1.686h-.583L44.07 198.125l-12.055 1.555-5.185-4.86.648-7.972 2.463-2.593 20.35-13.999-.064.065Z"
+      />
+    </svg>
+  )
+}
+
+function CodexMark({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      fillRule="evenodd"
+      style={{ display: 'block' }}
+    >
+      <path
+        clipRule="evenodd"
+        d="M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z"
+      />
+    </svg>
+  )
+}
+
+/* ---------------------------------------------------------------------------
+ * Per-agent brand colours — fixed (not theme-aware, they are brand colours)
+ * -------------------------------------------------------------------------*/
+
+const BRAND: Record<string, { color: string; glow: string }> = {
+  'claude-code': { color: '#D97757', glow: 'rgba(217,119,87,0.55)' },
+  codex: { color: '#e6e8eb', glow: 'rgba(230,232,235,0.45)' },
+}
+
+/* ---------------------------------------------------------------------------
+ * Fallback for unknown agents — backwards-compatible violet sparkle
+ * -------------------------------------------------------------------------*/
+
+function SparkleFallback({
+  state,
+  size,
+}: {
+  state: AgentState
+  size: number
+}) {
+  const active = state === 'in-progress'
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: size,
+        height: size,
+        flexShrink: 0,
+        color: '#c4b5fd',
+        fontSize: Math.max(8, size * 0.7),
+        lineHeight: 1,
+        opacity: active ? 0.9 : 0.5,
+      }}
+      aria-hidden="true"
+    >
+      ✦
+    </span>
+  )
+}
+
+/* ---------------------------------------------------------------------------
+ * AgentGlyph — brand mark + state badge composite
+ *
+ * States:
+ *   idle        → dim desaturated mark, no badge
+ *   in-progress → full-opacity mark + pulsing brand-tinted ring
+ *   completed   → mark scaled down + green check badge (bottom-right)
+ *   awaiting    → mark scaled down + amber chat-bubble badge (top-right, breathing)
+ *
+ * Unknown agents render the violet ✦ sparkle for backwards compatibility.
+ * Adding a new agent: add an entry to BRAND and a Mark component above.
+ * -------------------------------------------------------------------------*/
+
+export function AgentGlyph({
+  agent,
+  state,
+  size = 16,
+}: {
+  agent: string
+  state: AgentState
+  size?: number
+}) {
+  const brand = BRAND[agent]
+
+  // Unknown agent → backwards-compatible sparkle
+  if (!brand) return <SparkleFallback state={state} size={size} />
+
+  const { color, glow } = brand
+  const Mark = agent === 'codex' ? CodexMark : ClaudeMark
+
+  const markOpacity = state === 'idle' ? 0.45 : 1
+  const markFilter =
+    state === 'idle'
+      ? 'saturate(0.6)'
+      : state === 'in-progress'
+        ? `drop-shadow(0 0 5px ${glow})`
+        : 'none'
+  // Shrink mark slightly when a corner badge needs room
+  const hasBadge = state === 'completed' || state === 'awaiting'
+  const markScale = hasBadge ? 0.82 : 1
+  const badgeSize = Math.max(8, Math.round(size * 0.46))
+
+  return (
+    <span
+      style={{
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: size,
+        height: size,
+        flexShrink: 0,
+      }}
+    >
+      {/* In-progress — pulsing brand-tinted ring */}
+      {state === 'in-progress' && (
+        <span
+          style={{
+            position: 'absolute',
+            inset: -3,
+            borderRadius: '50%',
+            border: `1px solid ${color}`,
+            opacity: 0.4,
+            animation: 'pulse-ring 1.6s ease-out infinite',
+            pointerEvents: 'none',
+          }}
+        />
+      )}
+
+      {/* Brand mark */}
+      <span
+        style={{
+          color,
+          opacity: markOpacity,
+          filter: markFilter,
+          transform: `scale(${markScale})`,
+          transformOrigin: hasBadge ? '30% 30%' : '50% 50%',
+          transition: 'opacity 180ms, filter 220ms, transform 220ms',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Mark size={size} />
+      </span>
+
+      {/* Completed — green check badge, bottom-right */}
+      {state === 'completed' && (
+        <span
+          style={{
+            position: 'absolute',
+            right: -Math.round(badgeSize * 0.15),
+            bottom: -Math.round(badgeSize * 0.15),
+            width: badgeSize,
+            height: badgeSize,
+            borderRadius: badgeSize,
+            background: 'var(--running-dot)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: '0 0 0 1.5px var(--background)',
+            color: 'var(--background)',
+          }}
+        >
+          <svg
+            width={Math.round(badgeSize * 0.65)}
+            height={Math.round(badgeSize * 0.65)}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </span>
+      )}
+
+      {/* Awaiting — amber chat-bubble badge, top-right, breathing */}
+      {state === 'awaiting' && (
+        <span
+          style={{
+            position: 'absolute',
+            right: -Math.round(badgeSize * 0.2),
+            top: -Math.round(badgeSize * 0.2),
+            width: badgeSize,
+            height: badgeSize,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            animation: 'agent-breathe 1.8s ease-in-out infinite',
+          }}
+        >
+          <svg
+            width={badgeSize}
+            height={badgeSize}
+            viewBox="0 0 24 24"
+            fill="#e0af68"
+            stroke="var(--background)"
+            strokeWidth="1.4"
+            strokeLinejoin="round"
+          >
+            <path d="M3.2 4.5 A 1.8 1.8 0 0 1 5 2.7 h 14 A 1.8 1.8 0 0 1 20.8 4.5 v 10 A 1.8 1.8 0 0 1 19 16.3 H 10.3 l -4.6 3.8 a 0.5 0.5 0 0 1 -0.8 -0.4 v -3.4 H 5 A 1.8 1.8 0 0 1 3.2 14.5 z" />
+            <circle cx="8" cy="9.5" r="1.3" fill="var(--background)" stroke="none" />
+            <circle cx="12" cy="9.5" r="1.3" fill="var(--background)" stroke="none" />
+            <circle cx="16" cy="9.5" r="1.3" fill="var(--background)" stroke="none" />
+          </svg>
+        </span>
+      )}
+    </span>
+  )
+}

--- a/src/components/DangerBadge.tsx
+++ b/src/components/DangerBadge.tsx
@@ -1,0 +1,27 @@
+/**
+ * 🤘 badge shown when an agent tab is running with full permissions.
+ *
+ * - claude-code: --dangerously-skip-permissions
+ * - codex:       --yolo
+ *
+ * The badge and tooltip are the same regardless of which flag triggered it.
+ */
+export function DangerBadge({ size = 12 }: { size?: number }) {
+  return (
+    <span
+      title="All permissions enabled"
+      aria-label="All permissions enabled"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        fontSize: size,
+        lineHeight: 1,
+        cursor: 'help',
+      }}
+    >
+      🤘
+    </span>
+  )
+}

--- a/src/components/DangerBadge.tsx
+++ b/src/components/DangerBadge.tsx
@@ -9,6 +9,7 @@
 export function DangerBadge({ size = 12 }: { size?: number }) {
   return (
     <span
+      role="img"
       title="All permissions enabled"
       aria-label="All permissions enabled"
       style={{

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -15,6 +15,8 @@ import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
 import { ChevronRight, Folder, Pin } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { hasDangerFlag } from '@/components/agent.helpers'
+import { DangerBadge } from '@/components/DangerBadge'
 import { RunningDot } from '@/components/RunningDot'
 import { SidebarTabItem } from '@/components/Sidebar/SidebarTabItem'
 import {
@@ -67,6 +69,10 @@ export function SidebarProjectRow({ project }: { project: Project }) {
   const anyRunning = project.tabs.some(
     (t) => allTabMeta[makeTabKey(project.id, t.id)]?.status === 'running',
   )
+  const anyDanger = project.tabs.some((t) => {
+    const meta = allTabMeta[makeTabKey(project.id, t.id)]
+    return meta?.type === 'agent' && hasDangerFlag(meta.agentCmd)
+  })
 
   function handleTabDragEnd(event: DragEndEvent) {
     const { active, over } = event
@@ -146,6 +152,7 @@ export function SidebarProjectRow({ project }: { project: Project }) {
               </span>
             )}
             {anyRunning && !isOpen && !renaming && <RunningDot />}
+            {anyDanger && !isOpen && !renaming && <DangerBadge size={11} />}
             {project.pinned && !renaming && (
               <span
                 title="Unpin project"

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -105,7 +105,7 @@ export function SidebarTabItem({
              * so the input gets the full width.
              */}
             {!renaming && (
-              <span className="w-4 shrink-0 flex items-center justify-center">
+              <span className="flex w-4 shrink-0 items-center justify-center">
                 {tab.pinned && (
                   <span
                     title="Unpin tab"
@@ -163,11 +163,14 @@ export function SidebarTabItem({
                 #{tabMeta.git.pr.number}
               </a>
             )}
-            {!renaming && tabMeta?.type === 'agent' && hasDangerFlag(tabMeta.agentCmd) && (
-              <DangerBadge size={11} />
-            )}
+            {!renaming &&
+              tabMeta?.type === 'agent' &&
+              hasDangerFlag(tabMeta.agentCmd) && <DangerBadge size={11} />}
             {!renaming && (
-              <TabStatusIcon tabId={makeTabKey(projectId, tab.id)} active={isActive} />
+              <TabStatusIcon
+                tabId={makeTabKey(projectId, tab.id)}
+                active={isActive}
+              />
             )}
           </button>
         </div>

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -5,6 +5,8 @@ import { openUrl } from '@tauri-apps/plugin-opener'
 import { Pin } from 'lucide-react'
 import type React from 'react'
 import { useEffect, useRef, useState } from 'react'
+import { hasDangerFlag } from '@/components/agent.helpers'
+import { DangerBadge } from '@/components/DangerBadge'
 import { TabStatusIcon } from '@/components/TabStatusIcon'
 import {
   ContextMenu,
@@ -21,7 +23,11 @@ import {
 } from '@/modules/stores/$navigation'
 import { removeTab, renameTab, toggleTabPin } from '@/modules/stores/$projects'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
-import { MONO_FONT, makeTabKey } from '@/screens/workspace/workspace.helpers'
+import {
+  MONO_FONT,
+  makeTabKey,
+  resolveTabLabel,
+} from '@/screens/workspace/workspace.helpers'
 import type { Tab } from '@/screens/workspace/workspace.types'
 
 export function SidebarTabItem({
@@ -100,12 +106,17 @@ export function SidebarTabItem({
                 style={{ fontFamily: MONO_FONT, fontSize: 11.5 }}
               />
             ) : (
-              <span
-                className={cn('flex-1 truncate', isActive && 'font-medium')}
-                style={{ fontFamily: MONO_FONT, fontSize: 11.5 }}
-              >
-                {tab.label}
-              </span>
+              <>
+                <span
+                  className={cn('flex-1 truncate', isActive && 'font-medium')}
+                  style={{ fontFamily: MONO_FONT, fontSize: 11.5 }}
+                >
+                  {resolveTabLabel(tab, tabMeta?.cwd)}
+                </span>
+                {tabMeta?.type === 'agent' && hasDangerFlag(tabMeta.agentCmd) && (
+                  <DangerBadge size={11} />
+                )}
+              </>
             )}
             {!renaming && tabMeta?.git?.pr && prUrl && (
               <a

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -134,7 +134,7 @@ export function SidebarTabItem({
               </a>
             )}
             {!renaming && (
-              <TabStatusIcon tabId={makeTabKey(projectId, tab.id)} />
+              <TabStatusIcon tabId={makeTabKey(projectId, tab.id)} active={isActive} />
             )}
             {tab.pinned && !renaming && (
               <span

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -84,7 +84,7 @@ export function SidebarTabItem({
           <button
             type="button"
             className={cn(
-              'relative mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center gap-2 rounded-md pr-2 pl-[34px] text-left',
+              'relative mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center gap-2 rounded-md pr-2 pl-[20px] text-left',
               isActive
                 ? 'bg-sidebar-active text-sidebar-fg-strong'
                 : 'text-sidebar-fg hover:bg-sidebar-hover',
@@ -97,6 +97,32 @@ export function SidebarTabItem({
             {isActive && (
               <span className="absolute top-1.5 bottom-1.5 left-3.5 w-0.5 rounded-sm bg-accent" />
             )}
+
+            {/*
+             * Left pin slot — fixed width so label text stays aligned across
+             * all rows regardless of pinned state. Only shows the icon when
+             * pinned; stays invisible otherwise. Hidden during inline rename
+             * so the input gets the full width.
+             */}
+            {!renaming && (
+              <span className="w-4 shrink-0 flex items-center justify-center">
+                {tab.pinned && (
+                  <span
+                    title="Unpin tab"
+                    className="opacity-50 hover:opacity-100"
+                    onPointerDown={(e) => {
+                      e.stopPropagation()
+                      e.preventDefault()
+                      toggleTabPin(projectId, tab.id)
+                    }}
+                  >
+                    <Pin size={9} />
+                  </span>
+                )}
+              </span>
+            )}
+
+            {/* Label / rename input */}
             {renaming ? (
               <InlineEdit
                 value={tab.label}
@@ -106,18 +132,22 @@ export function SidebarTabItem({
                 style={{ fontFamily: MONO_FONT, fontSize: 11.5 }}
               />
             ) : (
-              <>
-                <span
-                  className={cn('flex-1 truncate', isActive && 'font-medium')}
-                  style={{ fontFamily: MONO_FONT, fontSize: 11.5 }}
-                >
-                  {resolveTabLabel(tab, tabMeta?.cwd)}
-                </span>
-                {tabMeta?.type === 'agent' && hasDangerFlag(tabMeta.agentCmd) && (
-                  <DangerBadge size={11} />
-                )}
-              </>
+              <span
+                className={cn('flex-1 truncate', isActive && 'font-medium')}
+                style={{ fontFamily: MONO_FONT, fontSize: 11.5 }}
+              >
+                {resolveTabLabel(tab, tabMeta?.cwd)}
+              </span>
             )}
+
+            {/*
+             * Right-side indicators, left to right:
+             *   PR link → DangerBadge → StatusIcon
+             *
+             * DangerBadge sits immediately left of the status icon so it reads
+             * as "this agent is running hot" rather than a separate entity.
+             * PR link comes before danger so it groups with the label content.
+             */}
             {!renaming && tabMeta?.git?.pr && prUrl && (
               <a
                 href={prUrl}
@@ -133,21 +163,11 @@ export function SidebarTabItem({
                 #{tabMeta.git.pr.number}
               </a>
             )}
+            {!renaming && tabMeta?.type === 'agent' && hasDangerFlag(tabMeta.agentCmd) && (
+              <DangerBadge size={11} />
+            )}
             {!renaming && (
               <TabStatusIcon tabId={makeTabKey(projectId, tab.id)} active={isActive} />
-            )}
-            {tab.pinned && !renaming && (
-              <span
-                title="Unpin tab"
-                className="shrink-0 opacity-50 hover:opacity-100"
-                onPointerDown={(e) => {
-                  e.stopPropagation()
-                  e.preventDefault()
-                  toggleTabPin(projectId, tab.id)
-                }}
-              >
-                <Pin size={9} />
-              </span>
             )}
           </button>
         </div>

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -100,7 +100,7 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
               className="flex flex-1 cursor-pointer items-center gap-1.5 overflow-hidden pr-1 pl-3"
               onClick={() => navigateToTab(projectId, tab.id)}
             >
-              <TabStatusIcon tabId={makeTabKey(projectId, tab.id)} />
+              <TabStatusIcon tabId={makeTabKey(projectId, tab.id)} active={isActive} />
               <span className="truncate" style={{ fontFamily: MONO_FONT }}>
                 {resolveTabLabel(tab, tabMeta?.cwd)}
               </span>

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -100,7 +100,10 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
               className="flex flex-1 cursor-pointer items-center gap-1.5 overflow-hidden pr-1 pl-3"
               onClick={() => navigateToTab(projectId, tab.id)}
             >
-              <TabStatusIcon tabId={makeTabKey(projectId, tab.id)} active={isActive} />
+              <TabStatusIcon
+                tabId={makeTabKey(projectId, tab.id)}
+                active={isActive}
+              />
               <span className="truncate" style={{ fontFamily: MONO_FONT }}>
                 {resolveTabLabel(tab, tabMeta?.cwd)}
               </span>

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -14,6 +14,8 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
 import { Pin, X } from 'lucide-react'
+import { hasDangerFlag } from '@/components/agent.helpers'
+import { DangerBadge } from '@/components/DangerBadge'
 import { GitBadge } from '@/components/GitBadge'
 import { TabStatusIcon } from '@/components/TabStatusIcon'
 import {
@@ -36,7 +38,11 @@ import {
   toggleTabPin,
 } from '@/modules/stores/$projects'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
-import { MONO_FONT, makeTabKey } from '@/screens/workspace/workspace.helpers'
+import {
+  MONO_FONT,
+  makeTabKey,
+  resolveTabLabel,
+} from '@/screens/workspace/workspace.helpers'
 import type { Project, Tab } from '@/screens/workspace/workspace.types'
 
 /* ---------------------------------------------------------------------------
@@ -45,6 +51,8 @@ import type { Project, Tab } from '@/screens/workspace/workspace.types'
 function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
   const activeTabsByProject = useStore($activeTabId)
   const isActive = activeTabsByProject[projectId] === tab.id
+  const allTabMeta = useStore($tabMeta)
+  const tabMeta = allTabMeta[makeTabKey(projectId, tab.id)]
 
   const {
     attributes,
@@ -94,8 +102,11 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
             >
               <TabStatusIcon tabId={makeTabKey(projectId, tab.id)} />
               <span className="truncate" style={{ fontFamily: MONO_FONT }}>
-                {tab.label}
+                {resolveTabLabel(tab, tabMeta?.cwd)}
               </span>
+              {tabMeta?.type === 'agent' && hasDangerFlag(tabMeta.agentCmd) && (
+                <DangerBadge size={11} />
+              )}
             </button>
 
             {/* Pin / close action — sibling of nav button, not nested */}

--- a/src/components/TabStatusIcon.tsx
+++ b/src/components/TabStatusIcon.tsx
@@ -42,7 +42,7 @@ type Props = {
  *   Renders AgentGlyph with the agent's brand mark.
  *   idle   → dim mark (full opacity when the tab/sidebar item is active)
  *   done   → green check badge (bottom-right corner of the mark)
- *   error  → green check badge (OSC 133 maps both done/error → completed)
+ *   error  → green check badge (same as done — see TECH DEBT note in agent.helpers.ts)
  *
  *   `in-progress` (pulsing ring) and `awaiting` (amber chat-bubble badge)
  *   are defined in AgentState but not yet returned by deriveAgentState —

--- a/src/components/TabStatusIcon.tsx
+++ b/src/components/TabStatusIcon.tsx
@@ -1,4 +1,6 @@
 import { useStore } from '@nanostores/react'
+import { AgentGlyph } from '@/components/AgentGlyph'
+import { deriveAgentState } from '@/components/agent.helpers'
 import { RunningDot } from '@/components/RunningDot'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
 
@@ -7,15 +9,19 @@ type Props = {
 }
 
 /**
- * Replaces the static running indicator in tab pills.
+ * Status indicator for tab pills and sidebar rows.
  * Reads from `$tabMeta` (driven by ProcessTrackerMod + ClaudeCodeMod/CodexMod).
  *
- * - agent type + running → violet sparkle (✦) — AI agent is active
- * - agent type + idle   → dim violet sparkle — session detected, agent idle
- * - running → animated RunningDot
- * - done → green dot
- * - error → red dot
- * - idle → dim static dot
+ * Shell / task:
+ *   running → animated RunningDot (pulsing green)
+ *   done    → static green dot
+ *   error   → static red dot
+ *   idle    → dim static dot
+ *
+ * Agent:
+ *   Renders AgentGlyph with the agent's brand mark and a state badge.
+ *   State is derived from OSC 133 status today; AgentTurnMod will enrich
+ *   this with completed / awaiting states in the future.
  */
 export function TabStatusIcon({ tabId }: Props) {
   const allMeta = useStore($tabMeta)
@@ -23,23 +29,17 @@ export function TabStatusIcon({ tabId }: Props) {
   const status = meta?.status ?? 'idle'
   const type = meta?.type ?? 'shell'
 
-  // Agent tab — show sparkle instead of dot
   if (type === 'agent') {
-    const isRunning = status === 'running'
     return (
-      <span
-        className={`shrink-0 text-violet-400 ${isRunning ? 'opacity-90' : 'opacity-50'}`}
-        style={{ fontSize: 10, lineHeight: 1 }}
-        aria-hidden="true"
-      >
-        ✦
-      </span>
+      <AgentGlyph
+        agent={meta?.agentName ?? ''}
+        state={deriveAgentState(meta)}
+        size={14}
+      />
     )
   }
 
-  if (status === 'running') {
-    return <RunningDot />
-  }
+  if (status === 'running') return <RunningDot />
 
   if (status === 'done') {
     return (
@@ -53,7 +53,6 @@ export function TabStatusIcon({ tabId }: Props) {
     )
   }
 
-  // idle
   return (
     <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current opacity-35" />
   )

--- a/src/components/TabStatusIcon.tsx
+++ b/src/components/TabStatusIcon.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
 import { useStore } from '@nanostores/react'
+import { useEffect, useRef, useState } from 'react'
 import { AgentGlyph } from '@/components/AgentGlyph'
 import { deriveAgentState } from '@/components/agent.helpers'
 import { RunningDot } from '@/components/RunningDot'

--- a/src/components/TabStatusIcon.tsx
+++ b/src/components/TabStatusIcon.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react'
 import { useStore } from '@nanostores/react'
 import { AgentGlyph } from '@/components/AgentGlyph'
 import { deriveAgentState } from '@/components/agent.helpers'
@@ -13,22 +14,84 @@ type Props = {
  * Status indicator for tab pills and sidebar rows.
  * Reads from `$tabMeta` (driven by ProcessTrackerMod + ClaudeCodeMod/CodexMod).
  *
- * Shell / task:
- *   running → animated RunningDot (pulsing green)
- *   done    → static green dot
- *   error   → static red dot
- *   idle    → dim static dot
+ * ── Shell / task state machine ───────────────────────────────────────────────
  *
- * Agent:
- *   Renders AgentGlyph with the agent's brand mark and a state badge.
- *   State is derived from OSC 133 status today; AgentTurnMod will enrich
- *   this with completed / awaiting states in the future.
+ *   running ──► animated RunningDot (pulsing green)
+ *      │
+ *      ▼ (exit 0)
+ *   done ────► static green dot  ──► [10s elapsed OR tab becomes active] ──► idle
+ *      │
+ *      │ (exit non-0, bypasses done)
+ *      ▼
+ *   error ───► static red dot  (persists until the shell starts running again —
+ *              error is actionable and should not self-clear)
+ *      │
+ *      ▼ (user runs another command)
+ *   running  (cycle repeats)
+ *
+ *   idle ────► dim static dot
+ *
+ * The "done" green is intentionally transient — it signals completion but
+ * becomes stale once acknowledged. Two things clear it:
+ *   1. 10 seconds elapse (auto-dismiss for unattended tabs)
+ *   2. The tab becomes active (user has seen it — clear immediately)
+ * Either path transitions the visual to "idle" (dim dot).
+ *
+ * ── Agent ────────────────────────────────────────────────────────────────────
+ *
+ *   Renders AgentGlyph with the agent's brand mark.
+ *   idle   → dim mark (full opacity when the tab/sidebar item is active)
+ *   done   → green check badge (bottom-right corner of the mark)
+ *   error  → green check badge (OSC 133 maps both done/error → completed)
+ *
+ *   `in-progress` (pulsing ring) and `awaiting` (amber chat-bubble badge)
+ *   are defined in AgentState but not yet returned by deriveAgentState —
+ *   AgentTurnMod will unlock them when it writes agentState to TabMeta.
  */
+
+/** How long (ms) the green "done" dot stays visible before fading to idle. */
+const DONE_LINGER_MS = 10_000
+
 export function TabStatusIcon({ tabId, active = false }: Props) {
   const allMeta = useStore($tabMeta)
   const meta = allMeta[tabId]
   const status = meta?.status ?? 'idle'
   const type = meta?.type ?? 'shell'
+
+  // Controls whether the transient green "done" dot is currently visible.
+  // Kept in local state rather than the store because it is purely a display
+  // concern — the underlying status remains 'done' until the next command runs.
+  const [showDone, setShowDone] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Start or cancel the linger timer whenever status changes.
+  useEffect(() => {
+    if (status === 'done') {
+      setShowDone(true)
+      timerRef.current = setTimeout(() => setShowDone(false), DONE_LINGER_MS)
+    } else {
+      // running / error / idle all cancel any in-flight timer immediately.
+      setShowDone(false)
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [status])
+
+  // Navigating to the tab counts as "acknowledged" — clear the done dot right away.
+  useEffect(() => {
+    if (active && showDone) {
+      setShowDone(false)
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [active, showDone])
 
   if (type === 'agent') {
     return (
@@ -43,7 +106,7 @@ export function TabStatusIcon({ tabId, active = false }: Props) {
 
   if (status === 'running') return <RunningDot />
 
-  if (status === 'done') {
+  if (showDone) {
     return (
       <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-green-400 opacity-70" />
     )

--- a/src/components/TabStatusIcon.tsx
+++ b/src/components/TabStatusIcon.tsx
@@ -6,6 +6,7 @@ import { $tabMeta } from '@/modules/stores/$tabMeta'
 
 type Props = {
   tabId: string
+  active?: boolean
 }
 
 /**
@@ -23,7 +24,7 @@ type Props = {
  *   State is derived from OSC 133 status today; AgentTurnMod will enrich
  *   this with completed / awaiting states in the future.
  */
-export function TabStatusIcon({ tabId }: Props) {
+export function TabStatusIcon({ tabId, active = false }: Props) {
   const allMeta = useStore($tabMeta)
   const meta = allMeta[tabId]
   const status = meta?.status ?? 'idle'
@@ -35,6 +36,7 @@ export function TabStatusIcon({ tabId }: Props) {
         agent={meta?.agentName ?? ''}
         state={deriveAgentState(meta)}
         size={14}
+        active={active}
       />
     )
   }

--- a/src/components/agent.helpers.ts
+++ b/src/components/agent.helpers.ts
@@ -5,12 +5,13 @@ import type { TabMeta } from '@/modules/stores/$tabMeta'
  *
  * - idle        : process exists, no active turn (dim mark)
  * - in-progress : agent is producing output (pulsing ring)
- * - completed   : last turn finished, waiting for next prompt (green check badge)
+ * - completed   : session ended — green check badge (bottom-right)
  * - awaiting    : agent is waiting for user confirmation (amber chat-bubble badge)
  *
- * `completed` and `awaiting` are future states — `deriveAgentState` never
- * returns them yet. When the AgentTurnMod is built it will write
- * `TabMeta.agentState` directly; update this helper to prefer that field.
+ * Currently `deriveAgentState` returns `idle` and `completed` only.
+ * `in-progress` and `awaiting` are unlocked when AgentTurnMod writes
+ * `TabMeta.agentState` directly; add `if (meta.agentState) return meta.agentState`
+ * as the first check in `deriveAgentState` at that point.
  */
 export type AgentState = 'idle' | 'in-progress' | 'completed' | 'awaiting'
 
@@ -25,6 +26,12 @@ export type AgentState = 'idle' | 'in-progress' | 'completed' | 'awaiting'
  * When AgentTurnMod is built it will write `TabMeta.agentState` directly.
  * At that point, add `if (meta.agentState) return meta.agentState` as the
  * first check below, and the richer states will light up automatically.
+ *
+ * TECH DEBT: Both `done` and `error` map to `completed` (green check badge).
+ * Error exits should ideally show a distinct red badge, but we have no
+ * reliable way to distinguish a clean agent exit from an error exit at the
+ * OSC 133 level today. Treat any session end as successful for now and
+ * revisit when AgentTurnMod provides richer exit metadata.
  */
 export function deriveAgentState(meta: TabMeta | undefined): AgentState {
   if (!meta || meta.type !== 'agent') return 'idle'

--- a/src/components/agent.helpers.ts
+++ b/src/components/agent.helpers.ts
@@ -1,0 +1,56 @@
+import type { TabMeta } from '@/modules/stores/$tabMeta'
+
+/**
+ * The four visual states an agent tab can be in.
+ *
+ * - idle        : process exists, no active turn (dim mark)
+ * - in-progress : agent is producing output (pulsing ring)
+ * - completed   : last turn finished, waiting for next prompt (green check badge)
+ * - awaiting    : agent is waiting for user confirmation (amber chat-bubble badge)
+ *
+ * `completed` and `awaiting` are future states — `deriveAgentState` never
+ * returns them yet. When the AgentTurnMod is built it will write
+ * `TabMeta.agentState` directly; update this helper to prefer that field.
+ */
+export type AgentState = 'idle' | 'in-progress' | 'completed' | 'awaiting'
+
+/**
+ * Maps live TabMeta → AgentState for rendering.
+ *
+ * Future hook: when TabMeta gains an `agentState` field set by AgentTurnMod,
+ * add `if (meta.agentState) return meta.agentState` before the status mapping.
+ */
+export function deriveAgentState(meta: TabMeta | undefined): AgentState {
+  if (!meta || meta.type !== 'agent') return 'idle'
+  if (meta.status === 'running') return 'in-progress'
+  if (meta.status === 'done' || meta.status === 'error') return 'completed'
+  return 'idle'
+}
+
+/**
+ * Returns true when the agent command includes a full-permissions flag.
+ *
+ * Per-agent flags:
+ *   - claude-code → --dangerously-skip-permissions
+ *   - codex       → --yolo
+ *
+ * When adding a new agent, add its full-permissions flag here.
+ * The 🤘 badge and tooltip are the same regardless of which flag triggered it.
+ */
+export function hasDangerFlag(agentCmd: string | undefined): boolean {
+  if (!agentCmd) return false
+  return (
+    agentCmd.includes('--dangerously-skip-permissions') ||
+    agentCmd.includes('--yolo')
+  )
+}
+
+/**
+ * Parses the `--model <name>` flag from an agent command string.
+ * Returns null when the flag is absent.
+ */
+export function parseModelFlag(agentCmd: string | undefined): string | null {
+  if (!agentCmd) return null
+  const match = agentCmd.match(/--model\s+(\S+)/)
+  return match?.[1] ?? null
+}

--- a/src/components/agent.helpers.ts
+++ b/src/components/agent.helpers.ts
@@ -17,12 +17,17 @@ export type AgentState = 'idle' | 'in-progress' | 'completed' | 'awaiting'
 /**
  * Maps live TabMeta → AgentState for rendering.
  *
- * Future hook: when TabMeta gains an `agentState` field set by AgentTurnMod,
- * add `if (meta.agentState) return meta.agentState` before the status mapping.
+ * `in-progress` and `awaiting` are intentionally not returned here yet — we
+ * have no signal that distinguishes "agent process is alive" from "agent is
+ * actively producing output". OSC 133 status only tells us the shell is
+ * running, not whether the agent turn is in flight.
+ *
+ * When AgentTurnMod is built it will write `TabMeta.agentState` directly.
+ * At that point, add `if (meta.agentState) return meta.agentState` as the
+ * first check below, and the richer states will light up automatically.
  */
 export function deriveAgentState(meta: TabMeta | undefined): AgentState {
   if (!meta || meta.type !== 'agent') return 'idle'
-  if (meta.status === 'running') return 'in-progress'
   if (meta.status === 'done' || meta.status === 'error') return 'completed'
   return 'idle'
 }

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,17 @@
     opacity: 0;
   }
 }
+@keyframes agent-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.12);
+    opacity: 0.82;
+  }
+}
 
 /* ─── Tailwind v4 theme mapping ─────────────────────────────── */
 @theme inline {
@@ -125,6 +136,7 @@
   --status-bar-background: #fafafa;
   --status-bar-border: rgba(0, 0, 0, 0.06);
   --status-bar-foreground: rgba(0, 0, 0, 0.45);
+  --status-bar-foreground-strong: rgba(0, 0, 0, 0.82);
 
   /* Accent (fixed) */
   --accent: oklch(0.55 0.18 225);
@@ -215,6 +227,7 @@
     --status-bar-background: #141517;
     --status-bar-border: rgba(255, 255, 255, 0.06);
     --status-bar-foreground: rgba(255, 255, 255, 0.45);
+    --status-bar-foreground-strong: rgba(255, 255, 255, 0.82);
 
     /* Accent (fixed) */
     --accent: oklch(0.68 0.15 225);


### PR DESCRIPTION
## Summary

- **New `AgentGlyph` component** — composite brand mark + state badge: pulsing ring for `in-progress`, green check bottom-right for `completed`, breathing amber chat-bubble top-right for `awaiting`. Falls back to violet ✦ sparkle for unknown agents.
- **New `DangerBadge`** — 🤘 with tooltip "All permissions enabled", shown on agent tabs running with `--dangerously-skip-permissions` (claude-code) or `--yolo` (codex).
- **New `agent.helpers.ts`** — `AgentState` type, `deriveAgentState`, `hasDangerFlag`, `parseModelFlag` helpers. Extensible: add new agents by adding entries to the `BRAND` map in `AgentGlyph` and flags to `hasDangerFlag`.
- **`TabStatusIcon` rewrite** — shell tabs keep existing RunningDot/dot logic; agent tabs render `AgentGlyph`.
- **`TabBar` + `SidebarTabItem`** — labels now use `resolveTabLabel` (CWD-derived by default, user-renamed label preserved). `DangerBadge` shown inline for agent tabs with danger flag.
- **`SidebarProjectRow`** — `anyDanger` aggregate: shows `DangerBadge` on the collapsed project row when any child tab has the danger flag active.
- **CSS** — `agent-breathe` keyframe + `--status-bar-foreground-strong` tokens added.

## Test plan

- [ ] Shell tab: idle → dim dot, running → RunningDot pulse, done → green dot, error → red dot
- [ ] Agent tab (claude-code): idle → dim Claude mark, running → Claude mark + pulsing orange ring
- [ ] Agent tab with `--dangerously-skip-permissions`: 🤘 badge visible in tab bar, sidebar item, and collapsed project row
- [ ] Agent tab (codex): idle → dim Codex hex mark, running → Codex mark + pulsing white ring
- [ ] Agent tab with `--yolo`: 🤘 badge visible
- [ ] Unknown agent name: violet ✦ sparkle renders without crashing
- [ ] Tab label: shell tab without user rename shows `/last-segment` of CWD
- [ ] Tab label: user-renamed tab keeps its label regardless of CWD