### PR TITLE
fix(git-monitor): refresh on command done instead of waiting 60s

### DIFF
--- a/src-tauri/src/mod_engine/mods/git_monitor.rs
+++ b/src-tauri/src/mod_engine/mods/git_monitor.rs
@@ -87,6 +87,12 @@ impl Mod for GitMonitorMod {
     ///
     /// A 2-second debounce prevents a storm of parallel queries when commands
     /// complete in rapid succession.
+    ///
+    /// The CWD is read inside a short async delay (50 ms) rather than
+    /// immediately. When the user runs `cd` the shell emits OSC 133;D *before*
+    /// OSC 7, so reading the watch value synchronously would capture the old
+    /// directory. The delay lets the engine process OSC 7 and call
+    /// `on_cwd_changed`, which updates `cwd_tx`, before the git query starts.
     fn on_output(&mut self, data: &[u8], ctx: &ModContext) {
         let Some(state) = self.tabs.get_mut(ctx.tab_id) else {
             return;
@@ -94,8 +100,10 @@ impl Mod for GitMonitorMod {
 
         let mut command_done = false;
         for seq in state.osc_parser.feed(data) {
-            // OSC 133;D = command done. Arg is "D" (exit 0) or "D;N" (exit N).
-            if seq.code == 133 && seq.arg.starts_with('D') {
+            // OSC 133;D = command done. Shell integration emits "D;<exit>"
+            // (e.g. "D;0" on success). Accept bare "D" as well for
+            // compatibility with any producer that omits the exit code.
+            if seq.code == 133 && (seq.arg == "D" || seq.arg.starts_with("D;")) {
                 command_done = true;
                 break;
             }
@@ -114,13 +122,31 @@ impl Mod for GitMonitorMod {
         }
 
         // No CWD known yet — shell integration may not have fired OSC 7 yet.
-        let cwd = match state.cwd_tx.borrow().clone() {
-            Some(c) => c,
-            None => return,
-        };
+        if state.cwd_tx.borrow().is_none() {
+            return;
+        }
 
         state.last_query_at = Some(now);
-        self.spawn_git_query(cwd, ctx.async_emitter());
+
+        // Subscribe before the spawn so the receiver sees updates made during
+        // the 50 ms sleep (i.e. OSC 7 processed by DirTrackerMod in this same
+        // output chunk updating the watch via on_cwd_changed).
+        let mut cwd_rx = state.cwd_tx.subscribe();
+        let emitter = ctx.async_emitter();
+        tokio::spawn(async move {
+            // Yield briefly so the engine can process any OSC 7 that arrived
+            // in the same PTY chunk as the OSC 133;D. After this sleep the
+            // watch receiver holds the correct current directory.
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            // Wait for a Some value — cwd_rx starts as None only on fresh tabs
+            // where the early-exit above already guards us, so this completes
+            // immediately in practice.
+            let cwd = cwd_rx.borrow_and_update().clone();
+            if let Some(cwd) = cwd {
+                let data = query_git_info(&cwd).await;
+                emitter.emit("git_monitor", "git_info", data);
+            }
+        });
     }
 
     fn on_cwd_changed(&mut self, cwd: &str, ctx: &ModContext) {

--- a/src-tauri/src/mod_engine/mods/git_monitor.rs
+++ b/src-tauri/src/mod_engine/mods/git_monitor.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::time::Instant;
 
 use crate::mod_engine::{AsyncEmitter, Mod, ModContext};
+use crate::mod_engine::osc_parser::OscParser;
 use tokio::sync::watch;
 
 struct GitTabState {
@@ -8,13 +10,22 @@ struct GitTabState {
     /// Watch sender: updated on each on_cwd_changed; the 60s timer reads the receiver.
     cwd_tx: watch::Sender<Option<String>>,
     timer: Option<tokio::task::JoinHandle<()>>,
+    /// OSC 133 parser — detects command-done sequences to trigger immediate git refresh.
+    osc_parser: OscParser,
+    /// Timestamp of the last triggered git query, used to debounce rapid re-runs.
+    last_query_at: Option<Instant>,
 }
 
 /// Monitors git context for the tab's current working directory.
 ///
 /// Triggers:
 /// 1. CWD change (received via `on_cwd_changed` push from the engine)
-/// 2. 60-second periodic refresh timer
+/// 2. Command done — OSC 133;D fired by the shell after any command exits
+/// 3. 60-second periodic refresh timer (fallback for shells without OSC 133)
+///
+/// Trigger 2 fixes the common case where a command like `git push` or `git pull`
+/// changes remote tracking state without changing the CWD. The 60-second timer
+/// remains as a safety net but should rarely be the first to catch an update.
 ///
 /// Emits `git_info` events with branch, ahead/behind, dirty, worktree, and PR.
 pub struct GitMonitorMod {
@@ -63,8 +74,53 @@ impl Mod for GitMonitorMod {
                 last_queried_cwd: None,
                 cwd_tx,
                 timer: Some(timer),
+                osc_parser: OscParser::new(),
+                last_query_at: None,
             },
         );
+    }
+
+    /// Watches for OSC 133;D (command done) sequences and fires an immediate git
+    /// re-query when one is detected. This keeps the status bar up-to-date after
+    /// commands like `git push`, `git pull`, `git commit`, or `git merge` that
+    /// change git state without changing the working directory.
+    ///
+    /// A 2-second debounce prevents a storm of parallel queries when commands
+    /// complete in rapid succession.
+    fn on_output(&mut self, data: &[u8], ctx: &ModContext) {
+        let Some(state) = self.tabs.get_mut(ctx.tab_id) else {
+            return;
+        };
+
+        let mut command_done = false;
+        for seq in state.osc_parser.feed(data) {
+            // OSC 133;D = command done. Arg is "D" (exit 0) or "D;N" (exit N).
+            if seq.code == 133 && seq.arg.starts_with('D') {
+                command_done = true;
+                break;
+            }
+        }
+
+        if !command_done {
+            return;
+        }
+
+        // Debounce: skip if a query fired within the last 2 seconds.
+        let now = Instant::now();
+        if let Some(last) = state.last_query_at {
+            if now.duration_since(last).as_secs() < 2 {
+                return;
+            }
+        }
+
+        // No CWD known yet — shell integration may not have fired OSC 7 yet.
+        let cwd = match state.cwd_tx.borrow().clone() {
+            Some(c) => c,
+            None => return,
+        };
+
+        state.last_query_at = Some(now);
+        self.spawn_git_query(cwd, ctx.async_emitter());
     }
 
     fn on_cwd_changed(&mut self, cwd: &str, ctx: &ModContext) {
@@ -82,6 +138,7 @@ impl Mod for GitMonitorMod {
         let _ = state.cwd_tx.send(Some(cwd.to_string()));
 
         // Fire an immediate git query for the new directory.
+        state.last_query_at = Some(Instant::now());
         self.spawn_git_query(cwd.to_string(), ctx.async_emitter());
     }
 


### PR DESCRIPTION
## Problem

Git status in the status bar only updated on two triggers:
1. CWD change (OSC 7) — fires when you navigate to a new directory
2. 60-second periodic timer — background fallback

When a command like `git push`, `git pull`, `git commit`, or `git merge` runs **in the same directory**, the CWD doesn't change. The ahead/behind counts and dirty flag stay stale until the 60-second timer finally fires.

## Fix

`GitMonitorMod.on_output` now parses **OSC 133;D** ("command done") sequences using a per-tab `OscParser`. The shell emits this sequence at the end of every command via the shell integration script Agent Terminal already injects.

When OSC 133;D is detected:
1. Check that a CWD is known for the tab (from the existing `watch::Sender`)
2. Debounce: skip if a query fired within the last 2 seconds
3. Spawn an async git re-query — same path as the CWD-change trigger

The 60-second timer is kept as a fallback for exotic shells where OSC 133 integration may not be active.

## Changes

- `src-tauri/src/mod_engine/mods/git_monitor.rs` only — no changes to the engine, context, or `Mod` trait
- Added `OscParser` and `last_query_at: Option<Instant>` fields to `GitTabState`
- New `on_output` impl on `GitMonitorMod`
- `on_cwd_changed` now also sets `last_query_at` so it participates in the same debounce window

## Behaviour after this fix

```
git push
  → OSC 133;D;0 fires
  → GitMonitorMod detects command done
  → spawns git query (branch, rev-list, status, worktree, gh pr — all parallel)
  → emits git_info event
  → status bar updates within ~200–500ms
```