### PR TITLE
feat(keyboard): tab auto-focus, Ctrl+Tab cycling, Ctrl+N project switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Agent Terminal is early stage and under heavy active development.
 - [x] MOD system (Rust-native plugin architecture)
 - [x] Claude Code + Codex detection and agent glyphs
 - [x] Live status bar (process metrics, git, CWD, icons)
-- [ ] Keyboard shortcuts (Cmd+T, Cmd+W, Cmd+1–9, and more)
+- [x] Keyboard shortcuts (Ctrl+T, Ctrl+W, Ctrl+Tab, Ctrl+1–9, and more)
 - [ ] Theming support (light / dark / custom color schemes)
 - [ ] Gemini CLI, Cursor, Open Code agent support
 - [ ] Agent turn detection (know when an agent is actively working vs idle)

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "nanostores": "^1.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hotkeys-hook": "^5.2.4",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
@@ -822,6 +823,8 @@
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-hotkeys-hook": ["react-hotkeys-hook@5.2.4", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-BgKg+A1+TawkYluh5Bo4cTmcgMN5L29uhJbDUQdHwPX+qgXRjIPYU5kIDHyxnAwCkCBiu9V5OpB2mpyeluVF2A=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nanostores": "^1.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hotkeys-hook": "^5.2.4",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -145,21 +145,19 @@ export function SidebarProjectRow({ project }: { project: Project }) {
                 : 'text-sidebar-fg hover:bg-sidebar-hover',
             )}
           >
+            {/* Chevron — controls expand/collapse only; separate from the
+                main content button to avoid nested-button invalid HTML */}
             <button
               type="button"
-              className="flex h-full flex-1 cursor-grab select-none items-center gap-1.5 px-1.5 text-left text-[12.5px]"
-              onClick={() => {
-                if (renaming) return
-                toggleExpanded(project.id)
-                navigateToProject(project.id)
-              }}
-              onDoubleClick={() => {
-                if (!renaming) setRenaming(true)
+              className="flex h-full w-6 shrink-0 items-center justify-center"
+              onClick={(e) => {
+                e.stopPropagation()
+                if (!renaming) toggleExpanded(project.id)
               }}
             >
               <span
                 className={cn(
-                  'flex h-5 w-5 shrink-0 items-center justify-center rounded transition-transform duration-[140ms]',
+                  'flex h-5 w-5 items-center justify-center rounded transition-transform duration-[140ms]',
                   isOpen && 'rotate-90',
                 )}
               >
@@ -169,6 +167,19 @@ export function SidebarProjectRow({ project }: { project: Project }) {
                   style={{ color: 'var(--sidebar-foreground)' }}
                 />
               </span>
+            </button>
+
+            <button
+              type="button"
+              className="flex h-full flex-1 cursor-grab select-none items-center gap-1.5 pr-1.5 text-left text-[12.5px]"
+              onClick={() => {
+                if (renaming) return
+                navigateToProject(project.id)
+              }}
+              onDoubleClick={() => {
+                if (!renaming) setRenaming(true)
+              }}
+            >
               {/* Folder icon with Ctrl+N badge overlay */}
               <span className="relative flex shrink-0 items-center justify-center">
                 <Folder

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -26,6 +26,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
+import { $ctrlHeld } from '@/modules/stores/$keyboard'
 import {
   $activeProjectId,
   $activeTabId,
@@ -34,6 +35,7 @@ import {
 } from '@/modules/stores/$navigation'
 import {
   $expanded,
+  $projects,
   addTab,
   removeProject,
   renameProject,
@@ -48,6 +50,17 @@ import type { Project } from '@/screens/workspace/workspace.types'
 export function SidebarProjectRow({ project }: { project: Project }) {
   const expanded = useStore($expanded)
   const isOpen = !!expanded[project.id]
+  const ctrlHeld = useStore($ctrlHeld)
+  const allProjects = useStore($projects)
+
+  // 1-based position in sidebar display order (pinned first) — matches Ctrl+N shortcut.
+  // Only projects 1–9 show a badge; beyond that there is no keyboard shortcut.
+  const orderedProjects = [
+    ...allProjects.filter((p) => p.pinned),
+    ...allProjects.filter((p) => !p.pinned),
+  ]
+  const projectNumber =
+    orderedProjects.findIndex((p) => p.id === project.id) + 1
   const activeProjectId = useStore($activeProjectId)
   const isActive = activeProjectId === project.id
   const allTabMeta = useStore($tabMeta)
@@ -156,15 +169,22 @@ export function SidebarProjectRow({ project }: { project: Project }) {
                   style={{ color: 'var(--sidebar-foreground)' }}
                 />
               </span>
-              <Folder
-                size={13}
-                className="shrink-0"
-                style={{
-                  color: isActive
-                    ? 'var(--sidebar-foreground-strong)'
-                    : 'var(--sidebar-foreground)',
-                }}
-              />
+              {/* Folder icon with Ctrl+N badge overlay */}
+              <span className="relative flex shrink-0 items-center justify-center">
+                <Folder
+                  size={13}
+                  style={{
+                    color: isActive
+                      ? 'var(--sidebar-foreground-strong)'
+                      : 'var(--sidebar-foreground)',
+                  }}
+                />
+                {ctrlHeld && projectNumber >= 1 && projectNumber <= 9 && (
+                  <span className="absolute -top-1.5 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary font-bold text-[8px] text-primary-foreground leading-none">
+                    {projectNumber}
+                  </span>
+                )}
+              </span>
               {renaming ? (
                 <InlineEdit
                   value={project.name}

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -34,7 +34,6 @@ import {
   navigateToTab,
 } from '@/modules/stores/$navigation'
 import {
-  $expanded,
   $projects,
   addTab,
   removeProject,
@@ -48,8 +47,8 @@ import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 import type { Project } from '@/screens/workspace/workspace.types'
 
 export function SidebarProjectRow({ project }: { project: Project }) {
-  const expanded = useStore($expanded)
-  const isOpen = !!expanded[project.id]
+  // undefined means the project pre-dates this field → treat as expanded
+  const isOpen = project.isExpanded !== false
   const ctrlHeld = useStore($ctrlHeld)
   const allProjects = useStore($projects)
 

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -148,6 +148,8 @@ export function SidebarProjectRow({ project }: { project: Project }) {
                 main content button to avoid nested-button invalid HTML */}
             <button
               type="button"
+              aria-label={isOpen ? 'Collapse project' : 'Expand project'}
+              aria-expanded={isOpen}
               className="flex h-full w-6 shrink-0 items-center justify-center"
               onClick={(e) => {
                 e.stopPropagation()

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -16,15 +16,32 @@ type Props = {
   projectId: string
   tabId: string
   cwd: string
+  /** True when this tab is the currently visible one. Used to auto-focus
+   *  the xterm canvas so the user can type immediately after switching tabs
+   *  or projects without needing to click into the terminal first. */
+  isActive: boolean
 }
 
 export const TerminalPane = React.memo(function TerminalPane({
   projectId,
   tabId,
   cwd,
+  isActive,
 }: Props) {
   const tabKey = makeTabKey(projectId, tabId)
   const handleRef = useRef<XTermHandle | null>(null)
+
+  // Auto-focus the xterm canvas when this tab becomes active.
+  //
+  // The effect runs after React has painted, which means WorkspaceView has
+  // already applied `display: block` to the container div. Calling focus()
+  // on a display:none element is a no-op in xterm, so the paint-after timing
+  // here is load-bearing — do not call focus() synchronously on prop change.
+  useEffect(() => {
+    if (isActive) {
+      handleRef.current?.focus()
+    }
+  }, [isActive])
 
   // Called once when the xterm canvas is ready.
   //

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -63,6 +63,21 @@ const LIGHT_THEME: ITheme = {
   brightWhite: '#383a42',
 }
 
+// Returns true when the key combo is claimed by the app's hotkey layer
+// (react-hotkeys-hook at document level). Returning false from xterm's
+// attachCustomKeyEventHandler skips xterm's own handler so the event bubbles.
+function isAppShortcut(e: KeyboardEvent): boolean {
+  if (!e.ctrlKey) return false
+  return (
+    e.key === 'Tab' || // Ctrl+Tab, Ctrl+Shift+Tab
+    e.key === 't' ||
+    e.key === 'T' || // Ctrl+T
+    e.key === 'w' ||
+    e.key === 'W' || // Ctrl+W
+    '123456789'.includes(e.key) // Ctrl+1–9
+  )
+}
+
 export const XTermTerminal = React.memo(function XTermTerminal({
   onReady,
   onData,
@@ -119,6 +134,11 @@ export const XTermTerminal = React.memo(function XTermTerminal({
 
     termRef.current = term
     fitAddonRef.current = fitAddon
+
+    // Pass app-level shortcuts through to document-level hotkey handlers.
+    // xterm calls preventDefault on keys it processes; returning false here
+    // short-circuits that so the events bubble up to react-hotkeys-hook.
+    term.attachCustomKeyEventHandler((e) => !isAppShortcut(e))
 
     // WebGL renderer — falls back to xterm's built-in DOM renderer on context
     // loss. The canvas addon is not used: it is v5-only and was removed in v6.

--- a/src/modules/stores/$keyboard.ts
+++ b/src/modules/stores/$keyboard.ts
@@ -1,0 +1,8 @@
+import { atom } from 'nanostores'
+
+/**
+ * True while the Ctrl key is physically held down.
+ * Drives the project-number overlay in the sidebar so users can see which
+ * Ctrl+N shortcut maps to which project before pressing the digit.
+ */
+export const $ctrlHeld = atom<boolean>(false)

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -9,7 +9,6 @@ import {
 import type { Project, Tab } from '@/screens/workspace/workspace.types'
 
 export const $projects = atom<Project[]>([])
-export const $expanded = atom<Record<string, boolean>>({})
 
 function persist(projects: Project[]): void {
   IPC.saveProjects(projects).catch(() => {})
@@ -23,8 +22,13 @@ function arrayMove<T>(arr: T[], from: number, to: number): T[] {
 }
 
 export function toggleExpanded(projectId: string): void {
-  const cur = $expanded.get()
-  $expanded.set({ ...cur, [projectId]: !cur[projectId] })
+  const updated = $projects
+    .get()
+    .map((p) =>
+      p.id !== projectId ? p : { ...p, isExpanded: !(p.isExpanded !== false) },
+    )
+  $projects.set(updated)
+  persist(updated)
 }
 
 export function toggleProjectPin(projectId: string): void {
@@ -133,6 +137,7 @@ export function addProject(inheritCwd?: string): Project {
     name,
     path: inheritCwd ?? '',
     pinned: false,
+    isExpanded: true,
     tabs: [
       {
         id: 'shell',
@@ -145,7 +150,6 @@ export function addProject(inheritCwd?: string): Project {
   }
   const updated = [...projects, project]
   $projects.set(updated)
-  $expanded.set({ ...$expanded.get(), [id]: true })
   persist(updated)
   return project
 }

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -69,6 +69,11 @@ export function WorkspaceLayout() {
     }
   }, [])
 
+  // enableOnFormTags is required because xterm uses a hidden <textarea> to
+  // capture keyboard input. Without it react-hotkeys-hook silently ignores
+  // all key events while the terminal has focus.
+  const hotkeyOpts = { preventDefault: true, enableOnFormTags: true } as const
+
   // Ctrl+T — new tab in the active project
   useHotkeys(
     'ctrl+t',
@@ -77,7 +82,7 @@ export function WorkspaceLayout() {
       const newTab = addTab(projectId)
       if (newTab) navigateToTab(projectId, newTab.id)
     },
-    { preventDefault: true },
+    hotkeyOpts,
   )
 
   // Ctrl+W — close the active tab (pinned tabs are protected)
@@ -93,7 +98,7 @@ export function WorkspaceLayout() {
       onTabRemoved(projectId, tabId)
       removeTab(projectId, tabId)
     },
-    { preventDefault: true },
+    hotkeyOpts,
   )
 
   // Ctrl+Tab — cycle to the next tab in the active project (wraps around)
@@ -108,7 +113,7 @@ export function WorkspaceLayout() {
       const next = project.tabs[(idx + 1) % project.tabs.length]
       if (next) navigateToTab(projectId, next.id)
     },
-    { preventDefault: true },
+    hotkeyOpts,
   )
 
   // Ctrl+Shift+Tab — cycle to the previous tab in the active project (wraps around)
@@ -124,7 +129,7 @@ export function WorkspaceLayout() {
         project.tabs[(idx - 1 + project.tabs.length) % project.tabs.length]
       if (prev) navigateToTab(projectId, prev.id)
     },
-    { preventDefault: true },
+    hotkeyOpts,
   )
 
   // Ctrl+1–9 — switch to project N in sidebar display order (pinned first).
@@ -151,7 +156,7 @@ export function WorkspaceLayout() {
       const target = ordered[n]
       if (target) navigateToProject(target.id)
     },
-    { preventDefault: true },
+    hotkeyOpts,
   )
 
   return (

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -1,7 +1,9 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useState } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { Sidebar } from '@/components/Sidebar/Sidebar'
 import { StatusBar } from '@/components/StatusBar/StatusBar'
+import { $ctrlHeld } from '@/modules/stores/$keyboard'
 import {
   $activeProjectId,
   $activeTabId,
@@ -11,50 +13,6 @@ import {
 } from '@/modules/stores/$navigation'
 import { $projects, addTab, removeTab } from '@/modules/stores/$projects'
 import { WorkspaceView } from '@/screens/workspace/WorkspaceView'
-import type { Project } from '@/screens/workspace/workspace.types'
-
-/* ---------------------------------------------------------------------------
- * Keyboard shortcut helpers — extracted to keep handler complexity low
- * -------------------------------------------------------------------------*/
-
-function handleNewTab(projectId: string) {
-  const newTab = addTab(projectId)
-  if (newTab) navigateToTab(projectId, newTab.id)
-}
-
-function handleCloseTab(projectId: string, tabId: string) {
-  onTabRemoved(projectId, tabId)
-  removeTab(projectId, tabId)
-}
-
-function handleJumpToTab(project: Project, digit: string) {
-  const tab = project.tabs[Number.parseInt(digit, 10) - 1]
-  if (tab) navigateToTab(project.id, tab.id)
-}
-
-// Module-level handler reads from atoms directly — stable reference, empty deps.
-function onKeyDown(e: KeyboardEvent) {
-  if (!(e.metaKey || e.ctrlKey)) return
-  const projectId = $activeProjectId.get()
-  const project = $projects.get().find((p) => p.id === projectId)
-  if (!project) return
-  const tabId = $activeTabId.get()[projectId] ?? ''
-  if (e.key === 't') {
-    e.preventDefault()
-    handleNewTab(projectId)
-  } else if (e.key === 'w') {
-    // Guard: no active tab means nothing to close (avoids sending empty tabKey to backend)
-    if (!tabId) return
-    // Guard: pinned tabs cannot be closed by keyboard shortcut
-    const activeTab = project.tabs.find((t) => t.id === tabId)
-    if (activeTab?.pinned) return
-    e.preventDefault()
-    handleCloseTab(projectId, tabId)
-  } else if (/^[1-9]$/.test(e.key)) {
-    e.preventDefault()
-    handleJumpToTab(project, e.key)
-  }
-}
 
 /* ---------------------------------------------------------------------------
  * WorkspaceLayout
@@ -87,10 +45,114 @@ export function WorkspaceLayout() {
     }
   }, [projects, activeProjectId])
 
+  // Track whether Ctrl is physically held so the sidebar can show project-number
+  // badges. The blur listener resets the flag if the window loses focus while
+  // Ctrl is held — prevents the overlay from getting stuck.
   useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Control') $ctrlHeld.set(true)
+    }
+    function onKeyUp(e: KeyboardEvent) {
+      if (e.key === 'Control') $ctrlHeld.set(false)
+    }
+    function onBlur() {
+      $ctrlHeld.set(false)
+    }
+
     window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+      window.removeEventListener('blur', onBlur)
+    }
   }, [])
+
+  // Ctrl+T — new tab in the active project
+  useHotkeys(
+    'ctrl+t',
+    () => {
+      const projectId = $activeProjectId.get()
+      const newTab = addTab(projectId)
+      if (newTab) navigateToTab(projectId, newTab.id)
+    },
+    { preventDefault: true },
+  )
+
+  // Ctrl+W — close the active tab (pinned tabs are protected)
+  useHotkeys(
+    'ctrl+w',
+    () => {
+      const projectId = $activeProjectId.get()
+      const tabId = $activeTabId.get()[projectId] ?? ''
+      if (!tabId) return
+      const project = $projects.get().find((p) => p.id === projectId)
+      const tab = project?.tabs.find((t) => t.id === tabId)
+      if (tab?.pinned) return
+      onTabRemoved(projectId, tabId)
+      removeTab(projectId, tabId)
+    },
+    { preventDefault: true },
+  )
+
+  // Ctrl+Tab — cycle to the next tab in the active project (wraps around)
+  useHotkeys(
+    'ctrl+tab',
+    () => {
+      const projectId = $activeProjectId.get()
+      const project = $projects.get().find((p) => p.id === projectId)
+      if (!project || project.tabs.length < 2) return
+      const tabId = $activeTabId.get()[projectId]
+      const idx = project.tabs.findIndex((t) => t.id === tabId)
+      const next = project.tabs[(idx + 1) % project.tabs.length]
+      if (next) navigateToTab(projectId, next.id)
+    },
+    { preventDefault: true },
+  )
+
+  // Ctrl+Shift+Tab — cycle to the previous tab in the active project (wraps around)
+  useHotkeys(
+    'ctrl+shift+tab',
+    () => {
+      const projectId = $activeProjectId.get()
+      const project = $projects.get().find((p) => p.id === projectId)
+      if (!project || project.tabs.length < 2) return
+      const tabId = $activeTabId.get()[projectId]
+      const idx = project.tabs.findIndex((t) => t.id === tabId)
+      const prev =
+        project.tabs[(idx - 1 + project.tabs.length) % project.tabs.length]
+      if (prev) navigateToTab(projectId, prev.id)
+    },
+    { preventDefault: true },
+  )
+
+  // Ctrl+1–9 — switch to project N in sidebar display order (pinned first).
+  // Projects beyond 9 have no shortcut.
+  useHotkeys(
+    [
+      'ctrl+1',
+      'ctrl+2',
+      'ctrl+3',
+      'ctrl+4',
+      'ctrl+5',
+      'ctrl+6',
+      'ctrl+7',
+      'ctrl+8',
+      'ctrl+9',
+    ],
+    (e) => {
+      const n = Number.parseInt(e.key, 10) - 1
+      const allProjects = $projects.get()
+      const ordered = [
+        ...allProjects.filter((p) => p.pinned),
+        ...allProjects.filter((p) => !p.pinned),
+      ]
+      const target = ordered[n]
+      if (target) navigateToProject(target.id)
+    },
+    { preventDefault: true },
+  )
 
   return (
     <div className="relative flex h-screen w-screen flex-col overflow-hidden bg-background">

--- a/src/screens/workspace/WorkspaceView.tsx
+++ b/src/screens/workspace/WorkspaceView.tsx
@@ -36,18 +36,20 @@ export function WorkspaceView({ project }: Props) {
       <div className="relative min-h-0 flex-1 bg-terminal">
         {project.tabs.map((tab) => {
           if (!mounted.has(tab.id)) return null
+          const isActive = tab.id === activeTabId
           return (
             <div
               key={tab.id}
               className="absolute inset-0"
               // CSS show/hide: terminal instance stays mounted, preserving
               // ghostty-web canvas state, pty process, and scrollback history.
-              style={{ display: tab.id === activeTabId ? 'block' : 'none' }}
+              style={{ display: isActive ? 'block' : 'none' }}
             >
               <TerminalPane
                 projectId={project.id}
                 tabId={tab.id}
                 cwd={tab.lastCwd ?? project.path}
+                isActive={isActive}
               />
             </div>
           )

--- a/src/screens/workspace/workspace.types.ts
+++ b/src/screens/workspace/workspace.types.ts
@@ -20,4 +20,10 @@ export type Project = {
   path: string
   tabs: Tab[]
   pinned: boolean
+  /**
+   * Whether the project row is expanded in the sidebar.
+   * Persisted so the layout survives restarts.
+   * Defaults to true for projects that pre-date this field (undefined → expanded).
+   */
+  isExpanded?: boolean
 }


### PR DESCRIPTION
## What this PR does

Adds keyboard-driven navigation and a sidebar visual overlay, plus two UX fixes discovered during implementation.

### Keyboard shortcuts
- **Ctrl+T** — new tab in the active project
- **Ctrl+W** — close the active tab (pinned tabs protected)
- **Ctrl+Tab / Ctrl+Shift+Tab** — cycle tabs within the active project
- **Ctrl+1–9** — switch to project N in sidebar display order (pinned projects first)

### Sidebar Ctrl-held overlay
Hold Ctrl and the sidebar shows numbered badges (1–9) on project folder icons so you can see which shortcut maps to which project before pressing the key.

### Auto-focus terminal on tab/project switch
The xterm canvas receives focus automatically when a tab becomes active, so you can type immediately without clicking into the terminal.

### Chevron-only expand/collapse
Clicking a project row now only navigates to it. Expand/collapse is exclusively controlled by the chevron icon, preventing accidental collapse when switching projects.

### Persisted sidebar expand/collapse state
The open/collapsed state of each project in the sidebar now survives restarts. It is stored as `isExpanded` directly on the `Project` object and saved alongside the rest of the project data via `IPC.saveProjects`. The separate in-memory `$expanded` atom has been removed. Projects that pre-date this field (`isExpanded === undefined`) are treated as expanded on first load.

## Implementation notes

`react-hotkeys-hook` is used for all shortcut registration. Two things were required to make shortcuts fire when the terminal has focus:
1. `enableOnFormTags: true` — xterm uses a hidden `<textarea>` to capture input; without this option react-hotkeys-hook silently ignores events when that textarea is focused.
2. `term.attachCustomKeyEventHandler` — returns `false` for app-claimed shortcuts so xterm does not forward them to the pty.