### PR TITLE
feat: agent turn detection via hook events

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "biome check && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
     "lint:rust": "cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
     "typecheck": "tsc --noEmit",
-    "test": "bun test",
+    "test": "bun test && cargo test --manifest-path src-tauri/Cargo.toml",
     "lint:fix": "biome check --write --unsafe && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --fix --allow-dirty --allow-staged"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "biome check && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
     "lint:rust": "cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
     "typecheck": "tsc --noEmit",
-    "test": "bun test && cargo test --manifest-path src-tauri/Cargo.toml",
+    "test": "bun test && cargo test --manifest-path src-tauri/Cargo.toml --lib && cargo test --manifest-path src-tauri/Cargo.toml --test hook_integration -- --test-threads=1",
     "lint:fix": "biome check --write --unsafe && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --fix --allow-dirty --allow-staged"
   },
   "dependencies": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agent-terminal"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "dirs 5.0.1",
  "portable-pty",
  "serde",
@@ -228,6 +229,58 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -1613,6 +1666,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1684,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2145,6 +2205,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -3239,6 +3305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,6 +3490,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,6 +3527,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4465,6 +4560,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4503,6 +4599,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ portable-pty = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+axum = "0.8"
 dirs = "5"
 sysinfo = "0.33"
 

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -1,0 +1,733 @@
+//! Agent hook installation — silently wires hook configs at app startup.
+//!
+//! `ensure_hooks_installed()` is called once per launch. It writes a small
+//! shell helper script for each registered agent and appends our hook entries
+//! to the agent's config file — non-destructively. Existing entries from
+//! cmux, the user, or any other tool are preserved.
+//!
+//! Design goals:
+//! - **Idempotent**: calling it N times has the same effect as calling it once.
+//! - **Non-destructive**: never removes or modifies existing hook entries.
+//! - **Silent**: all errors are logged to stderr and swallowed. Never crashes
+//!   the app, never shows a prompt.
+//! - **Atomic writes**: config changes go through a temp-file rename so a
+//!   crash mid-write can't produce a corrupt config.
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+// ─── Static registry ─────────────────────────────────────────────────────────
+
+/// Distinguishes how hook entries are serialised into the agent's config file.
+pub enum HookConfigFormat {
+    /// `{"type":"command","command":"...","timeout":N}` — used by Claude Code.
+    Claude,
+    /// `{"command":"..."}` — used by Codex CLI.
+    Codex,
+}
+
+pub struct AgentHookEvent {
+    /// Name used as the key in the agent's config (e.g. `"UserPromptSubmit"`).
+    pub event_name: &'static str,
+}
+
+pub struct AgentHookConfig {
+    /// Human-readable name for log messages.
+    pub agent_name: &'static str,
+    /// Stem used to name the hook script: `<stem>-hook`.
+    pub hook_stem: &'static str,
+    /// Value injected as `"agent"` in the POST payload.
+    pub agent_id: &'static str,
+    /// Tilde path to the agent's hook config file.
+    pub config_tilde_path: &'static str,
+    pub config_format: HookConfigFormat,
+    /// Timeout (ms) written into Claude-format entries.
+    pub timeout_ms: u64,
+    pub events: &'static [AgentHookEvent],
+}
+
+pub static AGENT_HOOK_CONFIGS: &[AgentHookConfig] = &[
+    AgentHookConfig {
+        agent_name: "Claude Code",
+        hook_stem: "claude",
+        agent_id: "claude-code",
+        config_tilde_path: "~/.claude/settings.json",
+        config_format: HookConfigFormat::Claude,
+        timeout_ms: 10_000,
+        events: &[
+            AgentHookEvent { event_name: "SessionStart" },
+            AgentHookEvent { event_name: "UserPromptSubmit" },
+            AgentHookEvent { event_name: "PreToolUse" },
+            AgentHookEvent { event_name: "Notification" },
+            AgentHookEvent { event_name: "Stop" },
+            AgentHookEvent { event_name: "SessionEnd" },
+        ],
+    },
+    AgentHookConfig {
+        agent_name: "Codex CLI",
+        hook_stem: "codex",
+        agent_id: "codex",
+        config_tilde_path: "~/.codex/hooks.json",
+        config_format: HookConfigFormat::Codex,
+        timeout_ms: 5_000,
+        events: &[
+            AgentHookEvent { event_name: "SessionStart" },
+            AgentHookEvent { event_name: "UserPromptSubmit" },
+            AgentHookEvent { event_name: "Stop" },
+        ],
+    },
+];
+
+// ─── Public entry point ───────────────────────────────────────────────────────
+
+/// Silently installs/verifies hooks for all registered agents.
+/// Called once at app startup. Never panics, never returns an error to the caller.
+pub async fn ensure_hooks_installed() {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => {
+            eprintln!(
+                "[hook_config] could not determine home directory — skipping hook install"
+            );
+            return;
+        }
+    };
+    let hooks_dir = home.join(".agent-terminal").join("hooks");
+    for config in AGENT_HOOK_CONFIGS {
+        if let Err(e) = install_for_agent(config, &home, &hooks_dir).await {
+            eprintln!(
+                "[hook_config] failed to install hooks for {}: {e}",
+                config.agent_name
+            );
+        }
+    }
+}
+
+async fn install_for_agent(
+    config: &AgentHookConfig,
+    home: &Path,
+    hooks_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let script_path = hooks_dir.join(format!("{}-hook", config.hook_stem));
+    let config_path = expand_tilde(config.config_tilde_path, home);
+    write_hook_script_to(config, &script_path).await?;
+    merge_hook_config_at(config, &config_path, &script_path).await?;
+    Ok(())
+}
+
+// ─── Hook script generation ───────────────────────────────────────────────────
+
+/// Writes the hook shell script to `script_path`, creating parent dirs as needed.
+/// Skips the write if the file already contains the current content (idempotent).
+pub(crate) async fn write_hook_script_to(
+    config: &AgentHookConfig,
+    script_path: &Path,
+) -> std::io::Result<()> {
+    let content = build_hook_script(config.agent_id);
+
+    if let Some(parent) = script_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    // Skip write if content is already up to date (S2 test case).
+    if let Ok(existing) = tokio::fs::read_to_string(script_path).await {
+        if existing == content {
+            return Ok(());
+        }
+    }
+
+    tokio::fs::write(script_path, &content).await?;
+
+    // chmod +x (S1, S3 test cases).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let meta = std::fs::metadata(script_path)?;
+        let mut perms = meta.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(script_path, perms)?;
+    }
+
+    Ok(())
+}
+
+/// Generates the hook shell script content for `agent_id`.
+///
+/// The script reads the agent's JSON payload from stdin, prepends `agent` and
+/// `event` fields, and POSTs to the hook server. Always exits 0 so the agent
+/// is never blocked by a hook failure.
+fn build_hook_script(agent_id: &str) -> String {
+    // The sed command removes the leading `{` from the agent's JSON payload so
+    // we can inject our own fields at the front. The result is a valid JSON object:
+    //   {"agent":"claude-code","event":"UserPromptSubmit","session_id":"...","cwd":"..."}
+    format!(
+        "#!/bin/sh\n\
+# Written by Agent Terminal. Do not edit — regenerated on each launch.\n\
+INPUT=$(cat)\n\
+EVENT=\"$1\"\n\
+curl -sf -X POST http://localhost:47384/hook \\\n\
+  -H 'Content-Type: application/json' \\\n\
+  -d \"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\",$(echo \\\"$INPUT\\\" | sed 's/^{{//')}}\" \\\n\
+  >/dev/null 2>&1 || true\n",
+    )
+}
+
+// ─── Config merge ─────────────────────────────────────────────────────────────
+
+/// Appends our hook entries to `config_path` for `config`.
+///
+/// Idempotency contract:
+/// 1. Config does not exist → create with only our hooks.
+/// 2. Config exists, no `"hooks"` key → add `"hooks"` with our entries; preserve all other keys.
+/// 3. Config has `"hooks"` but missing an event key → add that event key.
+/// 4. Config has the event key but not our command → append our entry.
+/// 5. Our command already present → do nothing (no duplicate).
+/// 6. Existing entries from cmux or user are always preserved.
+/// 7. `"hooks"` keys for events we don't register are untouched.
+/// 8. Invalid JSON → error returned, file not modified.
+pub(crate) async fn merge_hook_config_at(
+    config: &AgentHookConfig,
+    config_path: &Path,
+    script_path: &Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Read existing config or treat as empty object.
+    let raw = if config_path.exists() {
+        tokio::fs::read_to_string(config_path).await?
+    } else {
+        "{}".to_string()
+    };
+
+    // Fail fast on malformed JSON (C8 test case) — we never clobber a corrupt file.
+    let mut root: Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("invalid JSON in {}: {e}", config_path.display()))?;
+
+    if !root.is_object() {
+        return Err(format!(
+            "{} root is not a JSON object",
+            config_path.display()
+        )
+        .into());
+    }
+
+    let script_path_str = script_path.to_string_lossy().to_string();
+    let mut modified = false;
+
+    {
+        let root_obj = root.as_object_mut().unwrap();
+        let hooks = root_obj
+            .entry("hooks")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+
+        let hooks_obj = hooks
+            .as_object_mut()
+            .ok_or("\"hooks\" is not a JSON object")?;
+
+        for event in config.events {
+            let our_command = format!("{} {}", script_path_str, event.event_name);
+
+            let arr = hooks_obj
+                .entry(event.event_name)
+                .or_insert_with(|| Value::Array(vec![]));
+
+            let arr = arr
+                .as_array_mut()
+                .ok_or_else(|| format!("\"hooks.{}\" is not a JSON array", event.event_name))?;
+
+            // Idempotency check — skip if our command is already present (C5, C10, D3, D4).
+            let already_installed = arr.iter().any(|entry| {
+                entry.get("command").and_then(|v| v.as_str()) == Some(our_command.as_str())
+            });
+
+            if !already_installed {
+                let entry = build_hook_entry(config, &our_command);
+                arr.push(entry);
+                modified = true;
+            }
+        }
+    }
+
+    if !modified {
+        return Ok(());
+    }
+
+    // Create parent directory if needed.
+    if let Some(parent) = config_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    // Atomic write: temp file → rename.
+    let serialized = serde_json::to_string_pretty(&root)?;
+    let tmp_path = config_path.with_extension("agent-terminal.tmp");
+    tokio::fs::write(&tmp_path, format!("{serialized}\n")).await?;
+    tokio::fs::rename(&tmp_path, config_path).await?;
+
+    Ok(())
+}
+
+fn build_hook_entry(config: &AgentHookConfig, command: &str) -> Value {
+    match config.config_format {
+        HookConfigFormat::Claude => serde_json::json!({
+            "type": "command",
+            "command": command,
+            "timeout": config.timeout_ms,
+        }),
+        HookConfigFormat::Codex => serde_json::json!({
+            "command": command,
+        }),
+    }
+}
+
+fn expand_tilde(path: &str, home: &Path) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        home.join(rest)
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn claude_config() -> &'static AgentHookConfig {
+        &AGENT_HOOK_CONFIGS[0]
+    }
+
+    fn codex_config() -> &'static AgentHookConfig {
+        &AGENT_HOOK_CONFIGS[1]
+    }
+
+    fn temp_dir(suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("at_hook_test_{suffix}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn read_json(path: &Path) -> Value {
+        let content = fs::read_to_string(path).unwrap();
+        serde_json::from_str(&content).unwrap()
+    }
+
+    fn has_our_command(v: &Value, event: &str, script: &Path) -> bool {
+        let expected = format!("{} {event}", script.display());
+        v["hooks"][event]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .any(|e| e["command"].as_str() == Some(expected.as_str()))
+            })
+            .unwrap_or(false)
+    }
+
+    // ── C1: fresh install — file does not exist ───────────────────────────────
+    #[tokio::test]
+    async fn c1_claude_fresh_install() {
+        let dir = temp_dir("c1");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        assert!(!config_path.exists());
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        assert!(config_path.exists());
+        let v = read_json(&config_path);
+        assert!(v["hooks"].is_object(), "hooks key must exist");
+        for event in claude_config().events {
+            assert!(
+                has_our_command(&v, event.event_name, &script),
+                "missing command for {}", event.event_name
+            );
+        }
+        // File must contain exactly the hooks we wrote — no phantom keys.
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.len(), 1, "root should have exactly one key: hooks");
+    }
+
+    // ── C2: file exists, no "hooks" key ──────────────────────────────────────
+    #[tokio::test]
+    async fn c2_claude_no_hooks_key() {
+        let dir = temp_dir("c2");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        fs::write(&config_path, r#"{"model":"sonnet","verbose":true}"#).unwrap();
+
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        // Existing keys preserved.
+        assert_eq!(v["model"].as_str(), Some("sonnet"));
+        assert_eq!(v["verbose"].as_bool(), Some(true));
+        // Our hooks added.
+        assert!(v["hooks"].is_object());
+        assert!(has_our_command(&v, "UserPromptSubmit", &script));
+    }
+
+    // ── C3: hooks key exists, event array missing ─────────────────────────────
+    #[tokio::test]
+    async fn c3_claude_event_array_missing() {
+        let dir = temp_dir("c3");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        // File has hooks but only for one existing event (not ours).
+        fs::write(
+            &config_path,
+            r#"{"hooks":{"PostToolUse":[{"type":"command","command":"my-tool"}]}}"#,
+        )
+        .unwrap();
+
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        // Existing unrelated event preserved.
+        let post_arr = v["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(post_arr.len(), 1, "PostToolUse should still have 1 entry");
+        // Our events added.
+        assert!(has_our_command(&v, "SessionStart", &script));
+        assert!(has_our_command(&v, "Stop", &script));
+    }
+
+    // ── C4: event array present, our command absent → append ─────────────────
+    #[tokio::test]
+    async fn c4_claude_append_to_existing_array() {
+        let dir = temp_dir("c4");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        fs::write(
+            &config_path,
+            r#"{"hooks":{"UserPromptSubmit":[{"type":"command","command":"other-tool prompt"}]}}"#,
+        )
+        .unwrap();
+
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        let arr = v["hooks"]["UserPromptSubmit"].as_array().unwrap();
+        // Original entry preserved.
+        assert!(arr.iter().any(|e| e["command"].as_str() == Some("other-tool prompt")));
+        // Our entry appended.
+        assert!(has_our_command(&v, "UserPromptSubmit", &script));
+        assert!(arr.len() >= 2, "should have at least 2 entries");
+    }
+
+    // ── C5: our command already present → no change ───────────────────────────
+    #[tokio::test]
+    async fn c5_claude_already_installed_no_duplicate() {
+        let dir = temp_dir("c5");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        // Pre-install once.
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+        let before = fs::read_to_string(&config_path).unwrap();
+
+        // Second call — should not modify the file.
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+        let after = fs::read_to_string(&config_path).unwrap();
+
+        assert_eq!(before, after, "file should be unchanged on re-install");
+    }
+
+    // ── C6: cmux entries preserved alongside ours ─────────────────────────────
+    #[tokio::test]
+    async fn c6_claude_cmux_entries_preserved() {
+        let dir = temp_dir("c6");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        fs::write(
+            &config_path,
+            r#"{"hooks":{"UserPromptSubmit":[{"type":"command","command":"cmux claude-hook prompt-submit"}]}}"#,
+        )
+        .unwrap();
+
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        let arr = v["hooks"]["UserPromptSubmit"].as_array().unwrap();
+        // cmux entry preserved.
+        assert!(arr
+            .iter()
+            .any(|e| e["command"].as_str() == Some("cmux claude-hook prompt-submit")));
+        // Our entry also present.
+        assert!(has_our_command(&v, "UserPromptSubmit", &script));
+    }
+
+    // ── C7: unregistered event array untouched ────────────────────────────────
+    #[tokio::test]
+    async fn c7_claude_unregistered_event_untouched() {
+        let dir = temp_dir("c7");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        fs::write(
+            &config_path,
+            r#"{"hooks":{"MyCustomHook":[{"type":"command","command":"custom-tool"}]}}"#,
+        )
+        .unwrap();
+
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        // Custom hook still has exactly one entry.
+        let arr = v["hooks"]["MyCustomHook"].as_array().unwrap();
+        assert_eq!(arr.len(), 1, "unregistered event should be untouched");
+        assert_eq!(arr[0]["command"].as_str(), Some("custom-tool"));
+    }
+
+    // ── C8: invalid JSON → error, file not modified ───────────────────────────
+    #[tokio::test]
+    async fn c8_claude_invalid_json_not_modified() {
+        let dir = temp_dir("c8");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+        let bad_json = "{ this is not json }";
+
+        fs::write(&config_path, bad_json).unwrap();
+
+        let result = merge_hook_config_at(claude_config(), &config_path, &script).await;
+        assert!(result.is_err(), "should error on invalid JSON");
+
+        // File must not have been modified.
+        let after = fs::read_to_string(&config_path).unwrap();
+        assert_eq!(after, bad_json, "file must not be modified on parse error");
+    }
+
+    // ── C9: all six Claude events installed in a single pass ──────────────────
+    #[tokio::test]
+    async fn c9_claude_all_six_events_installed() {
+        let dir = temp_dir("c9");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        let hooks = v["hooks"].as_object().unwrap();
+        assert_eq!(hooks.len(), 6, "should have exactly 6 event keys");
+
+        let expected = [
+            "SessionStart",
+            "UserPromptSubmit",
+            "PreToolUse",
+            "Notification",
+            "Stop",
+            "SessionEnd",
+        ];
+        for event in expected {
+            assert!(
+                has_our_command(&v, event, &script),
+                "missing command for {event}"
+            );
+        }
+    }
+
+    // ── C10: idempotent — two calls equal one call ────────────────────────────
+    #[tokio::test]
+    async fn c10_claude_idempotent_two_calls() {
+        let dir = temp_dir("c10");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        // Each event array should have exactly one entry (ours).
+        for event in claude_config().events {
+            let arr = v["hooks"][event.event_name].as_array().unwrap();
+            let our_cmd = format!("{} {}", script.display(), event.event_name);
+            let count = arr
+                .iter()
+                .filter(|e| e["command"].as_str() == Some(our_cmd.as_str()))
+                .count();
+            assert_eq!(count, 1, "event {} should have exactly one entry", event.event_name);
+        }
+    }
+
+    // ── D1: Codex fresh install ───────────────────────────────────────────────
+    #[tokio::test]
+    async fn d1_codex_fresh_install() {
+        let dir = temp_dir("d1");
+        let config_path = dir.join("hooks.json");
+        let script = dir.join("codex-hook");
+
+        merge_hook_config_at(codex_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        assert!(v["hooks"].is_object());
+        for event in codex_config().events {
+            let arr = v["hooks"][event.event_name].as_array().unwrap();
+            let our_cmd = format!("{} {}", script.display(), event.event_name);
+            assert!(
+                arr.iter().any(|e| e["command"].as_str() == Some(our_cmd.as_str())),
+                "missing {}", event.event_name
+            );
+            // Codex format: no "type" field.
+            let our_entry = arr
+                .iter()
+                .find(|e| e["command"].as_str() == Some(our_cmd.as_str()))
+                .unwrap();
+            assert!(
+                our_entry.get("type").is_none(),
+                "Codex entries must not have a type field"
+            );
+        }
+    }
+
+    // ── D2: Codex file exists, entries absent → appended ─────────────────────
+    #[tokio::test]
+    async fn d2_codex_append_to_existing() {
+        let dir = temp_dir("d2");
+        let config_path = dir.join("hooks.json");
+        let script = dir.join("codex-hook");
+
+        fs::write(
+            &config_path,
+            r#"{"hooks":{"SessionStart":[{"command":"my-existing-hook start"}]}}"#,
+        )
+        .unwrap();
+
+        merge_hook_config_at(codex_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        // Existing entry preserved.
+        let arr = v["hooks"]["SessionStart"].as_array().unwrap();
+        assert!(arr
+            .iter()
+            .any(|e| e["command"].as_str() == Some("my-existing-hook start")));
+        // Ours also present.
+        assert!(has_our_command(&v, "SessionStart", &script));
+    }
+
+    // ── D3: Codex entries already present → unchanged ─────────────────────────
+    #[tokio::test]
+    async fn d3_codex_already_installed() {
+        let dir = temp_dir("d3");
+        let config_path = dir.join("hooks.json");
+        let script = dir.join("codex-hook");
+
+        merge_hook_config_at(codex_config(), &config_path, &script)
+            .await
+            .unwrap();
+        let before = fs::read_to_string(&config_path).unwrap();
+
+        merge_hook_config_at(codex_config(), &config_path, &script)
+            .await
+            .unwrap();
+        let after = fs::read_to_string(&config_path).unwrap();
+
+        assert_eq!(before, after, "Codex file unchanged on re-install");
+    }
+
+    // ── D4: Codex idempotent — two calls ─────────────────────────────────────
+    #[tokio::test]
+    async fn d4_codex_idempotent_two_calls() {
+        let dir = temp_dir("d4");
+        let config_path = dir.join("hooks.json");
+        let script = dir.join("codex-hook");
+
+        merge_hook_config_at(codex_config(), &config_path, &script)
+            .await
+            .unwrap();
+        merge_hook_config_at(codex_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        for event in codex_config().events {
+            let arr = v["hooks"][event.event_name].as_array().unwrap();
+            let our_cmd = format!("{} {}", script.display(), event.event_name);
+            let count = arr
+                .iter()
+                .filter(|e| e["command"].as_str() == Some(our_cmd.as_str()))
+                .count();
+            assert_eq!(count, 1, "event {} should have exactly one entry", event.event_name);
+        }
+    }
+
+    // ── S1: script does not exist → written, chmod +x ────────────────────────
+    #[tokio::test]
+    async fn s1_script_written_executable() {
+        let dir = temp_dir("s1");
+        let script = dir.join("claude-hook");
+
+        assert!(!script.exists());
+        write_hook_script_to(claude_config(), &script).await.unwrap();
+
+        assert!(script.exists(), "script should be created");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = fs::metadata(&script).unwrap();
+            let mode = meta.permissions().mode();
+            assert!(mode & 0o100 != 0, "script should be executable by owner");
+        }
+    }
+
+    // ── S2: script exists with correct content → not rewritten ───────────────
+    #[tokio::test]
+    async fn s2_script_not_rewritten_if_current() {
+        let dir = temp_dir("s2");
+        let script = dir.join("claude-hook");
+
+        write_hook_script_to(claude_config(), &script).await.unwrap();
+        let mtime_before = fs::metadata(&script).unwrap().modified().unwrap();
+
+        // Brief pause to make mtime detectable.
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        write_hook_script_to(claude_config(), &script).await.unwrap();
+        let mtime_after = fs::metadata(&script).unwrap().modified().unwrap();
+
+        assert_eq!(mtime_before, mtime_after, "script should not be rewritten if already current");
+    }
+
+    // ── S3: script exists with outdated content → overwritten ─────────────────
+    #[tokio::test]
+    async fn s3_outdated_script_overwritten() {
+        let dir = temp_dir("s3");
+        let script = dir.join("claude-hook");
+
+        // Write stale content.
+        fs::write(&script, "#!/bin/sh\necho old").unwrap();
+
+        write_hook_script_to(claude_config(), &script).await.unwrap();
+
+        let content = fs::read_to_string(&script).unwrap();
+        assert!(content.contains("localhost:47384"), "script should be updated");
+        assert!(!content.contains("echo old"), "old content should be replaced");
+    }
+}

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -233,14 +233,23 @@ pub(crate) async fn merge_hook_config_at(
                 .as_array_mut()
                 .ok_or_else(|| format!("\"hooks.{}\" is not a JSON array", event.event_name))?;
 
-            // Idempotency check — skip if our command is already present (C5, C10, D3, D4).
-            let already_installed = arr.iter().any(|entry| {
-                entry.get("command").and_then(|v| v.as_str()) == Some(our_command.as_str())
+            // Migration: remove stale flat-format entries (old Claude format was
+            // {type, command} at the top level; Claude now requires the matcher+hooks
+            // nesting). These cause Claude Code to report a "settings file damaged" error.
+            let before = arr.len();
+            arr.retain(|entry| {
+                entry.get("command").and_then(|v| v.as_str()) != Some(our_command.as_str())
             });
+            if arr.len() < before {
+                modified = true;
+            }
+
+            // Idempotency check — skip if our command is already present in the
+            // current (nested matcher+hooks) format (C5, C10, D3, D4).
+            let already_installed = command_in_nested_entry(arr, &our_command);
 
             if !already_installed {
-                let entry = build_hook_entry(config, &our_command);
-                arr.push(entry);
+                arr.push(build_hook_entry(config, &our_command));
                 modified = true;
             }
         }
@@ -266,15 +275,39 @@ pub(crate) async fn merge_hook_config_at(
 
 fn build_hook_entry(config: &AgentHookConfig, command: &str) -> Value {
     match config.config_format {
+        // Claude Code format (as of Claude Code ≥1.x):
+        // each array entry is a matcher object wrapping an inner hooks array.
+        // Empty matcher string means "match all" (fires for every tool/event).
         HookConfigFormat::Claude => serde_json::json!({
-            "type": "command",
-            "command": command,
-            "timeout": config.timeout_ms,
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": command,
+                    "timeout": config.timeout_ms,
+                }
+            ]
         }),
         HookConfigFormat::Codex => serde_json::json!({
             "command": command,
         }),
     }
+}
+
+/// Returns true if `our_command` is found inside any entry's nested `hooks` array.
+/// Used for Claude's matcher+hooks format.
+fn command_in_nested_entry(arr: &[Value], our_command: &str) -> bool {
+    arr.iter().any(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .map(|inner| {
+                inner.iter().any(|h| {
+                    h.get("command").and_then(|v| v.as_str()) == Some(our_command)
+                })
+            })
+            .unwrap_or(false)
+    })
 }
 
 fn expand_tilde(path: &str, home: &Path) -> PathBuf {
@@ -320,8 +353,22 @@ mod tests {
         v["hooks"][event]
             .as_array()
             .map(|arr| {
-                arr.iter()
-                    .any(|e| e["command"].as_str() == Some(expected.as_str()))
+                arr.iter().any(|e| {
+                    // Claude new format: command is nested inside hooks[].
+                    let in_nested = e
+                        .get("hooks")
+                        .and_then(|h| h.as_array())
+                        .map(|inner| {
+                            inner.iter().any(|h| {
+                                h.get("command").and_then(|v| v.as_str())
+                                    == Some(expected.as_str())
+                            })
+                        })
+                        .unwrap_or(false);
+                    // Codex flat format: command is at top level.
+                    let at_top = e["command"].as_str() == Some(expected.as_str());
+                    in_nested || at_top
+                })
             })
             .unwrap_or(false)
     }
@@ -564,16 +611,59 @@ mod tests {
             .unwrap();
 
         let v = read_json(&config_path);
-        // Each event array should have exactly one entry (ours).
+        // Each event array should have exactly one entry (ours) in nested format.
         for event in claude_config().events {
             let arr = v["hooks"][event.event_name].as_array().unwrap();
             let our_cmd = format!("{} {}", script.display(), event.event_name);
+            // Count entries whose inner hooks[] contains our command.
             let count = arr
                 .iter()
-                .filter(|e| e["command"].as_str() == Some(our_cmd.as_str()))
+                .filter(|e| {
+                    e.get("hooks")
+                        .and_then(|h| h.as_array())
+                        .map(|inner| inner.iter().any(|h| {
+                            h.get("command").and_then(|v| v.as_str()) == Some(our_cmd.as_str())
+                        }))
+                        .unwrap_or(false)
+                })
                 .count();
             assert_eq!(count, 1, "event {} should have exactly one entry", event.event_name);
         }
+    }
+
+    // ── C11: stale flat-format entries are replaced with new nested format ────
+    #[tokio::test]
+    async fn c11_claude_migrates_old_flat_format() {
+        let dir = temp_dir("c11");
+        let config_path = dir.join("settings.json");
+        let script = dir.join("claude-hook");
+        let our_cmd = format!("{} UserPromptSubmit", script.display());
+
+        // Write the old (now-invalid) flat format that we used to produce.
+        fs::write(
+            &config_path,
+            format!(
+                r#"{{"hooks":{{"UserPromptSubmit":[{{"type":"command","command":"{our_cmd}","timeout":10000}}]}}}}"#
+            ),
+        )
+        .unwrap();
+
+        merge_hook_config_at(claude_config(), &config_path, &script)
+            .await
+            .unwrap();
+
+        let v = read_json(&config_path);
+        let arr = v["hooks"]["UserPromptSubmit"].as_array().unwrap();
+
+        // Old flat entry must be gone.
+        let flat_still_there = arr.iter().any(|e| e["command"].as_str() == Some(&our_cmd));
+        assert!(!flat_still_there, "stale flat entry should be removed");
+
+        // New nested entry must be present.
+        assert!(has_our_command(&v, "UserPromptSubmit", &script));
+
+        // Only one entry for UserPromptSubmit (no duplicate).
+        assert_eq!(arr.len(), 1, "should be exactly one entry after migration");
     }
 
     // ── D1: Codex fresh install ───────────────────────────────────────────────

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -302,6 +302,10 @@ mod tests {
 
     fn temp_dir(suffix: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("at_hook_test_{suffix}"));
+        // Wipe from any previous run so each test starts clean.
+        if dir.exists() {
+            fs::remove_dir_all(&dir).unwrap();
+        }
         fs::create_dir_all(&dir).unwrap();
         dir
     }

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -172,6 +172,12 @@ pub(crate) async fn write_hook_script_to(
 /// it has no business waiting for the HTTP response. `--max-time 5` stays as
 /// a ceiling on background curl lifetime so they don't accumulate as zombies
 /// if the server is hung and hooks fire repeatedly.
+///
+/// Why `127.0.0.1` and not `localhost`: the server binds `127.0.0.1:47384`
+/// (IPv4 only). On macOS, `localhost` resolves to `::1` first, so curl tries
+/// IPv6 and gets ECONNREFUSED before falling back to IPv4 (Happy Eyeballs).
+/// The fallback works, but every hook eats the latency for nothing. Pinning
+/// the script to `127.0.0.1` matches the server's address family directly.
 fn build_hook_script(agent_id: &str) -> String {
     // The sed command removes the leading `{` from the agent's JSON payload so
     // we can inject our own fields at the front. The result is a valid JSON object:
@@ -191,7 +197,7 @@ INPUT=$(cat)\n\
 EVENT=\"$1\"\n\
 STRIPPED=$(printf '%s' \"$INPUT\" | sed 's/^{{//')\n\
 PAYLOAD=\"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\",$STRIPPED\"\n\
-{{ curl -sf --max-time 5 -X POST http://localhost:47384/hook \\\n\
+{{ curl -sf --max-time 5 -X POST http://127.0.0.1:47384/hook \\\n\
     -H 'Content-Type: application/json' \\\n\
     -d \"$PAYLOAD\" \\\n\
     >/dev/null 2>&1 & }} 2>/dev/null\n\
@@ -819,7 +825,9 @@ mod tests {
         write_hook_script_to(claude_config(), &script).await.unwrap();
 
         let content = fs::read_to_string(&script).unwrap();
-        assert!(content.contains("localhost:47384"), "script should be updated");
+        // 127.0.0.1 (not `localhost`) so the script's address family matches
+        // the server's bind. See doc comment on `build_hook_script`.
+        assert!(content.contains("127.0.0.1:47384"), "script should be updated");
         assert!(!content.contains("echo old"), "old content should be replaced");
     }
 }

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -17,14 +17,15 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 
 // ─── Static registry ─────────────────────────────────────────────────────────
-
-/// Distinguishes how hook entries are serialised into the agent's config file.
-pub enum HookConfigFormat {
-    /// `{"type":"command","command":"...","timeout":N}` — used by Claude Code.
-    Claude,
-    /// `{"command":"..."}` — used by Codex CLI.
-    Codex,
-}
+//
+// All supported agents (Claude Code, Codex) speak the same hook protocol:
+// nested matcher+hooks JSON entries with `{type:"command", command:"…", timeout:N}`.
+// Codex's `hook_runtime.rs` module is literally called `ClaudeHooksEngine` and
+// reads the same shape from `~/.codex/hooks.json` that Claude reads from
+// `~/.claude/settings.json`. There used to be a `HookConfigFormat::Codex` flat
+// variant — that was wrong and silently broke codex hook delivery from day one.
+// The 2026-04-27 e2e tests caught it: Codex never fired for our config until we
+// rewrote `hooks.json` in the nested format.
 
 pub struct AgentHookEvent {
     /// Name used as the key in the agent's config (e.g. `"UserPromptSubmit"`).
@@ -40,8 +41,7 @@ pub struct AgentHookConfig {
     pub agent_id: &'static str,
     /// Tilde path to the agent's hook config file.
     pub config_tilde_path: &'static str,
-    pub config_format: HookConfigFormat,
-    /// Timeout (ms) written into Claude-format entries.
+    /// Timeout (ms) written into each hook entry.
     pub timeout_ms: u64,
     pub events: &'static [AgentHookEvent],
 }
@@ -52,7 +52,6 @@ pub static AGENT_HOOK_CONFIGS: &[AgentHookConfig] = &[
         hook_stem: "claude",
         agent_id: "claude-code",
         config_tilde_path: "~/.claude/settings.json",
-        config_format: HookConfigFormat::Claude,
         timeout_ms: 10_000,
         events: &[
             AgentHookEvent { event_name: "SessionStart" },
@@ -68,7 +67,6 @@ pub static AGENT_HOOK_CONFIGS: &[AgentHookConfig] = &[
         hook_stem: "codex",
         agent_id: "codex",
         config_tilde_path: "~/.codex/hooks.json",
-        config_format: HookConfigFormat::Codex,
         timeout_ms: 5_000,
         events: &[
             AgentHookEvent { event_name: "SessionStart" },
@@ -257,14 +255,10 @@ pub(crate) async fn merge_hook_config_at(
                 .as_array_mut()
                 .ok_or_else(|| format!("\"hooks.{}\" is not a JSON array", event.event_name))?;
 
-            // Idempotency check — skip if our command is already present (C5, C10, D3, D4).
-            // Check is format-aware: Claude uses nested `hooks[]` arrays; Codex uses flat entries.
-            let already_installed = match config.config_format {
-                HookConfigFormat::Claude => command_in_nested_entry(arr, &our_command),
-                HookConfigFormat::Codex => arr.iter().any(|entry| {
-                    entry.get("command").and_then(|v| v.as_str()) == Some(our_command.as_str())
-                }),
-            };
+            // Idempotency check — skip if our command is already present in the
+            // nested hooks[] array (C5, C10, D3, D4). Same check for both
+            // Claude and Codex since they share the schema.
+            let already_installed = command_in_nested_entry(arr, &our_command);
 
             if !already_installed {
                 arr.push(build_hook_entry(config, &our_command));
@@ -291,25 +285,23 @@ pub(crate) async fn merge_hook_config_at(
     Ok(())
 }
 
+/// Builds a single hook entry in the nested matcher+hooks JSON format.
+///
+/// Both Claude Code and Codex CLI use this exact schema. Codex implements
+/// Claude's hook protocol verbatim (see codex-rs/hooks/ — the engine is named
+/// `ClaudeHooksEngine`). Empty matcher string means "match all" (fires for
+/// every tool/event).
 fn build_hook_entry(config: &AgentHookConfig, command: &str) -> Value {
-    match config.config_format {
-        // Claude Code format (as of Claude Code ≥1.x):
-        // each array entry is a matcher object wrapping an inner hooks array.
-        // Empty matcher string means "match all" (fires for every tool/event).
-        HookConfigFormat::Claude => serde_json::json!({
-            "matcher": "",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": command,
-                    "timeout": config.timeout_ms,
-                }
-            ]
-        }),
-        HookConfigFormat::Codex => serde_json::json!({
-            "command": command,
-        }),
-    }
+    serde_json::json!({
+        "matcher": "",
+        "hooks": [
+            {
+                "type": "command",
+                "command": command,
+                "timeout": config.timeout_ms,
+            }
+        ]
+    })
 }
 
 /// Returns true if `our_command` is found inside any entry's nested `hooks` array.
@@ -649,7 +641,7 @@ mod tests {
         }
     }
 
-    // ── D1: Codex fresh install ───────────────────────────────────────────────
+    // ── D1: Codex fresh install — nested matcher+hooks format ────────────────
     #[tokio::test]
     async fn d1_codex_fresh_install() {
         let dir = temp_dir("d1");
@@ -663,34 +655,28 @@ mod tests {
         let v = read_json(&config_path);
         assert!(v["hooks"].is_object());
         for event in codex_config().events {
-            let arr = v["hooks"][event.event_name].as_array().unwrap();
-            let our_cmd = format!("{} {}", script.display(), event.event_name);
+            // Same nested format as Claude: each entry has a "hooks" array
+            // containing {type:"command", command:"…"} objects. Codex's hook
+            // engine is literally Claude's — see codex-rs/hooks/.
             assert!(
-                arr.iter().any(|e| e["command"].as_str() == Some(our_cmd.as_str())),
-                "missing {}", event.event_name
-            );
-            // Codex format: no "type" field.
-            let our_entry = arr
-                .iter()
-                .find(|e| e["command"].as_str() == Some(our_cmd.as_str()))
-                .unwrap();
-            assert!(
-                our_entry.get("type").is_none(),
-                "Codex entries must not have a type field"
+                has_our_command(&v, event.event_name, &script),
+                "missing {} in nested matcher+hooks format", event.event_name
             );
         }
     }
 
-    // ── D2: Codex file exists, entries absent → appended ─────────────────────
+    // ── D2: Codex file exists, entries absent → appended (nested format) ─────
     #[tokio::test]
     async fn d2_codex_append_to_existing() {
         let dir = temp_dir("d2");
         let config_path = dir.join("hooks.json");
         let script = dir.join("codex-hook");
 
+        // Pre-existing entry uses the same nested format too — that's the
+        // canonical schema for codex hooks.
         fs::write(
             &config_path,
-            r#"{"hooks":{"SessionStart":[{"command":"my-existing-hook start"}]}}"#,
+            r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"my-existing-hook start"}]}]}}"#,
         )
         .unwrap();
 
@@ -699,11 +685,20 @@ mod tests {
             .unwrap();
 
         let v = read_json(&config_path);
-        // Existing entry preserved.
         let arr = v["hooks"]["SessionStart"].as_array().unwrap();
-        assert!(arr
-            .iter()
-            .any(|e| e["command"].as_str() == Some("my-existing-hook start")));
+        // Existing entry preserved.
+        let existing_present = arr.iter().any(|entry| {
+            entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .map(|inner| {
+                    inner.iter().any(|h| {
+                        h.get("command").and_then(|c| c.as_str()) == Some("my-existing-hook start")
+                    })
+                })
+                .unwrap_or(false)
+        });
+        assert!(existing_present, "existing nested hook entry should be preserved");
         // Ours also present.
         assert!(has_our_command(&v, "SessionStart", &script));
     }
@@ -746,10 +741,25 @@ mod tests {
         for event in codex_config().events {
             let arr = v["hooks"][event.event_name].as_array().unwrap();
             let our_cmd = format!("{} {}", script.display(), event.event_name);
-            let count = arr
+            // Count occurrences inside nested hooks[] arrays (same format as Claude).
+            let count: usize = arr
                 .iter()
-                .filter(|e| e["command"].as_str() == Some(our_cmd.as_str()))
-                .count();
+                .map(|entry| {
+                    entry
+                        .get("hooks")
+                        .and_then(|h| h.as_array())
+                        .map(|inner| {
+                            inner
+                                .iter()
+                                .filter(|h| {
+                                    h.get("command").and_then(|c| c.as_str())
+                                        == Some(our_cmd.as_str())
+                                })
+                                .count()
+                        })
+                        .unwrap_or(0)
+                })
+                .sum();
             assert_eq!(count, 1, "event {} should have exactly one entry", event.event_name);
         }
     }

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -71,6 +71,11 @@ pub static AGENT_HOOK_CONFIGS: &[AgentHookConfig] = &[
         events: &[
             AgentHookEvent { event_name: "SessionStart" },
             AgentHookEvent { event_name: "UserPromptSubmit" },
+            // Codex's equivalent of Claude's `Notification` — fires when the
+            // agent is blocked waiting for user approval (e.g. a shell command
+            // that needs confirmation). Routed to the same `awaiting` state in
+            // AgentTurnMod so the UI shows the amber badge identically.
+            AgentHookEvent { event_name: "PermissionRequest" },
             AgentHookEvent { event_name: "Stop" },
         ],
     },

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -154,21 +154,45 @@ pub(crate) async fn write_hook_script_to(
 /// Generates the hook shell script content for `agent_id`.
 ///
 /// The script reads the agent's JSON payload from stdin, prepends `agent` and
-/// `event` fields, and POSTs to the hook server. Always exits 0 so the agent
-/// is never blocked by a hook failure.
+/// `event` fields, and fires a curl POST to the hook server in a detached
+/// background subshell. The script exits in milliseconds regardless of what
+/// curl does — Claude Code (and any other agent) is never blocked waiting on
+/// the hook server.
+///
+/// Why detach instead of `--connect-timeout`/`--max-time`: ECONNREFUSED is
+/// instant on macOS, so a missing server doesn't hang. The hang we hit in
+/// 2026-04-26 was from a zombie process holding port 47384 in LISTEN state
+/// without responding — curl established the TCP connection then waited ~60s
+/// for a response that never came. A timeout would bound the hang per call,
+/// but every hook would still pay that cost. Fire-and-forget eliminates the
+/// problem structurally: the script's only job is one-way notification, so
+/// it has no business waiting for the HTTP response. `--max-time 5` stays as
+/// a ceiling on background curl lifetime so they don't accumulate as zombies
+/// if the server is hung and hooks fire repeatedly.
 fn build_hook_script(agent_id: &str) -> String {
     // The sed command removes the leading `{` from the agent's JSON payload so
     // we can inject our own fields at the front. The result is a valid JSON object:
     //   {"agent":"claude-code","event":"UserPromptSubmit","session_id":"...","cwd":"..."}
+    //
+    // CRITICAL: the inner echo uses bare "$INPUT" (shell-quoted), NOT \"$INPUT\".
+    // The backslash-quote form prints LITERAL quote characters around the value,
+    // so sed never sees the leading `{` and the merged payload is malformed JSON.
+    // That bug shipped originally and silently broke every hook delivery —
+    // serde rejected the bad JSON, ps-fallback kept the UI working, nobody
+    // noticed until the integration tests caught it.
     format!(
         "#!/bin/sh\n\
 # Written by Agent Terminal. Do not edit — regenerated on each launch.\n\
+# Fire-and-forget: script returns immediately so Claude/Codex never block on hook delivery.\n\
 INPUT=$(cat)\n\
 EVENT=\"$1\"\n\
-curl -sf -X POST http://localhost:47384/hook \\\n\
-  -H 'Content-Type: application/json' \\\n\
-  -d \"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\",$(echo \\\"$INPUT\\\" | sed 's/^{{//')}}\" \\\n\
-  >/dev/null 2>&1 || true\n",
+STRIPPED=$(printf '%s' \"$INPUT\" | sed 's/^{{//')\n\
+PAYLOAD=\"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\",$STRIPPED\"\n\
+{{ curl -sf --max-time 5 -X POST http://localhost:47384/hook \\\n\
+    -H 'Content-Type: application/json' \\\n\
+    -d \"$PAYLOAD\" \\\n\
+    >/dev/null 2>&1 & }} 2>/dev/null\n\
+exit 0\n",
     )
 }
 

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -233,20 +233,14 @@ pub(crate) async fn merge_hook_config_at(
                 .as_array_mut()
                 .ok_or_else(|| format!("\"hooks.{}\" is not a JSON array", event.event_name))?;
 
-            // Migration: remove stale flat-format entries (old Claude format was
-            // {type, command} at the top level; Claude now requires the matcher+hooks
-            // nesting). These cause Claude Code to report a "settings file damaged" error.
-            let before = arr.len();
-            arr.retain(|entry| {
-                entry.get("command").and_then(|v| v.as_str()) != Some(our_command.as_str())
-            });
-            if arr.len() < before {
-                modified = true;
-            }
-
-            // Idempotency check — skip if our command is already present in the
-            // current (nested matcher+hooks) format (C5, C10, D3, D4).
-            let already_installed = command_in_nested_entry(arr, &our_command);
+            // Idempotency check — skip if our command is already present (C5, C10, D3, D4).
+            // Check is format-aware: Claude uses nested `hooks[]` arrays; Codex uses flat entries.
+            let already_installed = match config.config_format {
+                HookConfigFormat::Claude => command_in_nested_entry(arr, &our_command),
+                HookConfigFormat::Codex => arr.iter().any(|entry| {
+                    entry.get("command").and_then(|v| v.as_str()) == Some(our_command.as_str())
+                }),
+            };
 
             if !already_installed {
                 arr.push(build_hook_entry(config, &our_command));
@@ -629,41 +623,6 @@ mod tests {
                 .count();
             assert_eq!(count, 1, "event {} should have exactly one entry", event.event_name);
         }
-    }
-
-    // ── C11: stale flat-format entries are replaced with new nested format ────
-    #[tokio::test]
-    async fn c11_claude_migrates_old_flat_format() {
-        let dir = temp_dir("c11");
-        let config_path = dir.join("settings.json");
-        let script = dir.join("claude-hook");
-        let our_cmd = format!("{} UserPromptSubmit", script.display());
-
-        // Write the old (now-invalid) flat format that we used to produce.
-        fs::write(
-            &config_path,
-            format!(
-                r#"{{"hooks":{{"UserPromptSubmit":[{{"type":"command","command":"{our_cmd}","timeout":10000}}]}}}}"#
-            ),
-        )
-        .unwrap();
-
-        merge_hook_config_at(claude_config(), &config_path, &script)
-            .await
-            .unwrap();
-
-        let v = read_json(&config_path);
-        let arr = v["hooks"]["UserPromptSubmit"].as_array().unwrap();
-
-        // Old flat entry must be gone.
-        let flat_still_there = arr.iter().any(|e| e["command"].as_str() == Some(&our_cmd));
-        assert!(!flat_still_there, "stale flat entry should be removed");
-
-        // New nested entry must be present.
-        assert!(has_our_command(&v, "UserPromptSubmit", &script));
-
-        // Only one entry for UserPromptSubmit (no duplicate).
-        assert_eq!(arr.len(), 1, "should be exactly one entry after migration");
     }
 
     // ── D1: Codex fresh install ───────────────────────────────────────────────

--- a/src-tauri/src/hook_server.rs
+++ b/src-tauri/src/hook_server.rs
@@ -1,0 +1,69 @@
+//! Minimal HTTP server that receives hook payloads from AI coding agents.
+//!
+//! Agent hooks (Claude Code, Codex) are configured to POST structured JSON to
+//! `http://127.0.0.1:47384/hook` via a small shell helper script. This module
+//! receives those POSTs and forwards them to the MOD engine via an unbounded
+//! channel, where `AgentTurnMod` consumes them.
+//!
+//! The port is fixed so hook configs written to disk (e.g. `~/.claude/settings.json`)
+//! don't need to be rewritten on every launch. `47384` is not assigned to any
+//! common service in the IANA registry.
+
+use axum::{Router, extract::State, http::StatusCode, routing::post, Json};
+use serde::Deserialize;
+use tokio::sync::mpsc;
+
+/// Payload delivered by agent hook scripts to `POST /hook`.
+///
+/// The `agent` and `event` fields are injected by the hook script. All other
+/// fields are passed through as-is from the agent's own stdin JSON.
+#[derive(Deserialize, Clone, Debug)]
+pub struct HookPayload {
+    /// Which agent sent the event: `"claude-code"` or `"codex"`.
+    pub agent: String,
+    /// Lifecycle event name: `"SessionStart"`, `"UserPromptSubmit"`,
+    /// `"PreToolUse"`, `"Notification"`, `"Stop"`, `"SessionEnd"`.
+    pub event: String,
+    pub session_id: Option<String>,
+    pub cwd: Option<String>,
+    pub tool_name: Option<String>,
+    pub message: Option<String>,
+    pub transcript_path: Option<String>,
+    pub last_assistant_message: Option<String>,
+}
+
+/// Starts the hook HTTP server in a background task.
+///
+/// Binds to `127.0.0.1:47384`. If the port is unavailable (another
+/// agent-terminal instance is already running, or a conflicting service),
+/// logs a warning and returns — the rest of the app is unaffected. Hook-based
+/// agent state tracking will degrade gracefully to the `ps`-based heuristics.
+pub fn start_hook_server(hook_tx: mpsc::UnboundedSender<HookPayload>) {
+    tokio::spawn(async move {
+        let app = Router::new()
+            .route("/hook", post(receive_hook))
+            .with_state(hook_tx);
+
+        match tokio::net::TcpListener::bind("127.0.0.1:47384").await {
+            Ok(listener) => {
+                if let Err(e) = axum::serve(listener, app).await {
+                    eprintln!("[hook_server] server error: {e}");
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "[hook_server] failed to bind 127.0.0.1:47384 — \
+                     hook-based agent state will not be available: {e}"
+                );
+            }
+        }
+    });
+}
+
+async fn receive_hook(
+    State(tx): State<mpsc::UnboundedSender<HookPayload>>,
+    Json(payload): Json<HookPayload>,
+) -> StatusCode {
+    let _ = tx.send(payload);
+    StatusCode::OK
+}

--- a/src-tauri/src/hook_server.rs
+++ b/src-tauri/src/hook_server.rs
@@ -39,7 +39,7 @@ pub struct HookPayload {
 /// logs a warning and returns — the rest of the app is unaffected. Hook-based
 /// agent state tracking will degrade gracefully to the `ps`-based heuristics.
 pub fn start_hook_server(hook_tx: mpsc::UnboundedSender<HookPayload>) {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         let app = Router::new()
             .route("/hook", post(receive_hook))
             .with_state(hook_tx);

--- a/src-tauri/src/hook_server.rs
+++ b/src-tauri/src/hook_server.rs
@@ -21,8 +21,9 @@ use tokio::sync::mpsc;
 pub struct HookPayload {
     /// Which agent sent the event: `"claude-code"` or `"codex"`.
     pub agent: String,
-    /// Lifecycle event name: `"SessionStart"`, `"UserPromptSubmit"`,
+    /// Lifecycle event name. Claude Code: `"SessionStart"`, `"UserPromptSubmit"`,
     /// `"PreToolUse"`, `"Notification"`, `"Stop"`, `"SessionEnd"`.
+    /// Codex: same first three, plus `"PermissionRequest"`, `"PostToolUse"`, `"Stop"`.
     pub event: String,
     pub session_id: Option<String>,
     pub cwd: Option<String>,
@@ -30,6 +31,10 @@ pub struct HookPayload {
     pub message: Option<String>,
     pub transcript_path: Option<String>,
     pub last_assistant_message: Option<String>,
+    /// Sent by Codex `PermissionRequest` events — the human-readable
+    /// description of what the agent wants to do (typically a shell command).
+    /// Used as the awaiting-badge tooltip.
+    pub prompt: Option<String>,
 }
 
 /// Starts the hook HTTP server in a background task.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,7 +40,7 @@ pub fn run() {
 
             // Silently install/verify agent hook configs at every launch.
             // Runs in the background — never blocks startup, never crashes the app.
-            tokio::spawn(ensure_hooks_installed());
+            tauri::async_runtime::spawn(ensure_hooks_installed());
 
             // Build the mod engine. Hook channel is created inside the builder.
             let engine_builder = ModEngine::builder()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,16 @@
 mod commands;
+mod hook_config;
+mod hook_server;
 mod mod_engine;
 mod pty_manager;
 mod shell_integration;
 
+use hook_config::ensure_hooks_installed;
+use hook_server::start_hook_server;
 use mod_engine::{
     ModEngine,
     mods::{
+        AgentTurnMod,
         ClaudeCodeMod,
         CodexMod,
         DirTrackerMod,
@@ -33,14 +38,25 @@ pub fn run() {
                 eprintln!("[agent-terminal] shell integration setup failed: {e}");
             }
 
-            let mod_engine = ModEngine::builder()
+            // Silently install/verify agent hook configs at every launch.
+            // Runs in the background — never blocks startup, never crashes the app.
+            tokio::spawn(ensure_hooks_installed());
+
+            // Build the mod engine. Hook channel is created inside the builder.
+            let engine_builder = ModEngine::builder()
                 .with_mod(DirTrackerMod::new())
                 .with_mod(ProcessTrackerMod::new())
                 .with_mod(ClaudeCodeMod::new())
                 .with_mod(CodexMod::new())
                 .with_mod(ShellProcessMod::new())
                 .with_mod(GitMonitorMod::new())
-                .build(app.handle().clone());
+                .with_mod(AgentTurnMod::new());
+
+            // Start the hook HTTP server, wired to the engine's hook channel.
+            let hook_tx = engine_builder.hook_sender();
+            start_hook_server(hook_tx);
+
+            let mod_engine = engine_builder.build(app.handle().clone());
             app.manage(mod_engine);
             Ok(())
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,9 @@
 mod commands;
-mod hook_config;
-mod hook_server;
+// `pub` so integration tests in `tests/` can call `ensure_hooks_installed()` and
+// build payloads against `HookPayload`. Internal API otherwise — the app uses these
+// modules directly.
+pub mod hook_config;
+pub mod hook_server;
 mod mod_engine;
 mod pty_manager;
 mod shell_integration;

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use super::context::{AgentSignal, AgentSignalKind, CwdUpdate, ModContext, ModEvent};
 use super::Mod;
+use crate::hook_server::HookPayload;
 use tauri::{AppHandle, Emitter, async_runtime};
 use tokio::sync::mpsc;
 
@@ -56,8 +57,13 @@ impl ModEngineHandle {
 }
 
 /// Collects MODs before building the engine.
+///
+/// Also creates the hook event channel. Call `hook_sender()` before `build()` to
+/// get a sender you can pass to `start_hook_server()`.
 pub struct ModEngineBuilder {
     mods: Vec<Box<dyn Mod>>,
+    hook_tx: mpsc::UnboundedSender<HookPayload>,
+    hook_rx: mpsc::UnboundedReceiver<HookPayload>,
 }
 
 impl ModEngineBuilder {
@@ -66,8 +72,13 @@ impl ModEngineBuilder {
         self
     }
 
+    /// Returns a sender for hook events. Pass this to `start_hook_server()`.
+    pub fn hook_sender(&self) -> mpsc::UnboundedSender<HookPayload> {
+        self.hook_tx.clone()
+    }
+
     pub fn build(self, app: AppHandle) -> ModEngine {
-        ModEngine::start(self.mods, app)
+        ModEngine::start(self.mods, self.hook_rx, app)
     }
 }
 
@@ -83,7 +94,8 @@ pub struct ModEngine {
 
 impl ModEngine {
     pub fn builder() -> ModEngineBuilder {
-        ModEngineBuilder { mods: Vec::new() }
+        let (hook_tx, hook_rx) = mpsc::unbounded_channel::<HookPayload>();
+        ModEngineBuilder { mods: Vec::new(), hook_tx, hook_rx }
     }
 
     /// Returns a cheap cloneable handle suitable for passing to threads or commands.
@@ -91,7 +103,7 @@ impl ModEngine {
         self.handle.clone()
     }
 
-    fn start(mods: Vec<Box<dyn Mod>>, app: AppHandle) -> Self {
+    fn start(mods: Vec<Box<dyn Mod>>, mut hook_rx: mpsc::UnboundedReceiver<HookPayload>, app: AppHandle) -> Self {
         // Bounded channel for data messages (Output/Input/Resize).
         let (msg_tx, mut msg_rx) = mpsc::channel::<ModMessage>(512);
         // Unbounded channel for lifecycle messages (Open/Close) — never dropped.
@@ -189,6 +201,13 @@ impl ModEngine {
                                 for m in &mut mods { m.on_agent_cleared(&sig.agent, &ctx); }
                             }
                         }
+                    }
+                    // Hook events from the HTTP server. Not tab-scoped at the engine
+                    // level — AgentTurnMod resolves the tab internally via session_id /
+                    // CWD matching and emits directly via its own AsyncEmitter map.
+                    hook = hook_rx.recv() => {
+                        let Some(payload) = hook else { break };
+                        for m in &mut mods { m.on_hook_event(&payload); }
                     }
                 }
             }

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -78,7 +78,7 @@ impl ModEngineBuilder {
     }
 
     pub fn build(self, app: AppHandle) -> ModEngine {
-        ModEngine::start(self.mods, self.hook_rx, app)
+        ModEngine::start(self.mods, self.hook_tx, self.hook_rx, app)
     }
 }
 
@@ -90,6 +90,16 @@ impl ModEngineBuilder {
 /// `ModEngineHandle` for dispatching; the PTY read thread clones that handle.
 pub struct ModEngine {
     handle: ModEngineHandle,
+    /// Keeps the hook channel alive for the engine's full lifetime. The
+    /// dispatcher's `select!` arm calls `hook_rx.recv()`, which returns `None`
+    /// when the last sender is dropped. If `start_hook_server()` fails to
+    /// bind 47384, its own clone gets dropped — and without this keepalive
+    /// the channel would close, the select arm would hit `None`, and breaking
+    /// out of that arm would tear down the entire MOD engine (process
+    /// detection, dir tracking, git monitoring, all gone). Holding this clone
+    /// here means `recv()` only returns `None` at app shutdown when the whole
+    /// engine is dropped.
+    _hook_tx_keepalive: mpsc::UnboundedSender<HookPayload>,
 }
 
 impl ModEngine {
@@ -103,7 +113,12 @@ impl ModEngine {
         self.handle.clone()
     }
 
-    fn start(mods: Vec<Box<dyn Mod>>, mut hook_rx: mpsc::UnboundedReceiver<HookPayload>, app: AppHandle) -> Self {
+    fn start(
+        mods: Vec<Box<dyn Mod>>,
+        hook_tx_keepalive: mpsc::UnboundedSender<HookPayload>,
+        mut hook_rx: mpsc::UnboundedReceiver<HookPayload>,
+        app: AppHandle,
+    ) -> Self {
         // Bounded channel for data messages (Output/Input/Resize).
         let (msg_tx, mut msg_rx) = mpsc::channel::<ModMessage>(512);
         // Unbounded channel for lifecycle messages (Open/Close) — never dropped.
@@ -205,9 +220,15 @@ impl ModEngine {
                     // Hook events from the HTTP server. Not tab-scoped at the engine
                     // level — AgentTurnMod resolves the tab internally via session_id /
                     // CWD matching and emits directly via its own AsyncEmitter map.
+                    //
+                    // ModEngine holds a `_hook_tx_keepalive` clone so the channel never
+                    // closes naturally. If `recv()` ever does return `None` we just
+                    // skip — never `break` from the dispatcher, which would kill all
+                    // mod processing (process detection, dir tracking, git, …).
                     hook = hook_rx.recv() => {
-                        let Some(payload) = hook else { break };
-                        for m in &mut mods { m.on_hook_event(&payload); }
+                        if let Some(payload) = hook {
+                            for m in &mut mods { m.on_hook_event(&payload); }
+                        }
                     }
                 }
             }
@@ -220,6 +241,9 @@ impl ModEngine {
             }
         });
 
-        Self { handle: ModEngineHandle { tx: msg_tx, lifecycle_tx } }
+        Self {
+            handle: ModEngineHandle { tx: msg_tx, lifecycle_tx },
+            _hook_tx_keepalive: hook_tx_keepalive,
+        }
     }
 }

--- a/src-tauri/src/mod_engine/mod.rs
+++ b/src-tauri/src/mod_engine/mod.rs
@@ -50,4 +50,12 @@ pub trait Mod: Send + 'static {
     /// Called by the engine when `ProcessInspectorMod` no longer sees an agent
     /// process that was previously detected in this tab's CWD. Default is a no-op.
     fn on_agent_cleared(&mut self, _agent: &str, _ctx: &ModContext) {}
+
+    /// Called by the engine when a hook event arrives from the HTTP hook server.
+    ///
+    /// Hook events are not tab-scoped at the engine level — the payload carries
+    /// `session_id` and `cwd` that the MOD uses internally to resolve which tab
+    /// the event belongs to. `AgentTurnMod` is the only MOD that implements this;
+    /// all others use the default no-op.
+    fn on_hook_event(&mut self, _payload: &crate::hook_server::HookPayload) {}
 }

--- a/src-tauri/src/mod_engine/mods/agent_turn.rs
+++ b/src-tauri/src/mod_engine/mods/agent_turn.rs
@@ -1,0 +1,305 @@
+//! `AgentTurnMod` — tracks the turn state of AI coding agent sessions via
+//! structured hook events delivered by each agent's own hook system.
+//!
+//! State machine per session:
+//!
+//! ```text
+//! SessionStart   → Idle
+//! UserPromptSubmit / PreToolUse (non-question) → InProgress
+//! PreToolUse (tool_name == "AskUserQuestion")  → saves question, state unchanged
+//! Notification   → Awaiting { message }
+//! Stop           → Completed (async: reads transcript for last message)
+//! SessionEnd     → session removed, emit Idle to clear badge
+//! ```
+//!
+//! The mod emits `agent_state_changed` events to the frontend, which writes
+//! into `$tabMeta.agentState`. `deriveAgentState()` in `agent.helpers.ts`
+//! reads this field and renders the correct badge/animation.
+
+use std::collections::HashMap;
+
+use crate::hook_server::HookPayload;
+use crate::mod_engine::{AsyncEmitter, Mod, ModContext};
+
+// ─── State types ─────────────────────────────────────────────────────────────
+
+struct SessionState {
+    tab_id: String,
+    /// Saved from PreToolUse(AskUserQuestion) — used as the Awaiting message.
+    pending_question: Option<String>,
+}
+
+// ─── Mod ─────────────────────────────────────────────────────────────────────
+
+/// Tracks per-session agent turn state via hook events.
+pub struct AgentTurnMod {
+    /// tab_id → AsyncEmitter (populated on_open, removed on_close).
+    emitters: HashMap<String, AsyncEmitter>,
+    /// tab_id → current cwd (updated via on_cwd_changed).
+    tab_cwds: HashMap<String, String>,
+    /// session_id → SessionState (populated on SessionStart).
+    sessions: HashMap<String, SessionState>,
+}
+
+impl AgentTurnMod {
+    pub fn new() -> Self {
+        Self {
+            emitters: HashMap::new(),
+            tab_cwds: HashMap::new(),
+            sessions: HashMap::new(),
+        }
+    }
+
+    // ── Resolution helpers ────────────────────────────────────────────────────
+
+    /// Resolves a tab_id from a hook payload.
+    /// Tries session_id lookup first, then CWD prefix match as fallback.
+    fn tab_id_for(&self, payload: &HookPayload) -> Option<String> {
+        // 1. Direct session_id lookup (fastest — mapping established at SessionStart).
+        if let Some(sid) = &payload.session_id {
+            if let Some(state) = self.sessions.get(sid.as_str()) {
+                return Some(state.tab_id.clone());
+            }
+        }
+        // 2. CWD prefix match fallback.
+        self.cwd_match(payload.cwd.as_deref())
+    }
+
+    /// Finds a tab whose tracked CWD matches `cwd` via prefix matching.
+    fn cwd_match(&self, cwd: Option<&str>) -> Option<String> {
+        let cwd = cwd?;
+        self.tab_cwds
+            .iter()
+            .find(|(_, tab_cwd)| {
+                tab_cwd.starts_with(cwd) || cwd.starts_with(tab_cwd.as_str())
+            })
+            .map(|(tab_id, _)| tab_id.clone())
+    }
+
+    /// Gets or creates a session keyed by session_id (or a synthetic key for
+    /// sessions whose SessionStart was missed).
+    fn session_key(payload: &HookPayload, tab_id: &str) -> String {
+        payload
+            .session_id
+            .clone()
+            .unwrap_or_else(|| format!("synthetic:{tab_id}"))
+    }
+
+    // ── Emit helper ───────────────────────────────────────────────────────────
+
+    fn emit_state(&self, tab_id: &str, state: &str, message: Option<&str>) {
+        let Some(emitter) = self.emitters.get(tab_id) else { return };
+        let mut data = serde_json::json!({ "state": state });
+        if let Some(msg) = message {
+            data["message"] = serde_json::Value::String(msg.to_string());
+        }
+        emitter.emit("agent_turn", "agent_state_changed", data);
+    }
+}
+
+// ─── Mod trait implementation ─────────────────────────────────────────────────
+
+impl Mod for AgentTurnMod {
+    fn id(&self) -> &'static str {
+        "agent_turn"
+    }
+
+    fn on_open(&mut self, ctx: &ModContext) {
+        self.emitters.insert(ctx.tab_id.to_string(), ctx.async_emitter());
+    }
+
+    fn on_cwd_changed(&mut self, cwd: &str, ctx: &ModContext) {
+        self.tab_cwds.insert(ctx.tab_id.to_string(), cwd.to_string());
+    }
+
+    fn on_close(&mut self, ctx: &ModContext) {
+        self.emitters.remove(ctx.tab_id);
+        self.tab_cwds.remove(ctx.tab_id);
+        self.sessions.retain(|_, s| s.tab_id != ctx.tab_id);
+    }
+
+    fn on_agent_cleared(&mut self, _agent: &str, ctx: &ModContext) {
+        // Fallback cleanup if SessionEnd hook was missed (e.g. agent crashed).
+        self.sessions.retain(|_, s| s.tab_id != ctx.tab_id);
+    }
+
+    fn on_hook_event(&mut self, payload: &HookPayload) {
+        // Filter to known agents so stray POSTs from other tools don't affect state.
+        match payload.agent.as_str() {
+            "claude-code" | "codex" => {}
+            _ => return,
+        }
+        match payload.event.as_str() {
+            "SessionStart" => self.handle_session_start(payload),
+            "UserPromptSubmit" => self.handle_in_progress(payload),
+            "PreToolUse" => {
+                if payload.tool_name.as_deref() == Some("AskUserQuestion") {
+                    self.handle_save_question(payload);
+                } else {
+                    self.handle_in_progress(payload);
+                }
+            }
+            "Notification" => self.handle_awaiting(payload),
+            "Stop" => self.handle_completed(payload),
+            "SessionEnd" => self.handle_session_end(payload),
+            _ => {}
+        }
+    }
+}
+
+// ─── Event handlers ───────────────────────────────────────────────────────────
+
+impl AgentTurnMod {
+    fn handle_session_start(&mut self, payload: &HookPayload) {
+        let Some(session_id) = payload.session_id.clone() else { return };
+        let Some(tab_id) = self.cwd_match(payload.cwd.as_deref()) else { return };
+
+        self.sessions.insert(
+            session_id,
+            SessionState { tab_id: tab_id.clone(), pending_question: None },
+        );
+        self.emit_state(&tab_id, "idle", None);
+    }
+
+    fn handle_in_progress(&mut self, payload: &HookPayload) {
+        // Step 1 — resolve tab_id (immutable borrow).
+        let Some(tab_id) = self.tab_id_for(payload) else { return };
+
+        // Step 2 — mutate / create session (mutable borrow, drops before emit).
+        {
+            let key = Self::session_key(payload, &tab_id);
+            let state = self.sessions.entry(key).or_insert_with(|| SessionState {
+                tab_id: tab_id.clone(),
+                pending_question: None,
+            });
+            state.pending_question = None;
+        }
+
+        // Step 3 — emit (immutable borrow).
+        self.emit_state(&tab_id, "in-progress", None);
+    }
+
+    fn handle_save_question(&mut self, payload: &HookPayload) {
+        let Some(tab_id) = self.tab_id_for(payload) else { return };
+        let Some(msg) = &payload.message else { return };
+        if msg.trim().is_empty() { return; }
+
+        let msg = msg.clone();
+        let key = Self::session_key(payload, &tab_id);
+        let state = self.sessions.entry(key).or_insert_with(|| SessionState {
+            tab_id: tab_id.clone(),
+            pending_question: None,
+        });
+        state.pending_question = Some(msg);
+        // No state change — agent is still running.
+    }
+
+    fn handle_awaiting(&mut self, payload: &HookPayload) {
+        let Some(tab_id) = self.tab_id_for(payload) else { return };
+
+        // Step 2 — take pending_question out of session (mutable).
+        let message: Option<String> = {
+            let key = Self::session_key(payload, &tab_id);
+            let state = self.sessions.entry(key).or_insert_with(|| SessionState {
+                tab_id: tab_id.clone(),
+                pending_question: None,
+            });
+            state.pending_question.take()
+        };
+
+        // Fall back to raw notification message, or a generic placeholder.
+        let message = message
+            .or_else(|| payload.message.clone().filter(|m| !m.trim().is_empty()))
+            .or_else(|| Some("Needs your attention".to_string()));
+
+        self.emit_state(&tab_id, "awaiting", message.as_deref());
+    }
+
+    fn handle_completed(&mut self, payload: &HookPayload) {
+        let Some(tab_id) = self.tab_id_for(payload) else { return };
+        let Some(emitter) = self.emitters.get(&tab_id).cloned() else { return };
+
+        // Prefer direct payload field (Codex), then transcript file (Claude).
+        let direct_msg = payload
+            .last_assistant_message
+            .clone()
+            .filter(|m| !m.trim().is_empty());
+        let transcript = payload.transcript_path.clone();
+
+        tokio::spawn(async move {
+            let message = if let Some(msg) = direct_msg {
+                Some(msg)
+            } else if let Some(path) = transcript {
+                read_last_assistant_message(&path).await
+            } else {
+                None
+            };
+
+            let mut data = serde_json::json!({ "state": "completed" });
+            if let Some(msg) = message {
+                let truncated: String = msg.chars().take(200).collect();
+                data["message"] = serde_json::Value::String(truncated);
+            }
+            emitter.emit("agent_turn", "agent_state_changed", data);
+        });
+    }
+
+    fn handle_session_end(&mut self, payload: &HookPayload) {
+        // Determine tab_id before removing the session.
+        let tab_id = payload
+            .session_id
+            .as_ref()
+            .and_then(|sid| self.sessions.get(sid.as_str()).map(|s| s.tab_id.clone()))
+            .or_else(|| self.cwd_match(payload.cwd.as_deref()));
+
+        // Remove the session.
+        if let Some(sid) = &payload.session_id {
+            self.sessions.remove(sid.as_str());
+        }
+
+        // Emit idle to clear the completed badge.
+        if let Some(tab_id) = tab_id {
+            self.emit_state(&tab_id, "idle", None);
+        }
+    }
+}
+
+// ─── Transcript reader ────────────────────────────────────────────────────────
+
+/// Reads the last assistant message from a Claude session JSONL transcript.
+async fn read_last_assistant_message(transcript_path: &str) -> Option<String> {
+    let content = tokio::fs::read_to_string(transcript_path).await.ok()?;
+
+    for line in content.lines().rev() {
+        let entry: serde_json::Value = serde_json::from_str(line).ok()?;
+
+        if entry.get("message")?.get("role")?.as_str()? != "assistant" {
+            continue;
+        }
+
+        let content_val = &entry["message"]["content"];
+        let text = if let Some(s) = content_val.as_str() {
+            s.to_string()
+        } else if let Some(arr) = content_val.as_array() {
+            arr.iter()
+                .filter_map(|c| {
+                    if c.get("type")?.as_str()? == "text" {
+                        c.get("text")?.as_str().map(|s| s.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        } else {
+            continue;
+        };
+
+        let trimmed = text.trim().to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
+
+    None
+}

--- a/src-tauri/src/mod_engine/mods/agent_turn.rs
+++ b/src-tauri/src/mod_engine/mods/agent_turn.rs
@@ -277,17 +277,30 @@ impl AgentTurnMod {
 // ─── Transcript reader ────────────────────────────────────────────────────────
 
 /// Reads the last assistant message from a Claude session JSONL transcript.
+///
+/// Iterates lines in reverse and returns the first valid assistant message
+/// found. Lines that fail to parse OR don't match the assistant-message shape
+/// are skipped — we keep scanning earlier lines instead of aborting. Claude's
+/// JSONL transcripts mix entry types (user, assistant, tool_use, system,
+/// summary, etc.), so it's normal for the trailing lines near EOF to be
+/// non-assistant entries. Using `?` on per-line `Option`s here would bail out
+/// on the first such line and miss every assistant message before it.
 async fn read_last_assistant_message(transcript_path: &str) -> Option<String> {
     let content = tokio::fs::read_to_string(transcript_path).await.ok()?;
 
     for line in content.lines().rev() {
-        let entry: serde_json::Value = serde_json::from_str(line).ok()?;
+        let entry: serde_json::Value = match serde_json::from_str(line) {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
 
-        if entry.get("message")?.get("role")?.as_str()? != "assistant" {
+        let Some(message) = entry.get("message") else { continue };
+        let Some(role) = message.get("role").and_then(|r| r.as_str()) else { continue };
+        if role != "assistant" {
             continue;
         }
 
-        let content_val = &entry["message"]["content"];
+        let content_val = &message["content"];
         let text = if let Some(s) = content_val.as_str() {
             s.to_string()
         } else if let Some(arr) = content_val.as_array() {
@@ -312,4 +325,67 @@ async fn read_last_assistant_message(transcript_path: &str) -> Option<String> {
     }
 
     None
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_temp(name: &str, content: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    /// Regression guard for the bug Copilot caught on PR #24:
+    /// `read_last_assistant_message` previously used `?` on per-line `Option`s,
+    /// so the very first non-assistant line near EOF (a tool_use record, a
+    /// summary, or any malformed line) would abort the whole search and return
+    /// `None` — even if earlier valid assistant messages existed.
+    #[tokio::test]
+    async fn transcript_reader_skips_non_assistant_and_malformed_lines() {
+        let pid = std::process::id();
+        let path = write_temp(
+            &format!("agent-terminal-transcript-test-{pid}.jsonl"),
+            // Reverse-chronological reading: line 1 (top) is the OLDEST, line 5 is the NEWEST.
+            // The reader iterates lines.rev() so it sees line 5 first.
+            // - line 5: malformed JSON                    → must not abort
+            // - line 4: valid JSON, no `message` field    → must not abort
+            // - line 3: valid JSON, role != "assistant"   → must not abort
+            // - line 2: valid assistant message           → must be returned
+            // - line 1: earlier assistant (should NOT win — line 2 is more recent)
+            r#"{"message":{"role":"assistant","content":"earlier message"}}
+{"message":{"role":"assistant","content":"the right answer"}}
+{"message":{"role":"user","content":"a user line"}}
+{"type":"summary","payload":42}
+this line is not json at all
+"#,
+        );
+
+        let got = read_last_assistant_message(path.to_str().unwrap()).await;
+        assert_eq!(
+            got.as_deref(),
+            Some("the right answer"),
+            "reader must skip malformed/non-assistant lines and return the most recent assistant message"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Confirms array-shaped content (Claude's modern format) round-trips too.
+    #[tokio::test]
+    async fn transcript_reader_handles_array_content() {
+        let pid = std::process::id();
+        let path = write_temp(
+            &format!("agent-terminal-transcript-array-{pid}.jsonl"),
+            r#"{"message":{"role":"assistant","content":[{"type":"text","text":"hello world"}]}}
+"#,
+        );
+
+        let got = read_last_assistant_message(path.to_str().unwrap()).await;
+        assert_eq!(got.as_deref(), Some("hello world"));
+        std::fs::remove_file(&path).ok();
+    }
 }

--- a/src-tauri/src/mod_engine/mods/agent_turn.rs
+++ b/src-tauri/src/mod_engine/mods/agent_turn.rs
@@ -4,13 +4,18 @@
 //! State machine per session:
 //!
 //! ```text
-//! SessionStart   → Idle
+//! SessionStart                                 → Idle
 //! UserPromptSubmit / PreToolUse (non-question) → InProgress
 //! PreToolUse (tool_name == "AskUserQuestion")  → saves question, state unchanged
-//! Notification   → Awaiting { message }
-//! Stop           → Completed (async: reads transcript for last message)
-//! SessionEnd     → session removed, emit Idle to clear badge
+//! Notification (Claude) | PermissionRequest (Codex) → Awaiting { message }
+//! Stop                                         → Completed (async: reads transcript)
+//! SessionEnd                                   → session removed, emit Idle to clear badge
 //! ```
+//!
+//! Awaiting is dispatched from two different event names depending on the agent
+//! — Claude calls it `Notification`, Codex calls it `PermissionRequest`. They
+//! are functionally identical (agent is blocked, user attention required) and
+//! funnel into a single `handle_awaiting` so the UI sees one state.
 //!
 //! The mod emits `agent_state_changed` events to the frontend, which writes
 //! into `$tabMeta.agentState`. `deriveAgentState()` in `agent.helpers.ts`
@@ -139,7 +144,9 @@ impl Mod for AgentTurnMod {
                     self.handle_in_progress(payload);
                 }
             }
-            "Notification" => self.handle_awaiting(payload),
+            // Claude calls it Notification, Codex calls it PermissionRequest —
+            // same role, same handler.
+            "Notification" | "PermissionRequest" => self.handle_awaiting(payload),
             "Stop" => self.handle_completed(payload),
             "SessionEnd" => self.handle_session_end(payload),
             _ => {}
@@ -207,8 +214,11 @@ impl AgentTurnMod {
             state.pending_question.take()
         };
 
-        // Fall back to raw notification message, or a generic placeholder.
+        // Fall back through: saved question (Claude AskUserQuestion) →
+        // codex prompt (Codex PermissionRequest) → claude notification message →
+        // generic placeholder.
         let message = message
+            .or_else(|| payload.prompt.clone().filter(|m| !m.trim().is_empty()))
             .or_else(|| payload.message.clone().filter(|m| !m.trim().is_empty()))
             .or_else(|| Some("Needs your attention".to_string()));
 

--- a/src-tauri/src/mod_engine/mods/mod.rs
+++ b/src-tauri/src/mod_engine/mods/mod.rs
@@ -1,3 +1,4 @@
+mod agent_turn;
 mod claude_code;
 mod codex;
 mod dir_tracker;
@@ -5,6 +6,7 @@ mod git_monitor;
 mod process_tracker;
 mod shell_process;
 
+pub use agent_turn::AgentTurnMod;
 pub use claude_code::ClaudeCodeMod;
 pub use codex::CodexMod;
 pub use dir_tracker::DirTrackerMod;

--- a/src-tauri/tests/hook_integration.rs
+++ b/src-tauri/tests/hook_integration.rs
@@ -462,3 +462,278 @@ async fn i6_real_codex_hooks_no_duplicates() {
         );
     }
 }
+
+// ─── E2E (guided / interactive) helpers ──────────────────────────────────────
+//
+// IMPORTANT: E1/E2 below are NOT fully automated. They are guided tests that
+// require a human user (with a coding agent helping them) to manually run
+// claude/codex commands in a separate terminal.
+//
+// Why guided instead of automated subprocess spawning:
+//   1. AI CLIs prompt interactively for trust dialogs, auth, etc. — automating
+//      around all of that is brittle and per-version.
+//   2. While the test collector is bound to 47384, EVERY claude/codex process
+//      on the machine fires hooks at it (incl. the user's other terminals).
+//      Filtering by cwd helps but the cleanest signal is a human pointing the
+//      CLI at a known-empty directory created by the test.
+//   3. Real E2E means a real human sat down and verified the full path. An
+//      automated subprocess proves only that we can spawn a process; a guided
+//      test proves the actual user-facing behavior.
+//
+// HOW TO RUN: with `cargo test ... --include-ignored --test-threads=1
+// --nocapture`. The test prints exact instructions (cwd + command) on stderr.
+// A coding agent watching the test output should:
+//   - Read the printed cwd and command verbatim
+//   - Tell the user which terminal to open and what to type
+//   - Wait for the user to confirm the command was run
+//   - Let the test continue (it polls for the hook events automatically)
+//
+// SKIPPED when:
+//   - CI=true (CI/CD environments — these tests need a human)
+//   - port 47384 busy (agent-terminal running, or stale binding)
+
+fn ci_environment() -> bool {
+    std::env::var("CI").map(|v| v == "true").unwrap_or(false)
+}
+
+/// How long the guided E2E tests wait for hook events to arrive after printing
+/// instructions. Generous because the user needs time to switch terminals,
+/// paste the command, deal with any auth prompts, and let the LLM respond.
+const E2E_GUIDED_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Polls the received queue and returns ALL payloads from `cwd` once at least
+/// one `SessionStart` from `expected_agent` has arrived. Adds a 2-second tail
+/// after that to capture the rest of the hook sequence (UserPromptSubmit, Stop,
+/// SessionEnd, etc).
+///
+/// Returns an empty Vec on timeout — caller asserts non-empty.
+async fn wait_for_session_in_cwd(
+    received: &Received,
+    cwd: &str,
+    expected_agent: &str,
+    timeout_dur: Duration,
+) -> Vec<Value> {
+    let cwd_prefix = format!("{cwd}/");
+    let start = Instant::now();
+    let mut ours: Vec<Value> = Vec::new();
+    let mut session_start_seen_at: Option<Instant> = None;
+
+    while start.elapsed() < timeout_dur {
+        // Drain whatever is in the shared queue; keep only payloads that match
+        // our cwd and expected agent. Other sessions' hooks (your real Claude
+        // in another terminal) are ambient noise and dropped here.
+        {
+            let mut queue = received.lock().unwrap();
+            while let Some(p) = queue.pop_front() {
+                let matches_cwd = p["cwd"]
+                    .as_str()
+                    .map(|c| c == cwd || c.starts_with(&cwd_prefix))
+                    .unwrap_or(false);
+                let matches_agent = p["agent"] == expected_agent;
+                if matches_cwd && matches_agent {
+                    if p["event"] == "SessionStart" && session_start_seen_at.is_none() {
+                        session_start_seen_at = Some(Instant::now());
+                    }
+                    ours.push(p);
+                }
+            }
+        }
+
+        // Once we see SessionStart, wait an extra 2s for the rest of the
+        // session's events (UserPromptSubmit, Stop) to arrive, then return.
+        if let Some(t) = session_start_seen_at {
+            if t.elapsed() >= Duration::from_secs(2) {
+                return ours;
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    ours
+}
+
+/// Loud, multi-line instruction banner printed to stderr so a coding agent
+/// watching `cargo test --nocapture` output can immediately recognize the
+/// guidance and relay it to the user.
+///
+/// Tests use real INTERACTIVE sessions, not non-interactive `-p` / `exec` modes,
+/// because that's what end users actually use. Hook firing should be verified
+/// against the realistic path. The user opens a session, types a prompt, hits
+/// enter, and the test sees the events.
+fn print_e2e_instructions(
+    test_name: &str,
+    cwd: &str,
+    launch_command: &str,
+    prompt_to_send: &str,
+) {
+    eprintln!();
+    eprintln!("==============================================================");
+    eprintln!("  GUIDED E2E TEST — HUMAN ACTION REQUIRED");
+    eprintln!("  Test: {test_name}");
+    eprintln!("==============================================================");
+    eprintln!("  Step 1 — Open a NEW terminal window and run:");
+    eprintln!();
+    eprintln!("      cd {cwd}");
+    eprintln!("      {launch_command}");
+    eprintln!();
+    eprintln!("  Step 2 — Once the interactive session is ready, type this");
+    eprintln!("           prompt and press Enter to submit:");
+    eprintln!();
+    eprintln!("      {prompt_to_send}");
+    eprintln!();
+    eprintln!("  Step 3 — Wait for the agent to respond. The test will detect");
+    eprintln!("           hook events as they fire and move on automatically.");
+    eprintln!("           You can close the session anytime after that.");
+    eprintln!();
+    eprintln!("  Test will wait up to {} seconds for hook events.", E2E_GUIDED_TIMEOUT.as_secs());
+    eprintln!("==============================================================");
+    eprintln!();
+}
+
+// ─── E1: Real Claude Code fires hooks end-to-end (GUIDED) ────────────────────
+//
+// ⚠️ HUMAN-IN-THE-LOOP TEST. Read the long comment block above the helpers
+// before changing this. The test prepares an isolated cwd, prints exact
+// instructions on stderr, and then waits for hook events to arrive. A coding
+// agent watching `cargo test --nocapture` output should relay the printed
+// instructions to the user and wait for them to run the command.
+//
+// Pre-installs hooks via `ensure_hooks_installed()` so the user can run the
+// command immediately without first launching agent-terminal — even if
+// `~/.claude/settings.json` was previously reset.
+
+#[tokio::test]
+#[ignore]
+async fn e1_guided_claude_fires_hooks_end_to_end() {
+    if ci_environment() {
+        eprintln!("SKIP e1: CI=true — guided e2e tests need a human");
+        return;
+    }
+
+    let _g = acquire_port_lock();
+
+    // Idempotent: adds nothing if hooks are already present.
+    agent_terminal_lib::hook_config::ensure_hooks_installed().await;
+
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP e1: port 47384 busy (agent-terminal running?)");
+        return;
+    };
+    let server = start_collector(listener);
+
+    // Per-PID cwd so the user can re-run the test fresh and the test only sees
+    // hooks fired from THIS run, not stale events from a previous attempt.
+    // Canonicalize: macOS resolves /var/folders → /private/var/folders, and
+    // claude reports the canonical path in hook payloads. Without canonicalize,
+    // our cwd filter rejects every event from the user's manual session.
+    let test_cwd_raw = std::env::temp_dir().join(format!("agent-terminal-e1-{}", std::process::id()));
+    std::fs::create_dir_all(&test_cwd_raw).expect("could not create test cwd");
+    let test_cwd = std::fs::canonicalize(&test_cwd_raw).expect("could not canonicalize test cwd");
+    let test_cwd_str = test_cwd.to_string_lossy().to_string();
+
+    print_e2e_instructions(
+        "e1_guided_claude_fires_hooks_end_to_end",
+        &test_cwd_str,
+        "claude",
+        "Reply with the single word: pong",
+    );
+
+    let ours = wait_for_session_in_cwd(&server.received, &test_cwd_str, "claude-code", E2E_GUIDED_TIMEOUT)
+        .await;
+
+    eprintln!(
+        "e1: received {} matching hook payloads: {:?}",
+        ours.len(),
+        ours.iter()
+            .map(|p| format!("{}/{}", p["agent"].as_str().unwrap_or("?"), p["event"].as_str().unwrap_or("?")))
+            .collect::<Vec<_>>()
+    );
+
+    assert!(
+        !ours.is_empty(),
+        "no hook events arrived for cwd={test_cwd_str} within {}s. \
+         Did the user run `claude -p '...'` in that directory? \
+         If `which claude` is a cmux wrapper, ~/.claude/settings.json is bypassed.",
+        E2E_GUIDED_TIMEOUT.as_secs()
+    );
+
+    let saw_session_start = ours.iter().any(|p| p["event"] == "SessionStart");
+    assert!(
+        saw_session_start,
+        "claude-code events received from our cwd but no SessionStart: {ours:?}"
+    );
+
+    let saw_user_prompt = ours.iter().any(|p| p["event"] == "UserPromptSubmit");
+    assert!(
+        saw_user_prompt,
+        "SessionStart fired but no UserPromptSubmit — \
+         did the user actually submit a prompt? Events: {ours:?}"
+    );
+}
+
+// ─── E2: Real Codex fires hooks end-to-end (GUIDED) ──────────────────────────
+//
+// ⚠️ HUMAN-IN-THE-LOOP TEST. Same protocol as E1 but for codex.
+
+#[tokio::test]
+#[ignore]
+async fn e2_guided_codex_fires_hooks_end_to_end() {
+    if ci_environment() {
+        eprintln!("SKIP e2: CI=true — guided e2e tests need a human");
+        return;
+    }
+
+    let _g = acquire_port_lock();
+
+    agent_terminal_lib::hook_config::ensure_hooks_installed().await;
+
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP e2: port 47384 busy (agent-terminal running?)");
+        return;
+    };
+    let server = start_collector(listener);
+
+    let test_cwd_raw = std::env::temp_dir().join(format!("agent-terminal-e2-{}", std::process::id()));
+    std::fs::create_dir_all(&test_cwd_raw).expect("could not create test cwd");
+    let test_cwd = std::fs::canonicalize(&test_cwd_raw).expect("could not canonicalize test cwd");
+    let test_cwd_str = test_cwd.to_string_lossy().to_string();
+
+    // codex refuses to start outside a git repo, so init one in the temp dir.
+    // The user shouldn't need to think about this.
+    let _ = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&test_cwd)
+        .status();
+
+    print_e2e_instructions(
+        "e2_guided_codex_fires_hooks_end_to_end",
+        &test_cwd_str,
+        "codex",
+        "Reply with the single word: pong",
+    );
+
+    let ours = wait_for_session_in_cwd(&server.received, &test_cwd_str, "codex", E2E_GUIDED_TIMEOUT)
+        .await;
+
+    eprintln!(
+        "e2: received {} matching hook payloads: {:?}",
+        ours.len(),
+        ours.iter()
+            .map(|p| format!("{}/{}", p["agent"].as_str().unwrap_or("?"), p["event"].as_str().unwrap_or("?")))
+            .collect::<Vec<_>>()
+    );
+
+    assert!(
+        !ours.is_empty(),
+        "no hook events arrived for cwd={test_cwd_str} within {}s. \
+         Did the user run `codex exec ...` in that directory?",
+        E2E_GUIDED_TIMEOUT.as_secs()
+    );
+
+    let saw_session_start = ours.iter().any(|p| p["event"] == "SessionStart");
+    assert!(
+        saw_session_start,
+        "codex events received from our cwd but no SessionStart: {ours:?}"
+    );
+}
+

--- a/src-tauri/tests/hook_integration.rs
+++ b/src-tauri/tests/hook_integration.rs
@@ -1,0 +1,464 @@
+//! Integration tests for the hook pipeline.
+//!
+//! These tests invoke the real hook scripts installed at `~/.agent-terminal/hooks/`
+//! and verify that they correctly transform and POST payloads to the hook server.
+//! They also validate that the script returns immediately under failure modes
+//! that would otherwise hang Claude Code (the 2026-04-26 incident).
+//!
+//! # Running
+//!
+//! ```sh
+//! cargo test --manifest-path src-tauri/Cargo.toml --test hook_integration -- --test-threads=1
+//! ```
+//!
+//! `--test-threads=1` is REQUIRED — every test in this file binds (or asserts
+//! the absence of a binding on) port 47384. Parallel execution would race.
+//! The tests internally serialize with a Mutex as a defence-in-depth measure,
+//! but the test runner can still interleave with other tests in other files.
+//!
+//! Tests that touch real config files are marked `#[ignore]`. Run with:
+//!
+//! ```sh
+//! cargo test --manifest-path src-tauri/Cargo.toml --test hook_integration -- --include-ignored --test-threads=1
+//! ```
+
+use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Instant;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::time::{Duration, timeout};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Cross-test serialization for port 47384. Tests cannot run in parallel because
+/// they all share this single fixed port. The integration tests assume
+/// `--test-threads=1`, but the mutex is also held inside each test as a guard
+/// against accidental parallelism.
+fn port_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Acquires `port_lock()`, recovering from poisoning. Without this, a single
+/// panicking test would cascade into PoisonError panics in every subsequent
+/// test, masking the real failure.
+fn acquire_port_lock() -> std::sync::MutexGuard<'static, ()> {
+    port_lock().lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn hook_scripts_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("no home dir")
+        .join(".agent-terminal")
+        .join("hooks")
+}
+
+fn claude_hook() -> PathBuf {
+    hook_scripts_dir().join("claude-hook")
+}
+
+fn codex_hook() -> PathBuf {
+    hook_scripts_dir().join("codex-hook")
+}
+
+/// Try to bind port 47384. Returns the listener or None if the port is busy.
+async fn try_bind_hook_port() -> Option<TcpListener> {
+    TcpListener::bind("127.0.0.1:47384").await.ok()
+}
+
+type Received = Arc<Mutex<VecDeque<Value>>>;
+
+#[derive(Deserialize)]
+struct AnyPayload(Value);
+
+async fn collect_hook(
+    State(received): State<Received>,
+    Json(AnyPayload(payload)): Json<AnyPayload>,
+) -> StatusCode {
+    received.lock().unwrap().push_back(payload);
+    StatusCode::OK
+}
+
+/// Server handle that shuts down on drop, freeing port 47384 for the next test.
+struct CollectorServer {
+    received: Received,
+    shutdown: Option<oneshot::Sender<()>>,
+}
+
+impl Drop for CollectorServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// Starts the hook HTTP server on the given listener. Returns a handle that
+/// owns the shutdown signal and the received-payloads queue.
+fn start_collector(listener: TcpListener) -> CollectorServer {
+    let received: Received = Arc::new(Mutex::new(VecDeque::new()));
+    let rx_state = received.clone();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let app = Router::new()
+        .route("/hook", post(collect_hook))
+        .with_state(rx_state);
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+    CollectorServer {
+        received,
+        shutdown: Some(shutdown_tx),
+    }
+}
+
+/// Pipes `payload` to `script event` via stdin and waits for the child to exit.
+/// Returns the elapsed wall-clock time.
+fn run_hook(script: &PathBuf, event: &str, payload: &str) -> Duration {
+    let start = Instant::now();
+    let mut child = Command::new(script)
+        .arg(event)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn {}: {e}", script.display()));
+
+    use std::io::Write;
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.as_bytes())
+        .unwrap();
+    child.wait().expect("hook script did not exit");
+    start.elapsed()
+}
+
+/// Polls the received queue until a payload arrives or the timeout expires.
+async fn wait_for_payload(received: &Received) -> Option<Value> {
+    timeout(Duration::from_secs(3), async {
+        loop {
+            if let Some(p) = received.lock().unwrap().pop_front() {
+                return p;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .ok()
+}
+
+// ─── I1: Claude hook script fires with correct agent/event fields ─────────────
+
+#[tokio::test]
+async fn i1_claude_hook_fires_session_start() {
+    let _g = acquire_port_lock();
+
+    let script = claude_hook();
+    if !script.exists() {
+        eprintln!("SKIP i1: claude-hook not installed at {}", script.display());
+        return;
+    }
+
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP i1: port 47384 busy (agent-terminal running?)");
+        return;
+    };
+    let server = start_collector(listener);
+
+    let payload = r#"{"session_id":"test-session-i1","cwd":"/tmp/i1-project","transcript_path":"/tmp/i1.jsonl"}"#;
+    run_hook(&script, "SessionStart", payload);
+
+    let got = wait_for_payload(&server.received)
+        .await
+        .expect("no payload received within 3s");
+
+    assert_eq!(got["agent"], "claude-code", "agent field injected");
+    assert_eq!(got["event"], "SessionStart", "event field injected");
+    assert_eq!(got["session_id"], "test-session-i1", "session_id preserved");
+    assert_eq!(got["cwd"], "/tmp/i1-project", "cwd preserved");
+    assert_eq!(got["transcript_path"], "/tmp/i1.jsonl", "transcript_path preserved");
+}
+
+// ─── I2: Claude hook fires for PreToolUse (includes tool_name) ───────────────
+
+#[tokio::test]
+async fn i2_claude_hook_fires_pre_tool_use() {
+    let _g = acquire_port_lock();
+
+    let script = claude_hook();
+    if !script.exists() {
+        eprintln!("SKIP i2: claude-hook not installed");
+        return;
+    }
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP i2: port 47384 busy");
+        return;
+    };
+    let server = start_collector(listener);
+
+    let payload = r#"{"session_id":"test-session-i2","cwd":"/tmp/i2-project","tool_name":"Bash","tool_input":{"command":"ls"}}"#;
+    run_hook(&script, "PreToolUse", payload);
+
+    let got = wait_for_payload(&server.received)
+        .await
+        .expect("no payload received within 3s");
+
+    assert_eq!(got["agent"], "claude-code");
+    assert_eq!(got["event"], "PreToolUse");
+    assert_eq!(got["tool_name"], "Bash");
+}
+
+// ─── I3: Codex hook script fires with correct agent/event fields ──────────────
+
+#[tokio::test]
+async fn i3_codex_hook_fires_session_start() {
+    let _g = acquire_port_lock();
+
+    let script = codex_hook();
+    if !script.exists() {
+        eprintln!("SKIP i3: codex-hook not installed at {}", script.display());
+        return;
+    }
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP i3: port 47384 busy");
+        return;
+    };
+    let server = start_collector(listener);
+
+    let payload = r#"{"session_id":"codex-session-i3","cwd":"/tmp/i3-project"}"#;
+    run_hook(&script, "SessionStart", payload);
+
+    let got = wait_for_payload(&server.received)
+        .await
+        .expect("no payload received within 3s");
+
+    assert_eq!(got["agent"], "codex", "agent field injected");
+    assert_eq!(got["event"], "SessionStart", "event field injected");
+    assert_eq!(got["session_id"], "codex-session-i3", "session_id preserved");
+    assert_eq!(got["cwd"], "/tmp/i3-project", "cwd preserved");
+}
+
+// ─── I4: Codex Stop hook fires correctly ─────────────────────────────────────
+
+#[tokio::test]
+async fn i4_codex_hook_fires_stop() {
+    let _g = acquire_port_lock();
+
+    let script = codex_hook();
+    if !script.exists() {
+        eprintln!("SKIP i4: codex-hook not installed");
+        return;
+    }
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP i4: port 47384 busy");
+        return;
+    };
+    let server = start_collector(listener);
+
+    let payload = r#"{"session_id":"codex-session-i4","cwd":"/tmp/i4-project","last_assistant_message":"Done."}"#;
+    run_hook(&script, "Stop", payload);
+
+    let got = wait_for_payload(&server.received)
+        .await
+        .expect("no payload received within 3s");
+
+    assert_eq!(got["agent"], "codex");
+    assert_eq!(got["event"], "Stop");
+    assert_eq!(got["last_assistant_message"], "Done.");
+}
+
+// ─── I7: Hook script exits fast when nothing is listening on 47384 ────────────
+//
+// Regression test: confirms ECONNREFUSED is fast on macOS and the script
+// doesn't hang when agent-terminal is closed. Pre-fix this passed (curl fails
+// in ~25ms on its own), but the test exists to lock that behavior in.
+
+#[tokio::test]
+async fn i7_hook_script_does_not_hang_when_server_absent() {
+    let _g = acquire_port_lock();
+
+    let script = claude_hook();
+    if !script.exists() {
+        eprintln!("SKIP i7: claude-hook not installed");
+        return;
+    }
+
+    // Confirm port really is free. If an external process holds it, skip
+    // rather than report a misleading failure.
+    if try_bind_hook_port().await.is_none() {
+        eprintln!("SKIP i7: port 47384 busy — cannot test absent-server case");
+        return;
+    }
+    // (Listener dropped immediately above so the script sees a free port.)
+
+    let payload = r#"{"session_id":"i7","cwd":"/tmp/i7"}"#;
+    let elapsed = run_hook(&script, "SessionStart", payload);
+
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "hook script took {elapsed:?} when nothing was listening — should be <1s"
+    );
+}
+
+// ─── I8: Hook script exits fast when listener accepts but never responds ──────
+//
+// THIS is the 2026-04-26 regression test. Without fire-and-forget detach,
+// this test hangs for ~60 seconds (curl waits for a response that never comes).
+// With fire-and-forget, the script exits in milliseconds regardless.
+
+#[tokio::test]
+async fn i8_hook_script_does_not_hang_when_server_unresponsive() {
+    let _g = acquire_port_lock();
+
+    let script = claude_hook();
+    if !script.exists() {
+        eprintln!("SKIP i8: claude-hook not installed");
+        return;
+    }
+
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP i8: port 47384 busy");
+        return;
+    };
+
+    // Spawn an "accept-but-never-respond" loop. We accept incoming connections
+    // (so the kernel doesn't return ECONNREFUSED), then immediately drop the
+    // socket without reading or writing. The connection stays open from curl's
+    // POV; curl waits for a response that will never come.
+    //
+    // We hold the connections in a Vec so they don't get closed (which would
+    // make curl notice EOF and exit). They're released when the test ends.
+    let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+    let acceptor = tokio::spawn(async move {
+        let mut held = Vec::new();
+        loop {
+            tokio::select! {
+                _ = &mut stop_rx => break,
+                Ok((conn, _)) = listener.accept() => {
+                    held.push(conn);
+                }
+            }
+        }
+    });
+
+    let payload = r#"{"session_id":"i8","cwd":"/tmp/i8"}"#;
+    let elapsed = run_hook(&script, "SessionStart", payload);
+
+    // Tell the acceptor to stop and drop its held connections.
+    let _ = stop_tx.send(());
+    let _ = acceptor.await;
+
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "REGRESSION: hook script took {elapsed:?} against unresponsive server. \
+         Fire-and-forget detach is broken — script is waiting for curl response. \
+         See plans/.../2026-04-26-0830-claude-code-agent-turn-detection.md \
+         'Post-Implementation Bug — 2026-04-26' section."
+    );
+}
+
+// ─── I5: Real Claude settings.json has no duplicate entries (ignored) ─────────
+
+#[tokio::test]
+#[ignore]
+async fn i5_real_claude_settings_no_duplicates() {
+    let home = dirs::home_dir().expect("no home dir");
+    let settings = home.join(".claude").join("settings.json");
+
+    if !settings.exists() {
+        eprintln!("SKIP i5: ~/.claude/settings.json not found");
+        return;
+    }
+
+    let raw = tokio::fs::read_to_string(&settings).await.unwrap();
+    let v: Value = serde_json::from_str(&raw).expect("settings.json is not valid JSON");
+
+    // Missing "hooks" object is not a failure — just means agent-terminal
+    // hasn't installed any hooks yet (or Claude Code reset the file). The test
+    // only fires if our entries exist, in which case they must be deduplicated.
+    let Some(hooks) = v["hooks"].as_object() else {
+        eprintln!("SKIP i5: ~/.claude/settings.json has no \"hooks\" object — nothing to check");
+        return;
+    };
+
+    let our_prefix = home
+        .join(".agent-terminal")
+        .join("hooks")
+        .join("claude-hook")
+        .to_string_lossy()
+        .to_string();
+
+    for (event, entries) in hooks {
+        let arr = entries.as_array().expect("event array is not an array");
+        let mut commands: Vec<String> = vec![];
+        for entry in arr {
+            if let Some(inner) = entry.get("hooks").and_then(|h| h.as_array()) {
+                for h in inner {
+                    if let Some(cmd) = h.get("command").and_then(|c| c.as_str()) {
+                        commands.push(cmd.to_string());
+                    }
+                }
+            }
+        }
+        let our_cmds: Vec<_> = commands
+            .iter()
+            .filter(|c| c.starts_with(&our_prefix))
+            .collect();
+        assert!(
+            our_cmds.len() <= 1,
+            "duplicate agent-terminal entry in {event}: {our_cmds:?}"
+        );
+    }
+}
+
+// ─── I6: Real Codex hooks.json has no duplicate entries (ignored) ─────────────
+
+#[tokio::test]
+#[ignore]
+async fn i6_real_codex_hooks_no_duplicates() {
+    let home = dirs::home_dir().expect("no home dir");
+    let hooks_file = home.join(".codex").join("hooks.json");
+
+    if !hooks_file.exists() {
+        eprintln!("SKIP i6: ~/.codex/hooks.json not found");
+        return;
+    }
+
+    let raw = tokio::fs::read_to_string(&hooks_file).await.unwrap();
+    let v: Value = serde_json::from_str(&raw).expect("hooks.json is not valid JSON");
+
+    let Some(hooks) = v["hooks"].as_object() else {
+        eprintln!("SKIP i6: ~/.codex/hooks.json has no \"hooks\" object");
+        return;
+    };
+    let our_prefix = home
+        .join(".agent-terminal")
+        .join("hooks")
+        .join("codex-hook")
+        .to_string_lossy()
+        .to_string();
+
+    for (event, entries) in hooks {
+        let arr = entries.as_array().expect("event array is not an array");
+        let our_cmds: Vec<_> = arr
+            .iter()
+            .filter_map(|e| e.get("command").and_then(|c| c.as_str()))
+            .filter(|c| c.starts_with(&our_prefix))
+            .collect();
+        assert!(
+            our_cmds.len() <= 1,
+            "duplicate agent-terminal entry in {event}: {our_cmds:?}"
+        );
+    }
+}

--- a/src/components/agent.helpers.ts
+++ b/src/components/agent.helpers.ts
@@ -35,6 +35,9 @@ export type AgentState = 'idle' | 'in-progress' | 'completed' | 'awaiting'
  */
 export function deriveAgentState(meta: TabMeta | undefined): AgentState {
   if (!meta || meta.type !== 'agent') return 'idle'
+  // Hook data from AgentTurnMod takes priority — richer and more accurate.
+  if (meta.agentState) return meta.agentState
+  // Fallback: OSC 133 process exit signals a completed session.
   if (meta.status === 'done' || meta.status === 'error') return 'completed'
   return 'idle'
 }

--- a/src/modules/mods/mod-listener.ts
+++ b/src/modules/mods/mod-listener.ts
@@ -1,5 +1,6 @@
 import { listen } from '@tauri-apps/api/event'
 import {
+  type AgentTurnState,
   clearTabMeta,
   type GitInfo,
   type ProcessInfo,
@@ -56,6 +57,9 @@ function dispatch({
           type,
           agentName: undefined,
           agentCmd: undefined,
+          // Clear hook-driven state when the agent process exits.
+          agentState: undefined,
+          agentMessage: undefined,
         })
       } else {
         updateTabMeta(tabId, { type, agentName: agent, agentCmd: cmd })
@@ -83,6 +87,17 @@ function dispatch({
     case 'listening_ports': {
       const { ports } = data as { ports: number[] }
       updateTabMeta(tabId, { listeningPorts: ports })
+      break
+    }
+    case 'agent_state_changed': {
+      const { state, message } = data as {
+        state: AgentTurnState
+        message?: string
+      }
+      updateTabMeta(tabId, {
+        agentState: state,
+        agentMessage: message ?? undefined,
+      })
       break
     }
     case 'closed': {

--- a/src/modules/stores/$tabMeta.ts
+++ b/src/modules/stores/$tabMeta.ts
@@ -3,6 +3,13 @@ import { atom } from 'nanostores'
 export type TabStatus = 'idle' | 'running' | 'done' | 'error'
 export type TabType = 'shell' | 'task' | 'agent'
 
+/**
+ * Rich agent turn state — driven by hook events from AgentTurnMod.
+ * Matches the AgentState type in agent.helpers.ts so deriveAgentState can
+ * return it directly: `if (meta.agentState) return meta.agentState`.
+ */
+export type AgentTurnState = 'idle' | 'in-progress' | 'awaiting' | 'completed'
+
 export type GitInfo = {
   branch: string
   aheadBy: number
@@ -58,6 +65,18 @@ export type TabMeta = {
    * Derived from `processes` in the mod-listener; kept for backwards compat.
    */
   listeningPorts?: number[]
+  /**
+   * Rich agent turn state — set by AgentTurnMod via hook events.
+   * `undefined` means no hook data has arrived yet; deriveAgentState falls
+   * back to OSC 133-based heuristics in that case.
+   */
+  agentState?: AgentTurnState
+  /**
+   * Optional message associated with the current agentState.
+   * `awaiting`: the question or permission text the agent needs answered.
+   * `completed`: the last assistant message (truncated to ~200 chars).
+   */
+  agentMessage?: string
 }
 
 const defaultMeta: TabMeta = { status: 'idle', type: 'shell' }


### PR DESCRIPTION
## Summary

- Adds `AgentTurnMod` — a new MOD that receives structured lifecycle events from Claude Code and Codex via their native hook systems and maps them to four UI states: `idle`, `in-progress`, `awaiting`, `completed`
- Adds a minimal Axum HTTP server (`POST /hook`, port `47384`) to receive hook payloads injected by small fire-and-forget shell helper scripts
- Hook configs are installed **silently at every app launch** — `ensure_hooks_installed()` appends entries to `~/.claude/settings.json` and `~/.codex/hooks.json` without touching existing entries from cmux, user-defined hooks, or any other tool
- Frontend: `$tabMeta.agentState` (+ `agentMessage`) wired end-to-end; `deriveAgentState` now returns hook-driven state first, falls back to OSC 133 heuristics if no hook data has arrived
- **Both agents fully covered, including `awaiting`**: Claude routes its `Notification` event and Codex routes its `PermissionRequest` event through the same `handle_awaiting` — UI shows the same amber breathing badge for both with no awareness of the underlying event difference

## Architecture

```
Agent hook fires
  → fire-and-forget curl POST → localhost:47384/hook
    → HookServer (Axum)
      → hook channel → ModEngine select! arm
        → on_hook_event on all Mods
          → AgentTurnMod
            → session_id → tab_id resolution (CWD prefix match fallback)
              → emit agent_state_changed
                → mod-listener.ts → $tabMeta.agentState
                  → deriveAgentState() → UI badge/animation
```

## Bugs caught while building the integration test suite

Three significant bugs in the originally-shipped code were caught by the test suite added in this PR. Full incident write-ups in the plan file (`plans/DaniAkash/agent-terminal/features/2026-04-26-0830-claude-code-agent-turn-detection.md`).

1. **Hook script froze Claude Code system-wide** when something other than agent-terminal was bound to port 47384 (zombie agent-terminal, stale dev binary, anything in `LISTEN` state that didn't respond). Original script waited for the curl response; fixed by detaching curl into a background subshell so the hook script returns in milliseconds regardless of server state. Caught by integration test I8.
2. **Hook script silently delivered malformed JSON since the feature shipped.** `echo \"$INPUT\"` printed the value wrapped in literal quote characters, so `sed 's/^{//'` never stripped the leading brace and the merged POST body had unbalanced quotes. Axum returned 422 for every payload; the script's `\|\| true` swallowed the error. Hooks dropped every event; UI worked only because the `ps`-based fallback kept emitting basic `tab_type_changed` events. Fixed by using `printf '%s' \"\$INPUT\" | sed ...`. Caught by integration tests I1–I4.
3. **Codex hook config was in the wrong schema since the feature shipped.** Original used the cmux-derived flat `[{ \"command\": \"...\" }]` format. Codex's hook engine is literally a re-implementation of Claude's (`codex-rs/hooks/src/registry.rs` imports `ClaudeHooksEngine`) — it requires the same nested matcher+hooks JSON. Three days of dead code in `AgentTurnMod`'s codex path until guided e2e test E2 received zero events from real interactive codex. After fixing the schema, all three expected events arrived. The `HookConfigFormat` enum is now gone — both agents share one format.
4. **Codex `PermissionRequest` event was missing from the registry.** Original cmux research claimed codex only had 3 events and concluded \"no awaiting state possible.\" Inspecting the codex 0.125.0 binary shows it actually exposes 6: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, **PermissionRequest**, Stop. Routing PermissionRequest through `handle_awaiting` gives codex the same amber breathing badge as Claude with zero frontend changes. Same family of bug as #3 — anything in the original spec sourced from cmux research about codex must be re-verified against the actual codex binary.

## Test coverage

**17 unit tests** (`src-tauri/src/hook_config.rs`) — config-file mutation correctness, idempotency, format preservation:
- C1–C10: Claude `~/.claude/settings.json` merge semantics (fresh install, append, idempotent, cmux entries preserved, invalid JSON, all six events)
- D1–D4: Codex `~/.codex/hooks.json` merge semantics (fresh install, append, idempotent)
- S1–S3: Hook script write semantics (chmod +x, no rewrite when current, overwrite when stale)

**8 integration tests** (`src-tauri/tests/hook_integration.rs`) — exercise the actual installed hook scripts against an in-process Axum collector on port 47384:
- I1–I4: Pipe realistic Claude/Codex payloads to the real installed scripts, assert the merged JSON arrives at the collector with all fields preserved
- I7: Script exits <1s when nothing is listening (ECONNREFUSED case)
- **I8: Regression guard for the 2026-04-26 hang** — listener accepts but never responds, script must still exit <1s (without fire-and-forget detach this hangs ~5s)
- I5/I6 (`#[ignore]`): real-system idempotency check on `~/.claude/settings.json` and `~/.codex/hooks.json` (`cargo test -- --include-ignored`)

**2 guided e2e tests** (`#[ignore]`d, skip on `CI=true`) — require a human + agent in the loop:
- E1: Real Claude interactive session — verified `SessionStart` + `UserPromptSubmit` arrive end-to-end
- E2: Real Codex interactive session — verified `SessionStart` + `UserPromptSubmit` + `Stop` arrive end-to-end

## Test plan

- [x] `cargo test` — 17 unit + 6 integration tests pass automatically
- [x] `cargo test --test hook_integration -- --include-ignored --test-threads=1` — all 8 integration tests pass against real installed config files
- [x] Guided E1 (real claude interactive) — verified hook events arrive
- [x] Guided E2 (real codex interactive) — verified hook events arrive
- [ ] Run the app; open Claude Code in a tab; verify glyph animates to `in-progress` on prompt submit
- [ ] Verify `awaiting` state appears when Claude uses `AskUserQuestion` (amber breathing badge)
- [ ] Verify `awaiting` state appears when Codex blocks for permission (same amber badge)
- [ ] Verify `completed` badge appears after Claude/Codex stops
- [ ] Verify `idle` clears after `SessionEnd`
- [ ] Verify `~/.claude/settings.json` has 6 hook entries after first launch (matcher+hooks nested format)
- [ ] Verify `~/.codex/hooks.json` has 4 hook entries after first launch (same nested format)
- [ ] Re-launch; verify no duplicate entries (idempotency)
- [ ] If cmux is present: hook entries appended alongside cmux entries; cmux entries preserved