### PR TITLE
feat(ui): status bar V1 Extended — general · session split

### DIFF
--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -2,17 +2,20 @@ import { StatusBarLeft } from '@/components/StatusBar/StatusBarLeft'
 import { StatusBarRight } from '@/components/StatusBar/StatusBarRight'
 
 /**
- * Status bar — V1 Extended: full-length split (general · session).
+ * Status bar — V1 Extended: full-length split (workspace · session).
  *
- * ┌──────────────────────────────────────────────────────────────────────────┐
- * │  /cwd  branch*  ● N  claude N  codex N  🤘  ····  name · pid · mem · :port │
- * │  └────── StatusBarLeft (workspace) ───────┘  └── StatusBarRight (session) ┘│
- * └──────────────────────────────────────────────────────────────────────────┘
+ * ┌────────────────────────────────────────────────────────────────────────────────┐
+ * │  ● N active agents  ● X active tasks  Y failed tasks  ····  ⎇ branch  📂 /cwd │
+ * │  └──────────── StatusBarLeft (workspace overview) ─────────┘  └─ StatusBarRight┘│
+ * └────────────────────────────────────────────────────────────────────────────────┘
  *
- * Left  — workspace state: active tab CWD, git branch, global running counts,
- *          per-agent counts, danger indicator.
- * Right — active session: live process metadata for the focused tab (name,
- *          pid, elapsed, memory, ports, model, danger).
+ * Left  — workspace overview (global across all tabs/projects):
+ *          N active agents (claude + codex running) · X active tasks (shells running)
+ *          · Y failed tasks (any tab in error). Renders nothing when all counts are zero.
+ * Right — active tab context (switches on tab focus):
+ *          process info when available (name · pid · ⏱ elapsed · 🧮 mem · 🔌 ports · ✨ model)
+ *          or status text for shell tabs · then ⎇ git branch (with sync icons) · 📂 CWD basename
+ *          (hover tooltip shows full path). Renders nothing for idle tabs with no data.
  *
  * Each side renders null when it has nothing to show, so the bar degrades
  * gracefully on fresh tabs with no data yet.

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -1,33 +1,35 @@
-import { useStore } from '@nanostores/react'
-import { $projects } from '@/modules/stores/$projects'
-import { $tabMeta } from '@/modules/stores/$tabMeta'
-import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+import { StatusBarLeft } from '@/components/StatusBar/StatusBarLeft'
+import { StatusBarRight } from '@/components/StatusBar/StatusBarRight'
 
+/**
+ * Status bar — V1 Extended: full-length split (general · session).
+ *
+ * ┌──────────────────────────────────────────────────────────────────────────┐
+ * │  /cwd  branch*  ● N  claude N  codex N  🤘  ····  name · pid · mem · :port │
+ * │  └────── StatusBarLeft (workspace) ───────┘  └── StatusBarRight (session) ┘│
+ * └──────────────────────────────────────────────────────────────────────────┘
+ *
+ * Left  — workspace state: active tab CWD, git branch, global running counts,
+ *          per-agent counts, danger indicator.
+ * Right — active session: live process metadata for the focused tab (name,
+ *          pid, elapsed, memory, ports, model, danger).
+ *
+ * Each side renders null when it has nothing to show, so the bar degrades
+ * gracefully on fresh tabs with no data yet.
+ */
 export function StatusBar() {
-  const projects = useStore($projects)
-  const allTabMeta = useStore($tabMeta)
-  const sessionsRunning = projects.reduce(
-    (n, p) =>
-      n +
-      p.tabs.filter(
-        (t) => allTabMeta[makeTabKey(p.id, t.id)]?.status === 'running',
-      ).length,
-    0,
-  )
-
   return (
     <div
-      className="flex h-6 shrink-0 items-center border-t px-3 text-[11px]"
+      className="flex h-6 shrink-0 items-center gap-2 overflow-hidden border-t px-3 text-[11px]"
       style={{
         background: 'var(--status-bar-background)',
         borderColor: 'var(--status-bar-border)',
         color: 'var(--status-bar-foreground)',
+        fontFamily: 'var(--font-ui)',
       }}
     >
-      <span className="mr-auto">
-        {sessionsRunning > 0 ? `● ${sessionsRunning} running` : '○ idle'}
-      </span>
-      <span className="opacity-60">UTF-8 · zsh</span>
+      <StatusBarLeft />
+      <StatusBarRight />
     </div>
   )
 }

--- a/src/components/StatusBar/StatusBarLeft.tsx
+++ b/src/components/StatusBar/StatusBarLeft.tsx
@@ -1,88 +1,59 @@
 import { useStore } from '@nanostores/react'
 import type React from 'react'
-import { hasDangerFlag } from '@/components/agent.helpers'
-import { DangerBadge } from '@/components/DangerBadge'
 import { RunningDot } from '@/components/RunningDot'
-import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
 import { $projects } from '@/modules/stores/$projects'
 import { $tabMeta, type TabMeta } from '@/modules/stores/$tabMeta'
-import {
-  cwdBasename,
-  MONO_FONT,
-  makeTabKey,
-} from '@/screens/workspace/workspace.helpers'
+import { MONO_FONT, makeTabKey } from '@/screens/workspace/workspace.helpers'
 import type { Project } from '@/screens/workspace/workspace.types'
 
 /* ---------------------------------------------------------------------------
- * StatusBarLeft — workspace / general state
+ * StatusBarLeft — workspace overview
  *
- * Shows the active tab's CWD and git context, plus global counts across
- * every tab in every project.
+ * Shows aggregate counts across every tab in every project. Renders nothing
+ * when all counts are zero (left side intentionally empty on idle workspaces).
  *
- * Layout (items only rendered when non-zero / available):
+ * Layout (items only rendered when non-zero):
  *
- *   /cwd-basename  branch*+N  ● N  claude N  codex N  🤘
- *   │              │          │    │          │         └─ any agent running with a danger flag
- *   │              │          │    │          └─────────── running codex sessions (global)
- *   │              │          │    └────────────────────── running claude sessions (global)
- *   │              │          └─────────────────────────── running shell count (global)
- *   │              └────────────────────────────────────── git branch + dirty (*) + ahead (+N)
- *   └───────────────────────────────────────────────────── CWD basename of active tab
+ *   ● N active agents  ·  ● X active tasks  ·  Y failed tasks
+ *   │                      │                    │
+ *   │                      │                    └── tabs in error state (any type)
+ *   │                      └───────────────────── shell tabs currently running
+ *   └──────────────────────────────────────────── claude + codex sessions running
  *
  * Items are separated by a dim mid-dot (·).
  * -------------------------------------------------------------------------*/
 
 type WorkspaceCounts = {
-  shellRunning: number
-  claudeRunning: number
-  codexRunning: number
-  anyDanger: boolean
+  agentsRunning: number
+  tasksRunning: number
+  tasksFailed: number
 }
 
 /**
  * Scans all tabs across all projects and returns aggregate running counts.
  * Uses flatMap + filter to keep cyclomatic complexity low.
+ *
+ *   agentsRunning — agent tabs (claude, codex) with status "running"
+ *   tasksRunning  — shell tabs with status "running"
+ *   tasksFailed   — any tab with status "error" (across all types)
  */
 function computeWorkspaceCounts(
   projects: Project[],
   allTabMeta: Record<string, TabMeta>,
 ): WorkspaceCounts {
-  // Flatten to a single array of defined TabMeta values.
   const metas = projects
     .flatMap((p) => p.tabs.map((t) => allTabMeta[makeTabKey(p.id, t.id)]))
     .filter((m): m is TabMeta => m !== undefined)
 
   return {
-    shellRunning: metas.filter(
+    agentsRunning: metas.filter(
+      (m) => m.type === 'agent' && m.status === 'running',
+    ).length,
+    tasksRunning: metas.filter(
       (m) => m.type === 'shell' && m.status === 'running',
     ).length,
-    claudeRunning: metas.filter(
-      (m) =>
-        m.type === 'agent' &&
-        m.status === 'running' &&
-        m.agentName === 'claude-code',
-    ).length,
-    codexRunning: metas.filter(
-      (m) =>
-        m.type === 'agent' && m.status === 'running' && m.agentName === 'codex',
-    ).length,
-    anyDanger: metas.some(
-      (m) => m.type === 'agent' && hasDangerFlag(m.agentCmd),
-    ),
+    tasksFailed: metas.filter((m) => m.status === 'error').length,
   }
-}
-
-/** Formats git info into a compact `branch*+N-N` string. */
-function formatGitLabel(git: {
-  branch: string
-  isDirty: boolean
-  aheadBy: number
-  behindBy: number
-}): string {
-  const dirty = git.isDirty ? '*' : ''
-  const ahead = git.aheadBy > 0 ? `+${git.aheadBy}` : ''
-  const behind = git.behindBy > 0 ? `-${git.behindBy}` : ''
-  return `${git.branch}${dirty}${ahead}${behind}`
 }
 
 /** Thin separator dot between status bar items. */
@@ -97,71 +68,45 @@ function Dot() {
 export function StatusBarLeft() {
   const projects = useStore($projects)
   const allTabMeta = useStore($tabMeta)
-  const activeProjectId = useStore($activeProjectId)
-  const activeTabIds = useStore($activeTabId)
 
-  // Active tab context for CWD + git
-  const activeTabId = activeTabIds[activeProjectId] ?? ''
-  const activeMeta = activeTabId
-    ? allTabMeta[makeTabKey(activeProjectId, activeTabId)]
-    : undefined
-
-  const cwdDisplay = activeMeta?.cwd ? cwdBasename(activeMeta.cwd) : null
-  const git = activeMeta?.git
-  const { shellRunning, claudeRunning, codexRunning, anyDanger } =
-    computeWorkspaceCounts(projects, allTabMeta)
+  const { agentsRunning, tasksRunning, tasksFailed } = computeWorkspaceCounts(
+    projects,
+    allTabMeta,
+  )
 
   const items: React.ReactNode[] = []
 
-  if (cwdDisplay) {
+  if (agentsRunning > 0) {
     items.push(
-      <span key="cwd" style={{ fontFamily: MONO_FONT }}>
-        {cwdDisplay}
+      <span key="agents" className="flex items-center gap-1">
+        <RunningDot />
+        <span style={{ fontFamily: MONO_FONT }}>
+          {agentsRunning} active {agentsRunning === 1 ? 'agent' : 'agents'}
+        </span>
       </span>,
     )
   }
 
-  if (git?.branch) {
+  if (tasksRunning > 0) {
+    items.push(
+      <span key="tasks" className="flex items-center gap-1">
+        <RunningDot />
+        <span style={{ fontFamily: MONO_FONT }}>
+          {tasksRunning} active {tasksRunning === 1 ? 'task' : 'tasks'}
+        </span>
+      </span>,
+    )
+  }
+
+  if (tasksFailed > 0) {
     items.push(
       <span
-        key="git"
-        className="text-accent opacity-80"
-        style={{ fontFamily: MONO_FONT }}
+        key="failed"
+        style={{ fontFamily: MONO_FONT, color: 'var(--terminal-red)' }}
       >
-        {formatGitLabel(git)}
+        {tasksFailed} failed {tasksFailed === 1 ? 'task' : 'tasks'}
       </span>,
     )
-  }
-
-  if (shellRunning > 0) {
-    items.push(
-      <span key="shells" className="flex items-center gap-1">
-        <RunningDot />
-        {shellRunning}
-      </span>,
-    )
-  }
-
-  if (claudeRunning > 0) {
-    items.push(
-      <span key="claude" className="flex items-center gap-1">
-        <RunningDot />
-        <span style={{ fontFamily: MONO_FONT }}>claude {claudeRunning}</span>
-      </span>,
-    )
-  }
-
-  if (codexRunning > 0) {
-    items.push(
-      <span key="codex" className="flex items-center gap-1">
-        <RunningDot />
-        <span style={{ fontFamily: MONO_FONT }}>codex {codexRunning}</span>
-      </span>,
-    )
-  }
-
-  if (anyDanger) {
-    items.push(<DangerBadge key="danger" size={10} />)
   }
 
   if (items.length === 0) return null

--- a/src/components/StatusBar/StatusBarLeft.tsx
+++ b/src/components/StatusBar/StatusBarLeft.tsx
@@ -1,0 +1,180 @@
+import { useStore } from '@nanostores/react'
+import type React from 'react'
+import { hasDangerFlag } from '@/components/agent.helpers'
+import { DangerBadge } from '@/components/DangerBadge'
+import { RunningDot } from '@/components/RunningDot'
+import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
+import { $projects } from '@/modules/stores/$projects'
+import { $tabMeta, type TabMeta } from '@/modules/stores/$tabMeta'
+import {
+  cwdBasename,
+  MONO_FONT,
+  makeTabKey,
+} from '@/screens/workspace/workspace.helpers'
+import type { Project } from '@/screens/workspace/workspace.types'
+
+/* ---------------------------------------------------------------------------
+ * StatusBarLeft — workspace / general state
+ *
+ * Shows the active tab's CWD and git context, plus global counts across
+ * every tab in every project.
+ *
+ * Layout (items only rendered when non-zero / available):
+ *
+ *   /cwd-basename  branch*+N  ● N  claude N  codex N  🤘
+ *   │              │          │    │          │         └─ any agent running with a danger flag
+ *   │              │          │    │          └─────────── running codex sessions (global)
+ *   │              │          │    └────────────────────── running claude sessions (global)
+ *   │              │          └─────────────────────────── running shell count (global)
+ *   │              └────────────────────────────────────── git branch + dirty (*) + ahead (+N)
+ *   └───────────────────────────────────────────────────── CWD basename of active tab
+ *
+ * Items are separated by a dim mid-dot (·).
+ * -------------------------------------------------------------------------*/
+
+type WorkspaceCounts = {
+  shellRunning: number
+  claudeRunning: number
+  codexRunning: number
+  anyDanger: boolean
+}
+
+/**
+ * Scans all tabs across all projects and returns aggregate running counts.
+ * Uses flatMap + filter to keep cyclomatic complexity low.
+ */
+function computeWorkspaceCounts(
+  projects: Project[],
+  allTabMeta: Record<string, TabMeta>,
+): WorkspaceCounts {
+  // Flatten to a single array of defined TabMeta values.
+  const metas = projects
+    .flatMap((p) => p.tabs.map((t) => allTabMeta[makeTabKey(p.id, t.id)]))
+    .filter((m): m is TabMeta => m !== undefined)
+
+  return {
+    shellRunning: metas.filter(
+      (m) => m.type === 'shell' && m.status === 'running',
+    ).length,
+    claudeRunning: metas.filter(
+      (m) =>
+        m.type === 'agent' &&
+        m.status === 'running' &&
+        m.agentName === 'claude-code',
+    ).length,
+    codexRunning: metas.filter(
+      (m) =>
+        m.type === 'agent' && m.status === 'running' && m.agentName === 'codex',
+    ).length,
+    anyDanger: metas.some(
+      (m) => m.type === 'agent' && hasDangerFlag(m.agentCmd),
+    ),
+  }
+}
+
+/** Formats git info into a compact `branch*+N-N` string. */
+function formatGitLabel(git: {
+  branch: string
+  isDirty: boolean
+  aheadBy: number
+  behindBy: number
+}): string {
+  const dirty = git.isDirty ? '*' : ''
+  const ahead = git.aheadBy > 0 ? `+${git.aheadBy}` : ''
+  const behind = git.behindBy > 0 ? `-${git.behindBy}` : ''
+  return `${git.branch}${dirty}${ahead}${behind}`
+}
+
+/** Thin separator dot between status bar items. */
+function Dot() {
+  return (
+    <span aria-hidden="true" style={{ opacity: 0.3 }}>
+      ·
+    </span>
+  )
+}
+
+export function StatusBarLeft() {
+  const projects = useStore($projects)
+  const allTabMeta = useStore($tabMeta)
+  const activeProjectId = useStore($activeProjectId)
+  const activeTabIds = useStore($activeTabId)
+
+  // Active tab context for CWD + git
+  const activeTabId = activeTabIds[activeProjectId] ?? ''
+  const activeMeta = activeTabId
+    ? allTabMeta[makeTabKey(activeProjectId, activeTabId)]
+    : undefined
+
+  const cwdDisplay = activeMeta?.cwd ? cwdBasename(activeMeta.cwd) : null
+  const git = activeMeta?.git
+  const { shellRunning, claudeRunning, codexRunning, anyDanger } =
+    computeWorkspaceCounts(projects, allTabMeta)
+
+  const items: React.ReactNode[] = []
+
+  if (cwdDisplay) {
+    items.push(
+      <span key="cwd" style={{ fontFamily: MONO_FONT }}>
+        {cwdDisplay}
+      </span>,
+    )
+  }
+
+  if (git?.branch) {
+    items.push(
+      <span
+        key="git"
+        className="text-accent opacity-80"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        {formatGitLabel(git)}
+      </span>,
+    )
+  }
+
+  if (shellRunning > 0) {
+    items.push(
+      <span key="shells" className="flex items-center gap-1">
+        <RunningDot />
+        {shellRunning}
+      </span>,
+    )
+  }
+
+  if (claudeRunning > 0) {
+    items.push(
+      <span key="claude" className="flex items-center gap-1">
+        <RunningDot />
+        <span style={{ fontFamily: MONO_FONT }}>claude {claudeRunning}</span>
+      </span>,
+    )
+  }
+
+  if (codexRunning > 0) {
+    items.push(
+      <span key="codex" className="flex items-center gap-1">
+        <RunningDot />
+        <span style={{ fontFamily: MONO_FONT }}>codex {codexRunning}</span>
+      </span>,
+    )
+  }
+
+  if (anyDanger) {
+    items.push(<DangerBadge key="danger" size={10} />)
+  }
+
+  if (items.length === 0) return null
+
+  return (
+    <div className="mr-auto flex min-w-0 items-center gap-1.5 overflow-hidden">
+      {items.map((item, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static order, no reordering
+        <span key={i} className="flex items-center gap-1.5">
+          {i > 0 && <Dot />}
+          {item}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/StatusBar/StatusBarRight.tsx
+++ b/src/components/StatusBar/StatusBarRight.tsx
@@ -71,7 +71,7 @@ function Dot() {
  * Formats a memory value from kilobytes to a human-readable string.
  *   < 1 MB  → "NKB"
  *   < 1 GB  → "NMB"
- *   >= 1 GB → "N.NGb"   (rare for a terminal process but handled)
+ *   >= 1 GB → "N.NGB"   (rare for a terminal process but handled)
  */
 function formatMemory(kb: number): string {
   if (kb < 1024) return `${kb}KB`

--- a/src/components/StatusBar/StatusBarRight.tsx
+++ b/src/components/StatusBar/StatusBarRight.tsx
@@ -1,9 +1,19 @@
 import { useStore } from '@nanostores/react'
-import { hasDangerFlag, parseModelFlag } from '@/components/agent.helpers'
-import { DangerBadge } from '@/components/DangerBadge'
+import type React from 'react'
+import { parseModelFlag } from '@/components/agent.helpers'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
-import { MONO_FONT, makeTabKey } from '@/screens/workspace/workspace.helpers'
+import {
+  cwdBasename,
+  MONO_FONT,
+  makeTabKey,
+} from '@/screens/workspace/workspace.helpers'
 
 /* ---------------------------------------------------------------------------
  * StatusBarRight — active session state
@@ -14,20 +24,24 @@ import { MONO_FONT, makeTabKey } from '@/screens/workspace/workspace.helpers'
  * ProcessInspectorMod, but the component stays type-agnostic so it will
  * automatically work for any future tab type that provides process data.
  *
+ * CWD and git are always appended when available, regardless of proc data.
+ *
  * Tab with live process data (currently agent tabs only):
  *
- *   name · pid · elapsed · memory · :port1 :port2 · model · 🤘
- *   │      │     │         │        │                │       └── danger flag active
- *   │      │     │         │        │                └────────── --model flag value
- *   │      │     │         │        └─────────────────────────── listening TCP ports
- *   │      │     │         └──────────────────────────────────── RSS memory (MB)
- *   │      │     └────────────────────────────────────────────── wall-clock elapsed
- *   │      └──────────────────────────────────────────────────── process PID
- *   └─────────────────────────────────────────────────────────── process name
+ *   name · pid · elapsed · memory · :port1 :port2 · model · branch · /cwd
+ *   │      │     │         │        │                │       │         │
+ *   │      │     │         │        │                │       │         └── CWD basename (tooltip = full path)
+ *   │      │     │         │        │                │       └─────────── git branch + dirty (*) + ahead (+N)
+ *   │      │     │         │        │                └─────────────────── --model flag value
+ *   │      │     │         │        └──────────────────────────────────── listening TCP ports
+ *   │      │     │         └───────────────────────────────────────────── RSS memory (MB)
+ *   │      │     └─────────────────────────────────────────────────────── wall-clock elapsed
+ *   │      └───────────────────────────────────────────────────────────── process PID
+ *   └──────────────────────────────────────────────────────────────────── process name
  *
  * Tab with no process data (shell tabs, or agent tabs before first poll):
  *
- *   status   (running / done / error — hidden when idle)
+ *   status · branch · /cwd   (status hidden when idle)
  *
  * Items are separated by a dim mid-dot (·).
  * -------------------------------------------------------------------------*/
@@ -54,6 +68,19 @@ function formatMemory(kb: number): string {
   return `${(mb / 1024).toFixed(1)}GB`
 }
 
+/** Formats git info into a compact `branch*+N-N` string. */
+function formatGitLabel(git: {
+  branch: string
+  isDirty: boolean
+  aheadBy: number
+  behindBy: number
+}): string {
+  const dirty = git.isDirty ? '*' : ''
+  const ahead = git.aheadBy > 0 ? `+${git.aheadBy}` : ''
+  const behind = git.behindBy > 0 ? `-${git.behindBy}` : ''
+  return `${git.branch}${dirty}${ahead}${behind}`
+}
+
 export function StatusBarRight() {
   const allTabMeta = useStore($tabMeta)
   const activeProjectId = useStore($activeProjectId)
@@ -66,7 +93,9 @@ export function StatusBarRight() {
 
   if (!meta) return null
 
-  const { status, agentCmd, processes, listeningPorts } = meta
+  const { status, agentCmd, processes, listeningPorts, cwd, git } = meta
+
+  const items: React.ReactNode[] = []
 
   // ── Any tab with live process data ───────────────────────────────────────
   // Gate on proc being present, not on tab type, so this works for any tab
@@ -75,9 +104,8 @@ export function StatusBarRight() {
   if (proc) {
     const model = parseModelFlag(agentCmd)
     const ports = listeningPorts ?? []
-    const isDanger = hasDangerFlag(agentCmd)
 
-    const items: React.ReactNode[] = [
+    items.push(
       <span key="name" style={{ fontFamily: MONO_FONT }}>
         {proc.name}
       </span>,
@@ -90,7 +118,7 @@ export function StatusBarRight() {
       <span key="mem" style={{ fontFamily: MONO_FONT }}>
         {formatMemory(proc.memoryKb)}
       </span>,
-    ]
+    )
 
     if (ports.length > 0) {
       items.push(
@@ -115,47 +143,71 @@ export function StatusBarRight() {
         </span>,
       )
     }
-
-    if (isDanger) {
-      items.push(<DangerBadge key="danger" size={10} />)
+  } else if (status !== 'idle') {
+    // ── Tab with no process data yet — show status text ───────────────────
+    const statusColor: Record<string, string> = {
+      running: 'var(--terminal-green)',
+      done: 'var(--terminal-green)',
+      error: 'var(--terminal-red)',
     }
+    const label: Record<string, string> = {
+      running: 'running',
+      done: 'done',
+      error: 'error',
+    }
+    if (label[status]) {
+      items.push(
+        <span
+          key="status"
+          style={{ fontFamily: MONO_FONT, color: statusColor[status] }}
+        >
+          {label[status]}
+        </span>,
+      )
+    }
+  }
 
-    return (
-      <div className="ml-auto flex min-w-0 shrink-0 items-center gap-1.5 overflow-hidden">
-        {items.map((item, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static order, no reordering
-          <span key={i} className="flex items-center gap-1.5">
-            {i > 0 && <Dot />}
-            {item}
-          </span>
-        ))}
-      </div>
+  // ── Git branch — always shown when available (second from right) ─────────
+  if (git?.branch) {
+    items.push(
+      <span
+        key="git"
+        className="text-accent opacity-80"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        {formatGitLabel(git)}
+      </span>,
     )
   }
 
-  // ── Tab with no process data yet ─────────────────────────────────────────
-  // Only show when there's something interesting to say (not idle).
-  if (status === 'idle') return null
-
-  const statusLabel: Record<string, string> = {
-    running: 'running',
-    done: 'done',
-    error: 'error',
+  // ── CWD — always shown when available (rightmost), full path on hover ────
+  if (cwd) {
+    items.push(
+      <TooltipProvider key="cwd">
+        <Tooltip>
+          <TooltipTrigger
+            className="cursor-default appearance-none border-0 bg-transparent p-0 text-[11px] text-inherit"
+            style={{ fontFamily: MONO_FONT }}
+          >
+            {cwdBasename(cwd)}
+          </TooltipTrigger>
+          <TooltipContent side="top">{cwd}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    )
   }
-  const label = statusLabel[status]
-  if (!label) return null
 
-  const statusColor: Record<string, string> = {
-    running: 'var(--terminal-green)',
-    done: 'var(--terminal-green)',
-    error: 'var(--terminal-red)',
-  }
+  if (items.length === 0) return null
 
   return (
-    <div className="ml-auto flex shrink-0 items-center">
-      <span style={{ fontFamily: MONO_FONT, color: statusColor[status] }}>
-        {label}
-      </span>
+    <div className="ml-auto flex min-w-0 shrink-0 items-center gap-1.5 overflow-hidden">
+      {items.map((item, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static order, no reordering
+        <span key={i} className="flex items-center gap-1.5">
+          {i > 0 && <Dot />}
+          {item}
+        </span>
+      ))}
     </div>
   )
 }

--- a/src/components/StatusBar/StatusBarRight.tsx
+++ b/src/components/StatusBar/StatusBarRight.tsx
@@ -1,0 +1,155 @@
+import { useStore } from '@nanostores/react'
+import { hasDangerFlag, parseModelFlag } from '@/components/agent.helpers'
+import { DangerBadge } from '@/components/DangerBadge'
+import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
+import { MONO_FONT, makeTabKey } from '@/screens/workspace/workspace.helpers'
+
+/* ---------------------------------------------------------------------------
+ * StatusBarRight — active session state
+ *
+ * Shows runtime metadata for the currently focused tab.
+ *
+ * Agent tabs with live process data:
+ *
+ *   name · pid · elapsed · memory · :port1 :port2 · model · 🤘
+ *   │      │     │         │        │                │       └── danger flag active
+ *   │      │     │         │        │                └────────── --model flag value
+ *   │      │     │         │        └─────────────────────────── listening TCP ports
+ *   │      │     │         └──────────────────────────────────── RSS memory (MB)
+ *   │      │     └────────────────────────────────────────────── wall-clock elapsed
+ *   │      └──────────────────────────────────────────────────── agent process PID
+ *   └─────────────────────────────────────────────────────────── agent process name
+ *
+ * Shell tabs / agent tabs with no process data yet:
+ *
+ *   status   (running / done / error — hidden when idle)
+ *
+ * Items are separated by a dim mid-dot (·).
+ * -------------------------------------------------------------------------*/
+
+/** Thin separator dot between status bar items. */
+function Dot() {
+  return (
+    <span aria-hidden="true" style={{ opacity: 0.3 }}>
+      ·
+    </span>
+  )
+}
+
+/**
+ * Formats a memory value from kilobytes to a human-readable string.
+ *   < 1 MB  → "NKB"
+ *   < 1 GB  → "NMB"
+ *   >= 1 GB → "N.NGb"   (rare for a terminal process but handled)
+ */
+function formatMemory(kb: number): string {
+  if (kb < 1024) return `${kb}KB`
+  const mb = kb / 1024
+  if (mb < 1024) return `${Math.round(mb)}MB`
+  return `${(mb / 1024).toFixed(1)}GB`
+}
+
+export function StatusBarRight() {
+  const allTabMeta = useStore($tabMeta)
+  const activeProjectId = useStore($activeProjectId)
+  const activeTabIds = useStore($activeTabId)
+
+  const activeTabId = activeTabIds[activeProjectId] ?? ''
+  const meta = activeTabId
+    ? allTabMeta[makeTabKey(activeProjectId, activeTabId)]
+    : undefined
+
+  if (!meta) return null
+
+  const { type, status, agentCmd, processes, listeningPorts } = meta
+
+  // ── Agent tab with live process data ─────────────────────────────────────
+  const proc = processes?.[0]
+  if (type === 'agent' && proc) {
+    const model = parseModelFlag(agentCmd)
+    const ports = listeningPorts ?? []
+    const isDanger = hasDangerFlag(agentCmd)
+
+    const items: React.ReactNode[] = [
+      <span key="name" style={{ fontFamily: MONO_FONT }}>
+        {proc.name}
+      </span>,
+      <span key="pid" style={{ fontFamily: MONO_FONT, opacity: 0.6 }}>
+        {proc.pid}
+      </span>,
+      <span key="elapsed" style={{ fontFamily: MONO_FONT }}>
+        {proc.elapsedTime}
+      </span>,
+      <span key="mem" style={{ fontFamily: MONO_FONT }}>
+        {formatMemory(proc.memoryKb)}
+      </span>,
+    ]
+
+    if (ports.length > 0) {
+      items.push(
+        <span
+          key="ports"
+          style={{ fontFamily: MONO_FONT }}
+          className="text-accent opacity-80"
+        >
+          {ports.map((p) => `:${p}`).join(' ')}
+        </span>,
+      )
+    }
+
+    if (model) {
+      items.push(
+        <span
+          key="model"
+          style={{ fontFamily: MONO_FONT }}
+          className="opacity-60"
+        >
+          {model}
+        </span>,
+      )
+    }
+
+    if (isDanger) {
+      items.push(<DangerBadge key="danger" size={10} />)
+    }
+
+    return (
+      <div className="ml-auto flex min-w-0 shrink-0 items-center gap-1.5 overflow-hidden">
+        {items.map((item, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static order, no reordering
+          <span key={i} className="flex items-center gap-1.5">
+            {i > 0 && <Dot />}
+            {item}
+          </span>
+        ))}
+      </div>
+    )
+  }
+
+  // ── Shell tab or agent with no process data yet ───────────────────────────
+  // Only show when there's something interesting to say (not idle).
+  if (status === 'idle') return null
+
+  const statusLabel: Record<string, string> = {
+    running: 'running',
+    done: 'done',
+    error: 'error',
+  }
+  const label = statusLabel[status]
+  if (!label) return null
+
+  const statusColor: Record<string, string> = {
+    running: 'var(--terminal-green)',
+    done: 'var(--terminal-green)',
+    error: 'var(--terminal-red)',
+  }
+
+  return (
+    <div className="ml-auto flex shrink-0 items-center">
+      <span style={{ fontFamily: MONO_FONT, color: statusColor[status] }}>
+        {label}
+      </span>
+    </div>
+  )
+}

--- a/src/components/StatusBar/StatusBarRight.tsx
+++ b/src/components/StatusBar/StatusBarRight.tsx
@@ -8,9 +8,13 @@ import { MONO_FONT, makeTabKey } from '@/screens/workspace/workspace.helpers'
 /* ---------------------------------------------------------------------------
  * StatusBarRight — active session state
  *
- * Shows runtime metadata for the currently focused tab.
+ * Shows runtime metadata for the currently focused tab. The rich view fires
+ * for ANY tab type that has live process data — the gate is `proc != null`,
+ * not `type === 'agent'`. Today only agent tabs populate `processes` via
+ * ProcessInspectorMod, but the component stays type-agnostic so it will
+ * automatically work for any future tab type that provides process data.
  *
- * Agent tabs with live process data:
+ * Tab with live process data (currently agent tabs only):
  *
  *   name · pid · elapsed · memory · :port1 :port2 · model · 🤘
  *   │      │     │         │        │                │       └── danger flag active
@@ -18,10 +22,10 @@ import { MONO_FONT, makeTabKey } from '@/screens/workspace/workspace.helpers'
  *   │      │     │         │        └─────────────────────────── listening TCP ports
  *   │      │     │         └──────────────────────────────────── RSS memory (MB)
  *   │      │     └────────────────────────────────────────────── wall-clock elapsed
- *   │      └──────────────────────────────────────────────────── agent process PID
- *   └─────────────────────────────────────────────────────────── agent process name
+ *   │      └──────────────────────────────────────────────────── process PID
+ *   └─────────────────────────────────────────────────────────── process name
  *
- * Shell tabs / agent tabs with no process data yet:
+ * Tab with no process data (shell tabs, or agent tabs before first poll):
  *
  *   status   (running / done / error — hidden when idle)
  *
@@ -62,11 +66,13 @@ export function StatusBarRight() {
 
   if (!meta) return null
 
-  const { type, status, agentCmd, processes, listeningPorts } = meta
+  const { status, agentCmd, processes, listeningPorts } = meta
 
-  // ── Agent tab with live process data ─────────────────────────────────────
+  // ── Any tab with live process data ───────────────────────────────────────
+  // Gate on proc being present, not on tab type, so this works for any tab
+  // type that populates `processes` in the future.
   const proc = processes?.[0]
-  if (type === 'agent' && proc) {
+  if (proc) {
     const model = parseModelFlag(agentCmd)
     const ports = listeningPorts ?? []
     const isDanger = hasDangerFlag(agentCmd)
@@ -127,7 +133,7 @@ export function StatusBarRight() {
     )
   }
 
-  // ── Shell tab or agent with no process data yet ───────────────────────────
+  // ── Tab with no process data yet ─────────────────────────────────────────
   // Only show when there's something interesting to say (not idle).
   if (status === 'idle') return null
 

--- a/src/components/StatusBar/StatusBarRight.tsx
+++ b/src/components/StatusBar/StatusBarRight.tsx
@@ -1,4 +1,14 @@
 import { useStore } from '@nanostores/react'
+import {
+  Download,
+  FolderOpen,
+  GitBranch,
+  MemoryStick,
+  Plug,
+  Sparkles,
+  Timer,
+  Upload,
+} from 'lucide-react'
 import type React from 'react'
 import { parseModelFlag } from '@/components/agent.helpers'
 import {
@@ -8,7 +18,11 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
-import { $tabMeta } from '@/modules/stores/$tabMeta'
+import {
+  $tabMeta,
+  type GitInfo,
+  type ProcessInfo,
+} from '@/modules/stores/$tabMeta'
 import {
   cwdBasename,
   MONO_FONT,
@@ -28,21 +42,19 @@ import {
  *
  * Tab with live process data (currently agent tabs only):
  *
- *   name · pid · elapsed · memory · :port1 :port2 · model · branch · /cwd
- *   │      │     │         │        │                │       │         │
- *   │      │     │         │        │                │       │         └── CWD basename (tooltip = full path)
- *   │      │     │         │        │                │       └─────────── git branch + dirty (*) + ahead (+N)
- *   │      │     │         │        │                └─────────────────── --model flag value
- *   │      │     │         │        └──────────────────────────────────── listening TCP ports
- *   │      │     │         └───────────────────────────────────────────── RSS memory (MB)
- *   │      │     └─────────────────────────────────────────────────────── wall-clock elapsed
- *   │      └───────────────────────────────────────────────────────────── process PID
- *   └──────────────────────────────────────────────────────────────────── process name
+ *   name · pid · ⏱ elapsed · 🧮 memory · 🔌 :port1 :port2 · ✨ model · ⎇ branch [●] [↑N] [↓N] · 📂 /cwd
+ *   │      │                                                              │                              │
+ *   │      │                                                              │                              └── FolderOpen + CWD basename (tooltip = full path)
+ *   │      │                                                              └─────────────────────────────── GitBranch + name; ● if dirty; Upload N if ahead; Download N if behind
+ *   │      └──────────────────────────────────────────────────────────────────────────────────────────── process PID (no icon — self-describing number)
+ *   └─────────────────────────────────────────────────────────────────────────────────────────────────── process name (no icon — agent name is already a label)
  *
  * Tab with no process data (shell tabs, or agent tabs before first poll):
  *
- *   status · branch · /cwd   (status hidden when idle)
+ *   status · ⎇ branch [●] [↑N] [↓N] · 📂 /cwd   (status hidden when idle)
  *
+ * Icon sizing: size=10, strokeWidth=1.5 — visually balanced against 11px mono text.
+ * Icon opacity: matches the opacity of the adjacent text item.
  * Items are separated by a dim mid-dot (·).
  * -------------------------------------------------------------------------*/
 
@@ -68,17 +80,153 @@ function formatMemory(kb: number): string {
   return `${(mb / 1024).toFixed(1)}GB`
 }
 
-/** Formats git info into a compact `branch*+N-N` string. */
-function formatGitLabel(git: {
-  branch: string
-  isDirty: boolean
-  aheadBy: number
-  behindBy: number
-}): string {
-  const dirty = git.isDirty ? '*' : ''
-  const ahead = git.aheadBy > 0 ? `+${git.aheadBy}` : ''
-  const behind = git.behindBy > 0 ? `-${git.behindBy}` : ''
-  return `${git.branch}${dirty}${ahead}${behind}`
+/**
+ * Builds the list of items shown when the tab has live process data.
+ * Extracted to keep StatusBarRight's cognitive complexity under the lint limit.
+ *
+ * Always includes: name, pid, elapsed (Timer icon), memory (MemoryStick icon).
+ * Conditionally includes: ports (Plug icon), model (Sparkles icon).
+ */
+function buildProcItems(
+  proc: ProcessInfo,
+  ports: number[],
+  model: string | null,
+): React.ReactNode[] {
+  const items: React.ReactNode[] = [
+    // Process name + PID: no icons — both are already self-describing labels.
+    <span key="name" style={{ fontFamily: MONO_FONT }}>
+      {proc.name}
+    </span>,
+    <span key="pid" style={{ fontFamily: MONO_FONT, opacity: 0.6 }}>
+      {proc.pid}
+    </span>,
+    // Timer icon: elapsed wall-clock time since process started.
+    <span
+      key="elapsed"
+      className="flex items-center gap-1"
+      style={{ fontFamily: MONO_FONT }}
+    >
+      <Timer
+        aria-hidden="true"
+        size={10}
+        strokeWidth={1.5}
+        className="shrink-0 opacity-50"
+      />
+      {proc.elapsedTime}
+    </span>,
+    // MemoryStick icon: RSS memory usage.
+    <span
+      key="mem"
+      className="flex items-center gap-1"
+      style={{ fontFamily: MONO_FONT }}
+    >
+      <MemoryStick
+        aria-hidden="true"
+        size={10}
+        strokeWidth={1.5}
+        className="shrink-0 opacity-50"
+      />
+      {formatMemory(proc.memoryKb)}
+    </span>,
+  ]
+
+  if (ports.length > 0) {
+    // Plug icon: listening TCP socket.
+    items.push(
+      <span
+        key="ports"
+        className="flex items-center gap-1 text-accent opacity-80"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        <Plug
+          aria-hidden="true"
+          size={10}
+          strokeWidth={1.5}
+          className="shrink-0"
+        />
+        {ports.map((p) => `:${p}`).join(' ')}
+      </span>,
+    )
+  }
+
+  if (model) {
+    // Sparkles icon: --model flag value (AI model context).
+    items.push(
+      <span
+        key="model"
+        className="flex items-center gap-1 opacity-60"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        <Sparkles
+          aria-hidden="true"
+          size={10}
+          strokeWidth={1.5}
+          className="shrink-0"
+        />
+        {model}
+      </span>,
+    )
+  }
+
+  return items
+}
+
+/**
+ * Renders the git branch item with individual icons for each sync signal.
+ *
+ *   GitBranch icon + branch name
+ *   ● (dim dot) if there are uncommitted local changes
+ *   Upload icon + N if N commits ahead of remote (push needed)
+ *   Download icon + N if N commits behind remote (pull needed)
+ *
+ * All signals are grouped inside a single flex span so they separate from
+ * adjacent items with one dot, not multiple dots.
+ */
+function GitItem({ git }: { git: GitInfo }) {
+  return (
+    <span
+      className="flex items-center gap-1 text-accent opacity-80"
+      style={{ fontFamily: MONO_FONT }}
+    >
+      <GitBranch
+        aria-hidden="true"
+        size={10}
+        strokeWidth={1.5}
+        className="shrink-0"
+      />
+      {git.branch}
+      {git.isDirty && (
+        // Decorative dot signals uncommitted changes — replaces the old "*" suffix.
+        <span aria-hidden="true" className="opacity-70">
+          ●
+        </span>
+      )}
+      {git.aheadBy > 0 && (
+        // Upload icon: commits ahead of remote — a push is needed.
+        <span className="flex items-center gap-0.5">
+          <Upload
+            aria-hidden="true"
+            size={10}
+            strokeWidth={1.5}
+            className="shrink-0"
+          />
+          {git.aheadBy}
+        </span>
+      )}
+      {git.behindBy > 0 && (
+        // Download icon: commits behind remote — a pull is needed.
+        <span className="flex items-center gap-0.5">
+          <Download
+            aria-hidden="true"
+            size={10}
+            strokeWidth={1.5}
+            className="shrink-0"
+          />
+          {git.behindBy}
+        </span>
+      )}
+    </span>
+  )
 }
 
 export function StatusBarRight() {
@@ -104,45 +252,7 @@ export function StatusBarRight() {
   if (proc) {
     const model = parseModelFlag(agentCmd)
     const ports = listeningPorts ?? []
-
-    items.push(
-      <span key="name" style={{ fontFamily: MONO_FONT }}>
-        {proc.name}
-      </span>,
-      <span key="pid" style={{ fontFamily: MONO_FONT, opacity: 0.6 }}>
-        {proc.pid}
-      </span>,
-      <span key="elapsed" style={{ fontFamily: MONO_FONT }}>
-        {proc.elapsedTime}
-      </span>,
-      <span key="mem" style={{ fontFamily: MONO_FONT }}>
-        {formatMemory(proc.memoryKb)}
-      </span>,
-    )
-
-    if (ports.length > 0) {
-      items.push(
-        <span
-          key="ports"
-          style={{ fontFamily: MONO_FONT }}
-          className="text-accent opacity-80"
-        >
-          {ports.map((p) => `:${p}`).join(' ')}
-        </span>,
-      )
-    }
-
-    if (model) {
-      items.push(
-        <span
-          key="model"
-          style={{ fontFamily: MONO_FONT }}
-          className="opacity-60"
-        >
-          {model}
-        </span>,
-      )
-    }
+    items.push(...buildProcItems(proc, ports, model))
   } else if (status !== 'idle') {
     // ── Tab with no process data yet — show status text ───────────────────
     const statusColor: Record<string, string> = {
@@ -169,26 +279,25 @@ export function StatusBarRight() {
 
   // ── Git branch — always shown when available (second from right) ─────────
   if (git?.branch) {
-    items.push(
-      <span
-        key="git"
-        className="text-accent opacity-80"
-        style={{ fontFamily: MONO_FONT }}
-      >
-        {formatGitLabel(git)}
-      </span>,
-    )
+    items.push(<GitItem key="git" git={git} />)
   }
 
   // ── CWD — always shown when available (rightmost), full path on hover ────
+  // FolderOpen icon: active working directory. Tooltip reveals the full path.
   if (cwd) {
     items.push(
       <TooltipProvider key="cwd">
         <Tooltip>
           <TooltipTrigger
-            className="cursor-default appearance-none border-0 bg-transparent p-0 text-[11px] text-inherit"
+            className="flex cursor-default appearance-none items-center gap-1 border-0 bg-transparent p-0 text-[11px] text-inherit"
             style={{ fontFamily: MONO_FONT }}
           >
+            <FolderOpen
+              aria-hidden="true"
+              size={10}
+              strokeWidth={1.5}
+              className="shrink-0 opacity-60"
+            />
             {cwdBasename(cwd)}
           </TooltipTrigger>
           <TooltipContent side="top">{cwd}</TooltipContent>


### PR DESCRIPTION
## Summary

Implements the **Status Bar V1 Extended** — a full-width split layout replacing the previous placeholder bar.

### Left side — workspace overview (global)

Aggregate counts across all tabs in all projects. Renders nothing when the workspace is idle.

- `● N active agents` — claude + codex sessions currently running
- `● X active tasks` — shell tabs currently running
- `Y failed tasks` — any tab in error state (shown in red)

### Right side — active tab context (switches on tab focus)

All active-tab metadata in one place. CWD and git are always shown when available regardless of whether there is live process data, so even idle shell tabs show their directory and branch.

**With live process data (agent tabs):**
`name · pid · ⏱ elapsed · 🧮 memory · 🔌 :ports · ✨ model · ⎇ branch [●] [↑N] [↓N] · 📂 /cwd`

**Without process data (shell tabs):**
`status · ⎇ branch [●] [↑N] [↓N] · 📂 /cwd`

**Git signals** are split into discrete icons rather than a combined string:
- `GitBranch` icon + branch name
- `●` dim dot if there are uncommitted local changes (replaces the old `*` suffix)
- `Upload N` if N commits ahead of remote (push needed)
- `Download N` if N commits behind remote (pull needed)

**CWD** shows the basename with a tooltip revealing the full path on hover.

### Files changed

| File | Change |
|------|--------|
| `StatusBar.tsx` | Rewritten as thin orchestrator |
| `StatusBarLeft.tsx` | New — workspace aggregate counts |
| `StatusBarRight.tsx` | New — active tab process info, git, CWD with lucide icons |