### PR TITLE
feat(ux): scrollable sidebar + tab bar, project add-tab button

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -78,42 +78,54 @@ export function Sidebar() {
         </span>
       </div>
 
-      {/* Project tree */}
-      <div className="flex-1 overflow-y-auto py-1.5">
-        {projects.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-1 px-4 py-8 text-center">
-            <p className="text-[12px] text-sidebar-fg opacity-60">
-              No projects yet.
-            </p>
-            <p className="text-[11px] text-sidebar-fg opacity-40">
-              Click below to add your first project.
-            </p>
-          </div>
-        ) : (
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext
-              items={ordered.map((p) => p.id)}
-              strategy={verticalListSortingStrategy}
+      {/* Project tree — scrolls vertically; scrollbar hidden, bottom shadow
+          gives a visual cue when more content exists below. */}
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <div className="h-full overflow-y-auto py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {projects.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-1 px-4 py-8 text-center">
+              <p className="text-[12px] text-sidebar-fg opacity-60">
+                No projects yet.
+              </p>
+              <p className="text-[11px] text-sidebar-fg opacity-40">
+                Click below to add your first project.
+              </p>
+            </div>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
             >
-              {ordered.map((p) => (
-                <SidebarProjectRow key={p.id} project={p} />
-              ))}
-            </SortableContext>
-          </DndContext>
-        )}
+              <SortableContext
+                items={ordered.map((p) => p.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                {ordered.map((p) => (
+                  <SidebarProjectRow key={p.id} project={p} />
+                ))}
+              </SortableContext>
+            </DndContext>
+          )}
 
-        <button
-          type="button"
-          onClick={handleAddProject}
-          className="mx-1.5 mt-1 flex h-[26px] w-[calc(100%-12px)] items-center gap-1.5 rounded-md px-3 text-[12px] text-sidebar-fg opacity-70 hover:bg-sidebar-hover hover:opacity-100"
-        >
-          <span className="text-[13px] leading-none">+</span>
-          <span>New project</span>
-        </button>
+          <button
+            type="button"
+            onClick={handleAddProject}
+            className="mx-1.5 mt-1 flex h-[26px] w-[calc(100%-12px)] items-center gap-1.5 rounded-md px-3 text-[12px] text-sidebar-fg opacity-70 hover:bg-sidebar-hover hover:opacity-100"
+          >
+            <span className="text-[13px] leading-none">+</span>
+            <span>New project</span>
+          </button>
+        </div>
+
+        {/* Bottom shadow — signals overflowing project rows */}
+        <div
+          className="pointer-events-none absolute right-0 bottom-0 left-0 h-8"
+          style={{
+            background:
+              'linear-gradient(to top, var(--sidebar) 20%, transparent)',
+          }}
+        />
       </div>
     </div>
   )

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -123,7 +123,7 @@ export function Sidebar() {
           className="pointer-events-none absolute right-0 bottom-0 left-0 h-8"
           style={{
             background:
-              'linear-gradient(to top, var(--sidebar) 20%, transparent)',
+              'linear-gradient(to top, var(--color-sidebar) 20%, transparent)',
           }}
         />
       </div>

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -91,9 +91,7 @@ export function SidebarProjectRow({ project }: { project: Project }) {
     if (newName) renameProject(project.id, newName)
   }
 
-  function handleAddTab(e: React.PointerEvent) {
-    e.stopPropagation()
-    e.preventDefault()
+  function handleAddTab() {
     const tabId = $activeTabId.get()[project.id]
     const cwd = tabId
       ? ($tabMeta.get()[makeTabKey(project.id, tabId)]?.cwd ?? '')
@@ -118,64 +116,93 @@ export function SidebarProjectRow({ project }: { project: Project }) {
     >
       <ContextMenu>
         <ContextMenuTrigger className="block">
-          <button
-            type="button"
-            className={cn(
-              'mx-1.5 flex h-[26px] w-[calc(100%-12px)] cursor-grab select-none items-center gap-1.5 rounded-md px-1.5 text-left text-[12.5px]',
-              isActive
-                ? 'bg-sidebar-active text-sidebar-fg-strong'
-                : 'text-sidebar-fg hover:bg-sidebar-hover',
-            )}
-            onClick={() => {
-              if (renaming) return
-              toggleExpanded(project.id)
-              navigateToProject(project.id)
-            }}
-            onDoubleClick={() => {
-              if (!renaming) setRenaming(true)
-            }}
-          >
-            <span
+          {/*
+           * Row layout: [main button flex-1] [add-tab button?]
+           *
+           * The "+" new-terminal button is a sibling of the main button, not
+           * nested inside it. Nesting buttons is invalid HTML and causes the
+           * add-tab action to fire on right-click / middle-click (pointerdown).
+           * As a sibling it is keyboard-accessible and only fires on click.
+           */}
+          <div className="mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center">
+            <button
+              type="button"
               className={cn(
-                'flex h-5 w-5 shrink-0 items-center justify-center rounded transition-transform duration-[140ms]',
-                isOpen && 'rotate-90',
+                'flex h-full flex-1 cursor-grab select-none items-center gap-1.5 rounded-md px-1.5 text-left text-[12.5px]',
+                isActive
+                  ? 'bg-sidebar-active text-sidebar-fg-strong'
+                  : 'text-sidebar-fg hover:bg-sidebar-hover',
               )}
-            >
-              <ChevronRight
-                size={10}
-                className="shrink-0"
-                style={{ color: 'var(--sidebar-foreground)' }}
-              />
-            </span>
-            <Folder
-              size={13}
-              className="shrink-0"
-              style={{
-                color: isActive
-                  ? 'var(--sidebar-foreground-strong)'
-                  : 'var(--sidebar-foreground)',
+              onClick={() => {
+                if (renaming) return
+                toggleExpanded(project.id)
+                navigateToProject(project.id)
               }}
-            />
-            {renaming ? (
-              <InlineEdit
-                value={project.name}
-                onSave={handleRename}
-                onCancel={() => setRenaming(false)}
-                className="flex-1 bg-transparent text-[12.5px] outline-none"
-              />
-            ) : (
-              <span className="flex-1 truncate font-medium">
-                {project.name}
-              </span>
-            )}
-            {anyRunning && !isOpen && !renaming && <RunningDot />}
-            {anyDanger && !isOpen && !renaming && <DangerBadge size={11} />}
-            {/* Add-tab button — shown only when the project is expanded */}
-            {isOpen && !renaming && (
+              onDoubleClick={() => {
+                if (!renaming) setRenaming(true)
+              }}
+            >
               <span
+                className={cn(
+                  'flex h-5 w-5 shrink-0 items-center justify-center rounded transition-transform duration-[140ms]',
+                  isOpen && 'rotate-90',
+                )}
+              >
+                <ChevronRight
+                  size={10}
+                  className="shrink-0"
+                  style={{ color: 'var(--sidebar-foreground)' }}
+                />
+              </span>
+              <Folder
+                size={13}
+                className="shrink-0"
+                style={{
+                  color: isActive
+                    ? 'var(--sidebar-foreground-strong)'
+                    : 'var(--sidebar-foreground)',
+                }}
+              />
+              {renaming ? (
+                <InlineEdit
+                  value={project.name}
+                  onSave={handleRename}
+                  onCancel={() => setRenaming(false)}
+                  className="flex-1 bg-transparent text-[12.5px] outline-none"
+                />
+              ) : (
+                <span className="flex-1 truncate font-medium">
+                  {project.name}
+                </span>
+              )}
+              {anyRunning && !isOpen && !renaming && <RunningDot />}
+              {anyDanger && !isOpen && !renaming && <DangerBadge size={11} />}
+              {project.pinned && !renaming && (
+                <span
+                  title="Unpin project"
+                  className="shrink-0 opacity-50 hover:opacity-100"
+                  onPointerDown={(e) => {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    toggleProjectPin(project.id)
+                  }}
+                >
+                  <Pin size={9} />
+                </span>
+              )}
+            </button>
+
+            {/* Add-tab — proper sibling button; only fires on primary click */}
+            {isOpen && !renaming && (
+              <button
+                type="button"
                 title="New terminal"
-                className="shrink-0 opacity-50 hover:opacity-100"
-                onPointerDown={handleAddTab}
+                className="ml-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded opacity-50 hover:opacity-100"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleAddTab()
+                }}
               >
                 <svg
                   width="11"
@@ -191,22 +218,9 @@ export function SidebarProjectRow({ project }: { project: Project }) {
                     strokeLinecap="round"
                   />
                 </svg>
-              </span>
+              </button>
             )}
-            {project.pinned && !renaming && (
-              <span
-                title="Unpin project"
-                className="shrink-0 opacity-50 hover:opacity-100"
-                onPointerDown={(e) => {
-                  e.stopPropagation()
-                  e.preventDefault()
-                  toggleProjectPin(project.id)
-                }}
-              >
-                <Pin size={9} />
-              </span>
-            )}
-          </button>
+          </div>
         </ContextMenuTrigger>
         <ContextMenuContent className="w-44 text-[12px]">
           <ContextMenuItem onClick={() => setRenaming(true)}>

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -28,10 +28,13 @@ import {
 import { cn } from '@/lib/utils'
 import {
   $activeProjectId,
+  $activeTabId,
   navigateToProject,
+  navigateToTab,
 } from '@/modules/stores/$navigation'
 import {
   $expanded,
+  addTab,
   removeProject,
   renameProject,
   reorderTabs,
@@ -86,6 +89,20 @@ export function SidebarProjectRow({ project }: { project: Project }) {
   function handleRename(newName: string) {
     setRenaming(false)
     if (newName) renameProject(project.id, newName)
+  }
+
+  function handleAddTab(e: React.PointerEvent) {
+    e.stopPropagation()
+    e.preventDefault()
+    const tabId = $activeTabId.get()[project.id]
+    const cwd = tabId
+      ? ($tabMeta.get()[makeTabKey(project.id, tabId)]?.cwd ?? '')
+      : ''
+    const newTab = addTab(project.id, cwd || undefined)
+    if (newTab) {
+      navigateToProject(project.id)
+      navigateToTab(project.id, newTab.id)
+    }
   }
 
   return (
@@ -153,6 +170,29 @@ export function SidebarProjectRow({ project }: { project: Project }) {
             )}
             {anyRunning && !isOpen && !renaming && <RunningDot />}
             {anyDanger && !isOpen && !renaming && <DangerBadge size={11} />}
+            {/* Add-tab button — shown only when the project is expanded */}
+            {isOpen && !renaming && (
+              <span
+                title="New terminal"
+                className="shrink-0 opacity-50 hover:opacity-100"
+                onPointerDown={handleAddTab}
+              >
+                <svg
+                  width="11"
+                  height="11"
+                  viewBox="0 0 11 11"
+                  role="img"
+                  aria-label="New terminal"
+                >
+                  <path
+                    d="M5.5 1.5 V9.5 M1.5 5.5 H9.5"
+                    stroke="currentColor"
+                    strokeWidth="1.3"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </span>
+            )}
             {project.pinned && !renaming && (
               <span
                 title="Unpin project"

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -124,15 +124,17 @@ export function SidebarProjectRow({ project }: { project: Project }) {
            * add-tab action to fire on right-click / middle-click (pointerdown).
            * As a sibling it is keyboard-accessible and only fires on click.
            */}
-          <div className="mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center">
+          <div
+            className={cn(
+              'mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center rounded-md',
+              isActive
+                ? 'bg-sidebar-active text-sidebar-fg-strong'
+                : 'text-sidebar-fg hover:bg-sidebar-hover',
+            )}
+          >
             <button
               type="button"
-              className={cn(
-                'flex h-full flex-1 cursor-grab select-none items-center gap-1.5 rounded-md px-1.5 text-left text-[12.5px]',
-                isActive
-                  ? 'bg-sidebar-active text-sidebar-fg-strong'
-                  : 'text-sidebar-fg hover:bg-sidebar-hover',
-              )}
+              className="flex h-full flex-1 cursor-grab select-none items-center gap-1.5 px-1.5 text-left text-[12.5px]"
               onClick={() => {
                 if (renaming) return
                 toggleExpanded(project.id)

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -16,7 +16,6 @@ import { useStore } from '@nanostores/react'
 import { Pin, X } from 'lucide-react'
 import { hasDangerFlag } from '@/components/agent.helpers'
 import { DangerBadge } from '@/components/DangerBadge'
-import { GitBadge } from '@/components/GitBadge'
 import { TabStatusIcon } from '@/components/TabStatusIcon'
 import {
   ContextMenu,
@@ -155,10 +154,16 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
 
 /* ---------------------------------------------------------------------------
  * TabBar — horizontal DnD tab strip
+ *
+ * Layout: [scrollable tabs area | sticky add-tab button]
+ *
+ * The tab list lives in an overflow-x-auto container so it scrolls when tabs
+ * overflow. The add-tab "+" button is kept outside that container so it always
+ * sticks to the right edge. A gradient shadow on the right of the scroll
+ * container gives a visual cue that more tabs exist off-screen. The scrollbar
+ * itself is hidden to keep the UI clean.
  * -------------------------------------------------------------------------*/
 export function TabBar({ project }: { project: Project }) {
-  const activeTabsByProject = useStore($activeTabId)
-  const activeTabId = activeTabsByProject[project.id] ?? ''
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   )
@@ -195,25 +200,42 @@ export function TabBar({ project }: { project: Project }) {
       className="flex h-[38px] shrink-0 items-end border-[var(--tab-border)] border-b bg-tab-bar px-2"
       style={{ gap: 2 }}
     >
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={orderedTabs.map((t) => t.id)}
-          strategy={horizontalListSortingStrategy}
+      {/* Scrollable tabs — hides scrollbar, shows right-edge shadow */}
+      <div className="relative min-w-0 flex-1 overflow-hidden">
+        <div
+          className="flex items-end overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          style={{ gap: 2 }}
         >
-          {orderedTabs.map((t) => (
-            <TabItem key={t.id} tab={t} projectId={project.id} />
-          ))}
-        </SortableContext>
-      </DndContext>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={orderedTabs.map((t) => t.id)}
+              strategy={horizontalListSortingStrategy}
+            >
+              {orderedTabs.map((t) => (
+                <TabItem key={t.id} tab={t} projectId={project.id} />
+              ))}
+            </SortableContext>
+          </DndContext>
+        </div>
+        {/* Right-edge shadow — signals overflowing tabs */}
+        <div
+          className="pointer-events-none absolute top-0 right-0 bottom-0 w-8"
+          style={{
+            background:
+              'linear-gradient(to left, var(--tab-bar) 20%, transparent)',
+          }}
+        />
+      </div>
 
+      {/* Add-tab button — always visible, sticks to the right */}
       <button
         type="button"
         data-tauri-drag-region={undefined}
-        className="-mb-px flex h-7 w-6 items-center justify-center rounded text-tab-fg hover:bg-sidebar-hover hover:text-tab-fg-active"
+        className="-mb-px flex h-7 w-6 shrink-0 items-center justify-center rounded text-tab-fg hover:bg-sidebar-hover hover:text-tab-fg-active"
         onClick={handleAddTab}
       >
         <svg
@@ -232,20 +254,8 @@ export function TabBar({ project }: { project: Project }) {
         </svg>
       </button>
 
+      {/* Drag region fills the remaining header space */}
       <div className="flex-1" data-tauri-drag-region />
-
-      <div
-        data-tauri-drag-region
-        className="flex h-7 items-center gap-2 pr-1"
-        style={{ fontFamily: MONO_FONT, fontSize: 10.5 }}
-      >
-        {activeTabId && (
-          <GitBadge tabId={makeTabKey(project.id, activeTabId)} />
-        )}
-        <span className="pointer-events-none text-tab-fg opacity-50">
-          {project.path}
-        </span>
-      </div>
     </div>
   )
 }

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -234,7 +234,7 @@ export function TabBar({ project }: { project: Project }) {
           className="pointer-events-none absolute top-0 right-0 bottom-0 w-8"
           style={{
             background:
-              'linear-gradient(to left, var(--tab-bar) 20%, transparent)',
+              'linear-gradient(to left, var(--color-tab-bar) 20%, transparent)',
           }}
         />
       </div>

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -155,13 +155,17 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
 /* ---------------------------------------------------------------------------
  * TabBar — horizontal DnD tab strip
  *
- * Layout: [scrollable tabs area | sticky add-tab button]
+ * Layout: [scroll-container (content-sized, capped)] [add-tab button] [spacer]
  *
- * The tab list lives in an overflow-x-auto container so it scrolls when tabs
- * overflow. The add-tab "+" button is kept outside that container so it always
- * sticks to the right edge. A gradient shadow on the right of the scroll
- * container gives a visual cue that more tabs exist off-screen. The scrollbar
- * itself is hidden to keep the UI clean.
+ * The scroll container has no flex-grow — it is sized to its content (tabs).
+ * max-w: calc(100% - button-width) ensures it never pushes the "+" button
+ * off-screen when tabs overflow.
+ *
+ * Result:
+ *   Few tabs  → container is small → "+" sits right after the last tab
+ *   Many tabs → container hits the cap → tabs scroll, "+" stays at the right
+ *
+ * The scrollbar is hidden; a right-edge gradient shadow signals overflow.
  * -------------------------------------------------------------------------*/
 export function TabBar({ project }: { project: Project }) {
   const sensors = useSensors(
@@ -200,8 +204,12 @@ export function TabBar({ project }: { project: Project }) {
       className="flex h-[38px] shrink-0 items-end border-[var(--tab-border)] border-b bg-tab-bar px-2"
       style={{ gap: 2 }}
     >
-      {/* Scrollable tabs — hides scrollbar, shows right-edge shadow */}
-      <div className="relative min-w-0 flex-1 overflow-hidden">
+      {/* Tab strip — content-sized, capped so the add-button is never hidden.
+          `shrink-0` keeps it at content width; max-w caps it when tabs overflow. */}
+      <div
+        className="relative shrink-0 overflow-hidden"
+        style={{ maxWidth: 'calc(100% - 1.5rem)' }}
+      >
         <div
           className="flex items-end overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           style={{ gap: 2 }}
@@ -231,7 +239,8 @@ export function TabBar({ project }: { project: Project }) {
         />
       </div>
 
-      {/* Add-tab button — always visible, sticks to the right */}
+      {/* Add-tab button — flows right after the last tab when few tabs,
+          sits at the right edge when the strip hits its max-width cap. */}
       <button
         type="button"
         data-tauri-drag-region={undefined}
@@ -254,7 +263,7 @@ export function TabBar({ project }: { project: Project }) {
         </svg>
       </button>
 
-      {/* Drag region fills the remaining header space */}
+      {/* Remaining space is drag region — filled by the outer data-tauri-drag-region */}
       <div className="flex-1" data-tauri-drag-region />
     </div>
   )


### PR DESCRIPTION
## Changes

### Sidebar — vertical scroll with hidden scrollbar + bottom shadow
- Wrapped the project tree in a `relative overflow-hidden` container with an inner `overflow-y-auto` div
- Scrollbar hidden with `[scrollbar-width:none] [&::-webkit-scrollbar]:hidden` (works on both Firefox and WebKit)
- A bottom gradient shadow (`bg-sidebar → transparent`) sits over the scroll area to signal there's more content below

### Tab bar — horizontal scroll with sticky add-tab button + right shadow
- Tabs now live in an `overflow-x-auto` container that scrolls horizontally when tabs overflow
- The "+" add-tab button is kept **outside** the scroll container, always sticking to the right edge
- Right-edge gradient shadow signals overflowing tabs
- Scrollbar hidden the same way as sidebar
- Removed the right info section (GitBadge + project path) — that info is already surfaced in the status bar

### Sidebar project row — add-tab button when expanded
- When a project is open (expanded), a small "+" icon appears on the right side of the project header row
- Clicking it creates a new terminal tab inside that project (inheriting the current CWD) and navigates to it
- Uses `onPointerDown` + `stopPropagation` so it doesn't trigger the expand/collapse toggle

## Files changed
- `src/components/Sidebar/Sidebar.tsx` — scroll wrapper + bottom shadow
- `src/components/Sidebar/SidebarProjectRow.tsx` — add-tab button in project header
- `src/components/TabBar/TabBar.tsx` — scroll container, sticky add button, right shadow, removed right info section