### PR TITLE
fix(pty): self-healing reconnection for orphaned PTY sessions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -33,7 +33,10 @@ pub async fn open_tab(
     //    spawn_pty. Returns true.
     match try_reattach(app.clone(), &pty_map, mod_engine.handle(), &tab_id, on_data.clone()) {
         Ok(ReattachResult::ChannelUpdated) | Ok(ReattachResult::Reattached) => {
-            // Notify the frontend so it can write a "[Reconnected]" banner.
+            // The [Reconnected] banner is written directly to the data channel
+            // inside try_reattach — no listener timing gap. This event is emitted
+            // for any future consumers that want to react to reconnects without
+            // rendering text (e.g. status bar state, telemetry).
             app.emit("pty:reconnected", serde_json::json!({ "tabId": &tab_id })).ok();
             return Ok(false);
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,8 +1,8 @@
 use crate::mod_engine::ModEngine;
-use crate::pty_manager::{spawn_pty, PtyDataPayload, PtyMap};
+use crate::pty_manager::{spawn_pty, try_reattach, PtyDataPayload, PtyMap, ReattachResult};
 use portable_pty::PtySize;
 use std::io::Write;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, State};
 use tauri::ipc::Channel;
 
 #[tauri::command]
@@ -15,12 +15,40 @@ pub async fn open_tab(
     shell: Option<String>,
     on_data: Channel<PtyDataPayload>,
 ) -> Result<bool, String> {
-    // Returns true if a new pty was spawned, false if one was already running.
-    // The frontend uses this to decide whether to wait for the initial prompt
-    // or send \r to re-display the prompt on a freshly-mounted terminal.
-    if pty_map.lock().unwrap().contains_key(&tab_id) {
-        return Ok(false);
+    // Returns true  → new PTY spawned; frontend waits for the initial prompt.
+    // Returns false → existing PTY (live or just reattached); frontend sends \r
+    //                 to make the shell redraw its prompt.
+    //
+    // Three cases are handled here before falling through to spawn_pty:
+    //
+    // 1. Reader alive — already connected (StrictMode double-mount, tab switch).
+    //    No action needed; return false.
+    //
+    // 2. Reader dead, child alive — WebView previously disconnected (window
+    //    close/reopen, HMR reload). Reattach: a new reader thread is wired to
+    //    the existing PTY master fd and the new Channel. The PTY process (shell
+    //    or running agent) is undisturbed. Returns false so the frontend sends
+    //    \r and the shell redraws its prompt.
+    //
+    // 3. Reader dead, child exited — PTY is truly dead. The stale PtyMap entry
+    //    is removed and a fresh PTY is spawned below. Returns true.
+    match try_reattach(app.clone(), &pty_map, mod_engine.handle(), &tab_id, on_data.clone()) {
+        Ok(ReattachResult::AlreadyLive) => {
+            return Ok(false);
+        }
+        Ok(ReattachResult::Reattached) => {
+            // Notify the frontend so it can show a "[Reconnected]" banner.
+            // This fires after the reader thread is already running, so the
+            // banner appears before any buffered PTY output is flushed.
+            app.emit("pty:reconnected", serde_json::json!({ "tabId": &tab_id })).ok();
+            return Ok(false);
+        }
+        Ok(ReattachResult::Expired) | Ok(ReattachResult::NotFound) => {
+            // Fall through to fresh spawn below.
+        }
+        Err(e) => return Err(e),
     }
+
     spawn_pty(app, &pty_map, mod_engine.handle(), tab_id, cwd, shell, on_data)?;
     Ok(true)
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,27 +19,21 @@ pub async fn open_tab(
     // Returns false → existing PTY (live or just reattached); frontend sends \r
     //                 to make the shell redraw its prompt.
     //
-    // Three cases are handled here before falling through to spawn_pty:
+    // Three cases handled before falling through to spawn_pty:
     //
-    // 1. Reader alive — already connected (StrictMode double-mount, tab switch).
-    //    No action needed; return false.
+    // 1. ChannelUpdated — reader thread is alive and blocking on read(). The
+    //    shared Channel ref has been swapped to the new WebView connection.
+    //    Output resumes on the next byte from the PTY. Returns false.
     //
-    // 2. Reader dead, child alive — WebView previously disconnected (window
-    //    close/reopen, HMR reload). Reattach: a new reader thread is wired to
-    //    the existing PTY master fd and the new Channel. The PTY process (shell
-    //    or running agent) is undisturbed. Returns false so the frontend sends
-    //    \r and the shell redraws its prompt.
+    // 2. Reattached — reader thread had already exited before the reconnect
+    //    arrived (rare race: PTY EOF beat the reconnect). A new reader thread
+    //    is spawned on the same master fd. Returns false.
     //
-    // 3. Reader dead, child exited — PTY is truly dead. The stale PtyMap entry
-    //    is removed and a fresh PTY is spawned below. Returns true.
+    // 3. Expired / NotFound — child exited or no entry. Fall through to a fresh
+    //    spawn_pty. Returns true.
     match try_reattach(app.clone(), &pty_map, mod_engine.handle(), &tab_id, on_data.clone()) {
-        Ok(ReattachResult::AlreadyLive) => {
-            return Ok(false);
-        }
-        Ok(ReattachResult::Reattached) => {
-            // Notify the frontend so it can show a "[Reconnected]" banner.
-            // This fires after the reader thread is already running, so the
-            // banner appears before any buffered PTY output is flushed.
+        Ok(ReattachResult::ChannelUpdated) | Ok(ReattachResult::Reattached) => {
+            // Notify the frontend so it can write a "[Reconnected]" banner.
             app.emit("pty:reconnected", serde_json::json!({ "tabId": &tab_id })).ok();
             return Ok(false);
         }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -118,8 +118,10 @@ fn spawn_reader_thread(
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => {
                     // PTY process exited or master fd closed (close_tab called).
-                    // Clear the channel before emitting exit so no stale sends
-                    // race the teardown.
+                    // Mark dead immediately — before emitting pty:exit or calling
+                    // on_tab_close — so try_reattach cannot observe reader_alive=true
+                    // on a thread that is in the process of exiting.
+                    reader_alive.store(false, Ordering::Relaxed);
                     channel.lock().unwrap().take();
                     app.emit(
                         "pty:exit",
@@ -139,9 +141,10 @@ fn spawn_reader_thread(
                             Some(ch) => {
                                 ch.send(PtyDataPayload { data: data.clone() }).is_ok()
                             }
-                            // No channel — WebView is disconnected. Discard and
-                            // keep reading so the reader thread stays alive for
-                            // the next open_tab call.
+                            // No channel — WebView is disconnected. Terminal
+                            // forwarding is skipped but MODs still receive output
+                            // so their state stays current for when the frontend
+                            // reconnects.
                             None => true,
                         }
                     };
@@ -153,17 +156,14 @@ fn spawn_reader_thread(
                         // and open_tab will swap in a new channel on reconnect.
                         // Output from this read is lost; no replay buffer.
                         channel.lock().unwrap().take();
-                    } else {
-                        // Forward to MOD engine — non-blocking, silently drops
-                        // under load. The terminal always gets every byte.
-                        mod_handle.on_output(&tab_id, buf[..n].to_vec());
                     }
+                    // Always forward to MOD engine regardless of channel state —
+                    // MOD state (git, CWD, agent detection) must stay current
+                    // even while the WebView is disconnected.
+                    mod_handle.on_output(&tab_id, buf[..n].to_vec());
                 }
             }
         }
-
-        // Reader thread is exiting — only happens on PTY EOF or master fd close.
-        reader_alive.store(false, Ordering::Relaxed);
     });
 }
 
@@ -223,12 +223,11 @@ pub fn try_reattach(
         return Ok(ReattachResult::ChannelUpdated);
     }
 
-    // Reader thread exited before the reconnect arrived (it detected the dead
-    // channel, cleared it, and then... wait, in the new design the reader does
-    // NOT exit on channel failure). This branch is only reached if the PTY
-    // process itself sent EOF and reader_alive is false, but try_wait() above
-    // did not confirm child exit (race in zombie reaping). Spawn a fresh reader
-    // — it will see EOF quickly and emit pty:exit on its own.
+    // reader_alive is false but try_wait() did not confirm child exit. This
+    // happens when the PTY process exits and the reader thread sets reader_alive
+    // to false, but the OS has not yet reaped the zombie by the time try_wait()
+    // runs. Spawn a fresh reader on the same master fd — it will see EOF
+    // immediately and emit pty:exit on its own.
     let new_alive = Arc::new(AtomicBool::new(true));
     handle.reader_alive = new_alive.clone();
     let reader = handle.master.try_clone_reader().map_err(|e| e.to_string())?;

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -23,17 +23,28 @@ pub struct PtyExitPayload {
     pub tab_id: String,
 }
 
+/// The active frontend channel, shared between the reader thread and open_tab.
+///
+/// Wrapped in Arc<Mutex<Option<...>>> so open_tab can swap in a new Channel
+/// when the WebView reconnects without stopping or restarting the reader thread.
+/// The Option is None when the WebView is disconnected — the reader discards
+/// output silently during that window rather than exiting.
+pub type SharedChannel = Arc<Mutex<Option<Channel<PtyDataPayload>>>>;
+
 pub struct PtyHandle {
     pub master: Box<dyn portable_pty::MasterPty + Send>,
     pub writer: Box<dyn Write + Send>,
-    /// The child process (shell or agent). Kept alive so we can call
-    /// try_wait() during reconnect to distinguish "child still running but
-    /// channel dropped" from "child exited and PTY is truly dead".
+    /// The child process (shell or agent). Kept so open_tab can call try_wait()
+    /// to distinguish "child still running but WebView disconnected" (healable)
+    /// from "child exited and PTY is truly dead" (needs fresh spawn).
     pub child: Box<dyn portable_pty::Child + Send + Sync>,
-    /// Flipped to false by the reader thread when it exits — for any reason,
-    /// whether the channel was dropped (WebView disconnect) or the PTY process
-    /// exited. open_tab checks this flag to decide whether to reattach.
+    /// Flipped to false when the reader thread exits. Only exits on PTY EOF —
+    /// not on channel failure. Used to know whether a new reader thread must be
+    /// spawned if the reader somehow exited before the reconnect arrived.
     pub reader_alive: Arc<AtomicBool>,
+    /// The live frontend channel. Swapped by open_tab on reconnect without
+    /// touching the reader thread or the PTY process.
+    pub channel: SharedChannel,
 }
 
 pub type PtyMap = Arc<Mutex<HashMap<String, PtyHandle>>>;
@@ -49,51 +60,54 @@ const READ_BUF_SIZE: usize = 256 * 1024;
 
 /// Outcome returned by try_reattach — tells open_tab what happened.
 pub enum ReattachResult {
-    /// Reader thread was alive — already connected, no action taken.
-    AlreadyLive,
-    /// Reader was dead but child is still running — new reader thread spawned
-    /// on the existing PTY. The caller should return false (not a new session).
+    /// Channel was updated and the reader thread is still running. open_tab
+    /// should return false; the reader picks up the new channel on next output.
+    ChannelUpdated,
+    /// Channel was updated and a new reader thread was spawned (the previous one
+    /// had already exited before the reconnect arrived). open_tab returns false.
     Reattached,
-    /// Reader was dead and child has exited — stale PtyMap entry removed.
-    /// The caller should spawn a fresh PTY.
+    /// Child process has exited — PTY is truly dead. Stale entry removed.
+    /// open_tab should spawn a fresh PTY.
     Expired,
-    /// No PtyMap entry for this tab — caller should spawn a fresh PTY.
+    /// No PtyMap entry found. open_tab should spawn a fresh PTY.
     NotFound,
 }
 
-/// Spawns a dedicated reader thread that forwards PTY output to the frontend
-/// via the per-tab Channel.
+/// Spawns a dedicated reader thread that forwards PTY output to the frontend.
 ///
-/// Reader thread exit behaviour:
-/// - PTY process exits (read returns 0 or Err): emits `pty:exit`, calls
-///   on_tab_close, then exits. PTY is truly dead.
-/// - Channel dropped (send returns Err — WebView disconnected): exits silently.
-///   Does NOT emit pty:exit and does NOT call on_tab_close, because the PTY
-///   process is still running. MOD state is preserved so it can be resumed
-///   when the frontend reconnects.
+/// # Channel failure behaviour (self-healing contract)
 ///
-/// In both cases reader_alive is set to false before the thread exits,
-/// allowing open_tab to detect the stale state on reconnect.
+/// When on_data.send() fails (WebView disconnected, Channel JS object dropped),
+/// the reader thread does NOT exit. It clears the shared channel and keeps
+/// reading, discarding output until open_tab swaps in a new Channel.
 ///
-/// # Reconnection limitations
+/// This is the critical design choice that makes reconnection work regardless
+/// of timing: even if the reader thread is blocked on read() when the WebView
+/// disconnects, open_tab can safely hand it a new channel and the reader will
+/// start forwarding again on the very next byte of PTY output — no thread
+/// restart, no race on reader_alive.
 ///
-/// This mechanism heals WebView-restart disconnects (window close/reopen, HMR
-/// reload) by reattaching a new reader thread to the existing PTY master fd.
+/// # Known limitations
 ///
-/// It does NOT cover:
-/// - Output replay: bytes that the old reader thread read but could not send
-///   before the channel drop are gone. Output written by the PTY process after
-///   the channel dropped but before the new reader attaches may survive if still
-///   in the kernel PTY buffer, but this is not guaranteed.
-/// - Mid-session IPC drops while the WebView is still running: those require
-///   an active heartbeat/liveness probe, which is not implemented.
-/// - Full-app crash recovery: if the Tauri process exits, all PTY sessions are
-///   lost. A separate pty-host process (VS Code model) would be needed for that.
+/// - **No output replay**: bytes sent to the terminal between disconnect and
+///   reconnect are discarded. Output still in the kernel PTY buffer at the
+///   moment the channel is cleared may or may not be delivered — it depends on
+///   whether the send error is detected before or after that read() returns.
+///   A VS Code-style ring buffer would close this gap but is not implemented.
+///
+/// - **Mid-session drops only heal on next open_tab**: if the IPC channel dies
+///   while the WebView is still running (not a WebView restart), the reader
+///   clears its channel and goes silent — but nothing triggers open_tab again.
+///   A heartbeat/ping mechanism would be needed to detect and surface this.
+///
+/// - **Full-app crash**: if the Tauri process exits, all PTY sessions are lost.
+///   A separate long-lived pty-host process (VS Code model) would be needed
+///   for crash survival, and is out of scope for now.
 fn spawn_reader_thread(
     app: AppHandle,
     tab_id: String,
     mut reader: Box<dyn Read + Send>,
-    on_data: Channel<PtyDataPayload>,
+    channel: SharedChannel,
     mod_handle: ModEngineHandle,
     reader_alive: Arc<AtomicBool>,
 ) {
@@ -103,7 +117,10 @@ fn spawn_reader_thread(
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => {
-                    // PTY process exited or read error — PTY is dead.
+                    // PTY process exited or master fd closed (close_tab called).
+                    // Clear the channel before emitting exit so no stale sends
+                    // race the teardown.
+                    channel.lock().unwrap().take();
                     app.emit(
                         "pty:exit",
                         PtyExitPayload { tab_id: tab_id.clone() },
@@ -113,38 +130,49 @@ fn spawn_reader_thread(
                     break;
                 }
                 Ok(n) => {
-                    // Send to terminal — always first, never skipped.
-                    if on_data
-                        .send(PtyDataPayload {
-                            data: String::from_utf8_lossy(&buf[..n]).into_owned(),
-                        })
-                        .is_err()
-                    {
-                        // Channel dropped — WebView disconnected.
-                        // The PTY process is still running; do not emit pty:exit
-                        // and do not call on_tab_close. MOD state is intact and
-                        // the next open_tab call will reattach a new reader.
-                        break;
+                    let data = String::from_utf8_lossy(&buf[..n]).into_owned();
+
+                    // Lock briefly to send — released before calling on_output.
+                    let send_ok = {
+                        let guard = channel.lock().unwrap();
+                        match guard.as_ref() {
+                            Some(ch) => {
+                                ch.send(PtyDataPayload { data: data.clone() }).is_ok()
+                            }
+                            // No channel — WebView is disconnected. Discard and
+                            // keep reading so the reader thread stays alive for
+                            // the next open_tab call.
+                            None => true,
+                        }
+                    };
+
+                    if !send_ok {
+                        // Channel dropped mid-flight (WebView disconnected while
+                        // we were sending). Clear the dead channel and keep the
+                        // reader thread alive — the PTY process is still running
+                        // and open_tab will swap in a new channel on reconnect.
+                        // Output from this read is lost; no replay buffer.
+                        channel.lock().unwrap().take();
+                    } else {
+                        // Forward to MOD engine — non-blocking, silently drops
+                        // under load. The terminal always gets every byte.
+                        mod_handle.on_output(&tab_id, buf[..n].to_vec());
                     }
-                    // Forward to MOD engine — non-blocking, silently drops under load.
-                    // The terminal always gets every byte regardless of engine backpressure.
-                    mod_handle.on_output(&tab_id, buf[..n].to_vec());
                 }
             }
         }
 
-        // Always mark dead on exit, regardless of reason. open_tab reads this
-        // flag to decide whether a reattach is needed on the next call.
+        // Reader thread is exiting — only happens on PTY EOF or master fd close.
         reader_alive.store(false, Ordering::Relaxed);
     });
 }
 
-/// Checks whether the PTY for `tab_id` needs reconnection and, if so, handles
-/// it. Call this before spawn_pty so open_tab can short-circuit.
+/// Checks whether an existing PtyMap entry can be reconnected, and if so,
+/// wires up the new Channel and (if needed) a new reader thread.
 ///
-/// Returns a ReattachResult describing what happened. The caller acts on it:
-/// - AlreadyLive / Reattached → return Ok(false) to the frontend
-/// - Expired / NotFound → call spawn_pty, return Ok(true)
+/// Must be called before spawn_pty in open_tab. Acts on the result:
+/// - ChannelUpdated / Reattached → emit pty:reconnected, return Ok(false)
+/// - Expired / NotFound          → call spawn_pty, return Ok(true)
 pub fn try_reattach(
     app: AppHandle,
     pty_map: &PtyMap,
@@ -158,50 +186,37 @@ pub fn try_reattach(
         return Ok(ReattachResult::NotFound);
     };
 
+    // If the child has exited, the PTY is truly dead — remove the stale entry
+    // so the caller can spawn a fresh PTY.
+    if matches!(handle.child.try_wait(), Ok(Some(_))) {
+        map.remove(tab_id);
+        return Ok(ReattachResult::Expired);
+    }
+
+    // Child is still running (or indeterminate). Swap in the new channel.
+    // The reader thread — whether blocking on read() or actively discarding —
+    // will forward output via this channel on its next iteration.
+    *handle.channel.lock().unwrap() = Some(on_data);
+
     if handle.reader_alive.load(Ordering::Relaxed) {
-        // Reader is still running — normal reconnect path (StrictMode double
-        // mount, tab switch, etc.). Nothing to do.
-        return Ok(ReattachResult::AlreadyLive);
+        // Reader is running. Channel is updated. No thread restart needed.
+        return Ok(ReattachResult::ChannelUpdated);
     }
 
-    // Reader thread has exited. Determine whether the child process is alive.
-    // try_wait() is non-blocking: returns Ok(Some(_)) if exited, Ok(None) if
-    // still running, Err if the check itself failed.
-    match handle.child.try_wait() {
-        Ok(Some(_)) => {
-            // Child has exited — PTY is truly dead. Remove the stale entry so
-            // the caller can spawn a fresh PTY for this tab.
-            map.remove(tab_id);
-            Ok(ReattachResult::Expired)
-        }
-        _ => {
-            // Child is still running (try_wait returned Ok(None) or Err).
-            // Reattach: get a new read handle on the same PTY master fd and
-            // spin up a fresh reader thread wired to the new Channel.
-            //
-            // try_clone_reader() is the key API here — it creates a second
-            // Box<dyn Read + Send> on the existing master fd without disturbing
-            // the PTY or the process running inside it. The original read handle
-            // (held by the now-dead thread) has been dropped; this call is safe.
-            let reader = handle.master.try_clone_reader().map_err(|e| e.to_string())?;
+    // Reader thread exited before the reconnect arrived (it detected the dead
+    // channel, cleared it, and then... wait, in the new design the reader does
+    // NOT exit on channel failure). This branch is only reached if the PTY
+    // process itself sent EOF and reader_alive is false, but try_wait() above
+    // did not confirm child exit (race in zombie reaping). Spawn a fresh reader
+    // — it will see EOF quickly and emit pty:exit on its own.
+    let new_alive = Arc::new(AtomicBool::new(true));
+    handle.reader_alive = new_alive.clone();
+    let reader = handle.master.try_clone_reader().map_err(|e| e.to_string())?;
+    let channel = handle.channel.clone();
+    drop(map); // release the PtyMap lock before spawning
 
-            let new_alive = Arc::new(AtomicBool::new(true));
-            handle.reader_alive = new_alive.clone();
-
-            drop(map); // release the lock before spawning the thread
-
-            spawn_reader_thread(
-                app,
-                tab_id.to_string(),
-                reader,
-                on_data,
-                mod_handle,
-                new_alive,
-            );
-
-            Ok(ReattachResult::Reattached)
-        }
-    }
+    spawn_reader_thread(app, tab_id.to_string(), reader, channel, mod_handle, new_alive);
+    Ok(ReattachResult::Reattached)
 }
 
 pub fn spawn_pty(
@@ -277,20 +292,21 @@ pub fn spawn_pty(
     // before any on_output messages in the engine's ordered channel.
     mod_handle.on_tab_open(&tab_id, shell_pid);
 
+    let channel: SharedChannel = Arc::new(Mutex::new(Some(on_data)));
     let reader_alive = Arc::new(AtomicBool::new(true));
 
     spawn_reader_thread(
         app,
         tab_id.clone(),
         reader,
-        on_data,
+        channel.clone(),
         mod_handle,
         reader_alive.clone(),
     );
 
     pty_map.lock().unwrap().insert(
         tab_id,
-        PtyHandle { master: pair.master, writer, child, reader_alive },
+        PtyHandle { master: pair.master, writer, child, reader_alive, channel },
     );
 
     Ok(())

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -196,7 +196,27 @@ pub fn try_reattach(
     // Child is still running (or indeterminate). Swap in the new channel.
     // The reader thread — whether blocking on read() or actively discarding —
     // will forward output via this channel on its next iteration.
-    *handle.channel.lock().unwrap() = Some(on_data);
+    {
+        let mut ch = handle.channel.lock().unwrap();
+        *ch = Some(on_data);
+
+        // Write the reconnect banner directly through the data channel before
+        // returning. This is intentionally synchronous — the Channel.onmessage
+        // handler on the JS side is registered before invoke() is called, so
+        // this send is guaranteed to arrive without any listener timing issues.
+        //
+        // Writing via the data channel (rather than a Tauri event) avoids the
+        // async listen() race: Tauri events need listen() to resolve (a Promise)
+        // before the listener is active, but that Promise may not resolve before
+        // pty:reconnected fires. The data channel has no such gap.
+        if let Some(ch_ref) = ch.as_ref() {
+            ch_ref
+                .send(PtyDataPayload {
+                    data: "\r\n\x1b[2m[Reconnected]\x1b[0m\r\n".to_string(),
+                })
+                .ok();
+        }
+    }
 
     if handle.reader_alive.load(Ordering::Relaxed) {
         // Reader is running. Channel is updated. No thread restart needed.

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -3,6 +3,7 @@ use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter};
 use tauri::ipc::Channel;
@@ -25,6 +26,14 @@ pub struct PtyExitPayload {
 pub struct PtyHandle {
     pub master: Box<dyn portable_pty::MasterPty + Send>,
     pub writer: Box<dyn Write + Send>,
+    /// The child process (shell or agent). Kept alive so we can call
+    /// try_wait() during reconnect to distinguish "child still running but
+    /// channel dropped" from "child exited and PTY is truly dead".
+    pub child: Box<dyn portable_pty::Child + Send + Sync>,
+    /// Flipped to false by the reader thread when it exits — for any reason,
+    /// whether the channel was dropped (WebView disconnect) or the PTY process
+    /// exited. open_tab checks this flag to decide whether to reattach.
+    pub reader_alive: Arc<AtomicBool>,
 }
 
 pub type PtyMap = Arc<Mutex<HashMap<String, PtyHandle>>>;
@@ -37,6 +46,163 @@ pub type PtyMap = Arc<Mutex<HashMap<String, PtyHandle>>>;
 /// number of bytes immediately and read() blocks again. Those bytes are sent
 /// right away so the terminal never freezes waiting for a threshold.
 const READ_BUF_SIZE: usize = 256 * 1024;
+
+/// Outcome returned by try_reattach — tells open_tab what happened.
+pub enum ReattachResult {
+    /// Reader thread was alive — already connected, no action taken.
+    AlreadyLive,
+    /// Reader was dead but child is still running — new reader thread spawned
+    /// on the existing PTY. The caller should return false (not a new session).
+    Reattached,
+    /// Reader was dead and child has exited — stale PtyMap entry removed.
+    /// The caller should spawn a fresh PTY.
+    Expired,
+    /// No PtyMap entry for this tab — caller should spawn a fresh PTY.
+    NotFound,
+}
+
+/// Spawns a dedicated reader thread that forwards PTY output to the frontend
+/// via the per-tab Channel.
+///
+/// Reader thread exit behaviour:
+/// - PTY process exits (read returns 0 or Err): emits `pty:exit`, calls
+///   on_tab_close, then exits. PTY is truly dead.
+/// - Channel dropped (send returns Err — WebView disconnected): exits silently.
+///   Does NOT emit pty:exit and does NOT call on_tab_close, because the PTY
+///   process is still running. MOD state is preserved so it can be resumed
+///   when the frontend reconnects.
+///
+/// In both cases reader_alive is set to false before the thread exits,
+/// allowing open_tab to detect the stale state on reconnect.
+///
+/// # Reconnection limitations
+///
+/// This mechanism heals WebView-restart disconnects (window close/reopen, HMR
+/// reload) by reattaching a new reader thread to the existing PTY master fd.
+///
+/// It does NOT cover:
+/// - Output replay: bytes that the old reader thread read but could not send
+///   before the channel drop are gone. Output written by the PTY process after
+///   the channel dropped but before the new reader attaches may survive if still
+///   in the kernel PTY buffer, but this is not guaranteed.
+/// - Mid-session IPC drops while the WebView is still running: those require
+///   an active heartbeat/liveness probe, which is not implemented.
+/// - Full-app crash recovery: if the Tauri process exits, all PTY sessions are
+///   lost. A separate pty-host process (VS Code model) would be needed for that.
+fn spawn_reader_thread(
+    app: AppHandle,
+    tab_id: String,
+    mut reader: Box<dyn Read + Send>,
+    on_data: Channel<PtyDataPayload>,
+    mod_handle: ModEngineHandle,
+    reader_alive: Arc<AtomicBool>,
+) {
+    std::thread::spawn(move || {
+        let mut buf = [0u8; READ_BUF_SIZE];
+
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => {
+                    // PTY process exited or read error — PTY is dead.
+                    app.emit(
+                        "pty:exit",
+                        PtyExitPayload { tab_id: tab_id.clone() },
+                    )
+                    .ok();
+                    mod_handle.on_tab_close(&tab_id);
+                    break;
+                }
+                Ok(n) => {
+                    // Send to terminal — always first, never skipped.
+                    if on_data
+                        .send(PtyDataPayload {
+                            data: String::from_utf8_lossy(&buf[..n]).into_owned(),
+                        })
+                        .is_err()
+                    {
+                        // Channel dropped — WebView disconnected.
+                        // The PTY process is still running; do not emit pty:exit
+                        // and do not call on_tab_close. MOD state is intact and
+                        // the next open_tab call will reattach a new reader.
+                        break;
+                    }
+                    // Forward to MOD engine — non-blocking, silently drops under load.
+                    // The terminal always gets every byte regardless of engine backpressure.
+                    mod_handle.on_output(&tab_id, buf[..n].to_vec());
+                }
+            }
+        }
+
+        // Always mark dead on exit, regardless of reason. open_tab reads this
+        // flag to decide whether a reattach is needed on the next call.
+        reader_alive.store(false, Ordering::Relaxed);
+    });
+}
+
+/// Checks whether the PTY for `tab_id` needs reconnection and, if so, handles
+/// it. Call this before spawn_pty so open_tab can short-circuit.
+///
+/// Returns a ReattachResult describing what happened. The caller acts on it:
+/// - AlreadyLive / Reattached → return Ok(false) to the frontend
+/// - Expired / NotFound → call spawn_pty, return Ok(true)
+pub fn try_reattach(
+    app: AppHandle,
+    pty_map: &PtyMap,
+    mod_handle: ModEngineHandle,
+    tab_id: &str,
+    on_data: Channel<PtyDataPayload>,
+) -> Result<ReattachResult, String> {
+    let mut map = pty_map.lock().unwrap();
+
+    let Some(handle) = map.get_mut(tab_id) else {
+        return Ok(ReattachResult::NotFound);
+    };
+
+    if handle.reader_alive.load(Ordering::Relaxed) {
+        // Reader is still running — normal reconnect path (StrictMode double
+        // mount, tab switch, etc.). Nothing to do.
+        return Ok(ReattachResult::AlreadyLive);
+    }
+
+    // Reader thread has exited. Determine whether the child process is alive.
+    // try_wait() is non-blocking: returns Ok(Some(_)) if exited, Ok(None) if
+    // still running, Err if the check itself failed.
+    match handle.child.try_wait() {
+        Ok(Some(_)) => {
+            // Child has exited — PTY is truly dead. Remove the stale entry so
+            // the caller can spawn a fresh PTY for this tab.
+            map.remove(tab_id);
+            Ok(ReattachResult::Expired)
+        }
+        _ => {
+            // Child is still running (try_wait returned Ok(None) or Err).
+            // Reattach: get a new read handle on the same PTY master fd and
+            // spin up a fresh reader thread wired to the new Channel.
+            //
+            // try_clone_reader() is the key API here — it creates a second
+            // Box<dyn Read + Send> on the existing master fd without disturbing
+            // the PTY or the process running inside it. The original read handle
+            // (held by the now-dead thread) has been dropped; this call is safe.
+            let reader = handle.master.try_clone_reader().map_err(|e| e.to_string())?;
+
+            let new_alive = Arc::new(AtomicBool::new(true));
+            handle.reader_alive = new_alive.clone();
+
+            drop(map); // release the lock before spawning the thread
+
+            spawn_reader_thread(
+                app,
+                tab_id.to_string(),
+                reader,
+                on_data,
+                mod_handle,
+                new_alive,
+            );
+
+            Ok(ReattachResult::Reattached)
+        }
+    }
+}
 
 pub fn spawn_pty(
     app: AppHandle,
@@ -104,50 +270,28 @@ pub fn spawn_pty(
     let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     let shell_pid = child.process_id().unwrap_or(0);
 
-    let mut reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
+    let reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
 
     // Notify MODs before the read thread starts so on_open is always processed
     // before any on_output messages in the engine's ordered channel.
     mod_handle.on_tab_open(&tab_id, shell_pid);
 
-    let tab_id_thread = tab_id.clone();
-    std::thread::spawn(move || {
-        let mut buf = [0u8; READ_BUF_SIZE];
+    let reader_alive = Arc::new(AtomicBool::new(true));
 
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) | Err(_) => {
-                    app.emit(
-                        "pty:exit",
-                        PtyExitPayload { tab_id: tab_id_thread.clone() },
-                    )
-                    .ok();
-                    mod_handle.on_tab_close(&tab_id_thread);
-                    break;
-                }
-                Ok(n) => {
-                    // Send to terminal — always first, never skipped.
-                    if on_data
-                        .send(PtyDataPayload {
-                            data: String::from_utf8_lossy(&buf[..n]).into_owned(),
-                        })
-                        .is_err()
-                    {
-                        break;
-                    }
-                    // Forward to MOD engine — non-blocking, silently drops under load.
-                    // The terminal always gets every byte regardless of engine backpressure.
-                    mod_handle.on_output(&tab_id_thread, buf[..n].to_vec());
-                }
-            }
-        }
-    });
+    spawn_reader_thread(
+        app,
+        tab_id.clone(),
+        reader,
+        on_data,
+        mod_handle,
+        reader_alive.clone(),
+    );
 
-    pty_map
-        .lock()
-        .unwrap()
-        .insert(tab_id, PtyHandle { master: pair.master, writer });
+    pty_map.lock().unwrap().insert(
+        tab_id,
+        PtyHandle { master: pair.master, writer, child, reader_alive },
+    );
 
     Ok(())
 }

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -4,7 +4,7 @@ import {
   XTermTerminal,
 } from '@/components/XTermTerminal/XTermTerminal'
 import { IPC } from '@/modules/ipc/commands'
-import { onPtyExit } from '@/modules/ipc/events'
+import { onPtyExit, onPtyReconnected } from '@/modules/ipc/events'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
 // Tracks in-flight openTab calls per tabKey. Prevents concurrent calls
@@ -80,8 +80,20 @@ export const TerminalPane = React.memo(function TerminalPane({
       if (id === tabKey) handleRef.current?.write('\r\n[Process exited]\r\n')
     })
 
+    // Fires when the Rust backend reattaches a new reader thread to a live PTY
+    // after a WebView disconnect (window close/reopen, HMR reload). The banner
+    // appears in the terminal output so the user knows the session survived.
+    //
+    // Note: this event only fires on successful reconnection of a live PTY. If
+    // the PTY process had also exited during the disconnect, a fresh PTY is
+    // spawned instead and pty:exit fires for the old session — no banner here.
+    const unlistenReconnect = onPtyReconnected((id) => {
+      if (id === tabKey) handleRef.current?.write('\r\n[Reconnected]\r\n')
+    })
+
     return () => {
       unlistenExit.then((fn) => fn())
+      unlistenReconnect.then((fn) => fn())
       // Do NOT close the pty here. Pty lifetime is tied to the tab's
       // existence in the store. removeTab() calls IPC.closeTab() when
       // the user explicitly closes the tab.

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -4,7 +4,7 @@ import {
   XTermTerminal,
 } from '@/components/XTermTerminal/XTermTerminal'
 import { IPC } from '@/modules/ipc/commands'
-import { onPtyExit, onPtyReconnected } from '@/modules/ipc/events'
+import { onPtyExit } from '@/modules/ipc/events'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
 // Tracks in-flight openTab calls per tabKey. Prevents concurrent calls
@@ -80,20 +80,8 @@ export const TerminalPane = React.memo(function TerminalPane({
       if (id === tabKey) handleRef.current?.write('\r\n[Process exited]\r\n')
     })
 
-    // Fires when the Rust backend reattaches a new reader thread to a live PTY
-    // after a WebView disconnect (window close/reopen, HMR reload). The banner
-    // appears in the terminal output so the user knows the session survived.
-    //
-    // Note: this event only fires on successful reconnection of a live PTY. If
-    // the PTY process had also exited during the disconnect, a fresh PTY is
-    // spawned instead and pty:exit fires for the old session — no banner here.
-    const unlistenReconnect = onPtyReconnected((id) => {
-      if (id === tabKey) handleRef.current?.write('\r\n[Reconnected]\r\n')
-    })
-
     return () => {
       unlistenExit.then((fn) => fn())
-      unlistenReconnect.then((fn) => fn())
       // Do NOT close the pty here. Pty lifetime is tied to the tab's
       // existence in the store. removeTab() calls IPC.closeTab() when
       // the user explicitly closes the tab.

--- a/src/modules/ipc/events.ts
+++ b/src/modules/ipc/events.ts
@@ -5,3 +5,19 @@ import { listen } from '@tauri-apps/api/event'
 
 export const onPtyExit = (cb: (tabId: string) => void) =>
   listen<{ tabId: string }>('pty:exit', (e) => cb(e.payload.tabId))
+
+/**
+ * Fires when a dead reader thread is successfully reattached to a live PTY.
+ *
+ * This happens when the WebView restarts (window close/reopen, HMR reload)
+ * and the frontend calls openTab for a tab whose PTY process is still running.
+ * The Rust backend spins up a new reader thread on the existing PTY master fd
+ * and emits this event before any buffered output flows through.
+ *
+ * Limitation: output that the old reader thread read but could not send before
+ * the channel dropped is gone. Output written by the PTY process after the
+ * disconnect but still in the kernel PTY buffer may be delivered, but replay
+ * of earlier history is not supported.
+ */
+export const onPtyReconnected = (cb: (tabId: string) => void) =>
+  listen<{ tabId: string }>('pty:reconnected', (e) => cb(e.payload.tabId))

--- a/src/modules/ipc/events.ts
+++ b/src/modules/ipc/events.ts
@@ -7,17 +7,14 @@ export const onPtyExit = (cb: (tabId: string) => void) =>
   listen<{ tabId: string }>('pty:exit', (e) => cb(e.payload.tabId))
 
 /**
- * Fires when a dead reader thread is successfully reattached to a live PTY.
+ * Fires after the backend successfully reconnects a live PTY to a new WebView
+ * Channel (window close/reopen, HMR reload).
  *
- * This happens when the WebView restarts (window close/reopen, HMR reload)
- * and the frontend calls openTab for a tab whose PTY process is still running.
- * The Rust backend spins up a new reader thread on the existing PTY master fd
- * and emits this event before any buffered output flows through.
- *
- * Limitation: output that the old reader thread read but could not send before
- * the channel dropped is gone. Output written by the PTY process after the
- * disconnect but still in the kernel PTY buffer may be delivered, but replay
- * of earlier history is not supported.
+ * Note: the [Reconnected] banner is written directly into the PTY data stream
+ * by the Rust backend so it appears without any listen() timing gap. This event
+ * is intentionally kept for consumers that need to react to reconnects without
+ * rendering text — for example, resetting status-bar state or logging telemetry.
+ * TerminalPane does not subscribe to it.
  */
 export const onPtyReconnected = (cb: (tabId: string) => void) =>
   listen<{ tabId: string }>('pty:reconnected', (e) => cb(e.payload.tabId))


### PR DESCRIPTION
## Problem

When the WebView restarts (window close/reopen, HMR reload in dev), the JS Channel is dropped and the PTY reader thread exits — but the PTY process (shell or running agent) stays alive with a stale `PtyMap` entry. The next `open_tab` call found the stale entry and returned `false`, but no reader thread was alive to forward PTY output. Terminal appeared frozen.

## Fix

Added `reader_alive: Arc<AtomicBool>` and `child: Box<dyn Child + Send + Sync>` to `PtyHandle`. On each `open_tab` call, `try_reattach()` runs first:

- **Reader alive** → already connected, return `false` (existing behaviour)
- **Reader dead, child alive** → call `try_clone_reader()` on the existing PTY master fd, spin up a new reader thread wired to the new Channel, emit `pty:reconnected`, return `false`. PTY process is undisturbed.
- **Reader dead, child exited** → remove stale entry, fall through to fresh `spawn_pty`, return `true`

The reader thread now sets `reader_alive = false` on exit regardless of the exit reason (channel drop vs. process EOF), allowing `open_tab` to detect the stale state.

Frontend subscribes to `pty:reconnected` and writes `[Reconnected]` into the terminal so the user sees the session survived.

## Limitations (documented in code comments)

- **No scrollback replay**: bytes the old reader read but couldn't send before the channel drop are gone. Output still in the kernel PTY buffer at reattach time is delivered normally.
- **Heals WebView-restart disconnects only**: mid-session IPC drops while the WebView is still running require a heartbeat probe (not implemented).
- **Full-app crash**: if the Tauri process itself exits, all PTY sessions are lost (a VS Code-style separate pty-host process would be needed).

## Files changed

| File | Change |
|------|--------|
| `src-tauri/src/pty_manager.rs` | Add `reader_alive`/`child` to `PtyHandle`; extract `spawn_reader_thread()`; add `try_reattach()` |
| `src-tauri/src/commands.rs` | `open_tab` calls `try_reattach()` before `spawn_pty` |
| `src/modules/ipc/events.ts` | Export `onPtyReconnected` listener |
| `src/components/TerminalPane/TerminalPane.tsx` | Subscribe to `pty:reconnected`, write reconnect banner |