### PR TITLE
fix: stateful UTF-8 decoding for PTY output (xterm.js path)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "dirs 5.0.1",
+ "encoding_rs",
  "portable-pty",
  "serde",
  "serde_json",
@@ -970,6 +971,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,5 +24,6 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 axum = "0.8"
 dirs = "5"
+encoding_rs = "0.8"
 sysinfo = "0.33"
 

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -126,9 +126,11 @@ fn spawn_reader_thread(
         // next chunk. Same approach node-pty uses, just one layer up from the
         // PTY read in our case.
         let mut decoder = encoding_rs::UTF_8.new_decoder();
-        // Pre-sized for one read's worth of decoded output. UTF-8 → UTF-8 means
-        // the output never exceeds the input length; +4 for a safety margin
-        // around the decoder's internal carryover.
+        // Pre-sized for roughly one read's worth of decoded output. For valid
+        // UTF-8, the decoded text is about the same size as the input bytes,
+        // but malformed sequences or an EOF flush of trailing partial bytes
+        // can emit U+FFFD and expand the UTF-8 byte length. This is just a
+        // reasonable starting capacity, not a strict upper bound.
         let mut decoded = String::with_capacity(READ_BUF_SIZE + 4);
 
         loop {

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -114,10 +114,38 @@ fn spawn_reader_thread(
     std::thread::spawn(move || {
         let mut buf = [0u8; READ_BUF_SIZE];
 
+        // Stateful UTF-8 decoder. PTY read() can return a chunk that ends in
+        // the middle of a multi-byte UTF-8 sequence — common with TUI agents
+        // (Claude Code, Codex) that emit dense Unicode (box drawing, em-dashes,
+        // emoji). String::from_utf8_lossy would replace those partial bytes
+        // with U+FFFD on every chunk boundary, corrupting roughly one character
+        // per multi-byte char that lands on a read boundary.
+        //
+        // encoding_rs::Decoder maintains internal state across decode_to_string
+        // calls — partial trailing bytes are buffered and prepended to the
+        // next chunk. Same approach node-pty uses, just one layer up from the
+        // PTY read in our case.
+        let mut decoder = encoding_rs::UTF_8.new_decoder();
+        // Pre-sized for one read's worth of decoded output. UTF-8 → UTF-8 means
+        // the output never exceeds the input length; +4 for a safety margin
+        // around the decoder's internal carryover.
+        let mut decoded = String::with_capacity(READ_BUF_SIZE + 4);
+
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => {
                     // PTY process exited or master fd closed (close_tab called).
+                    // Flush the decoder — any partial UTF-8 bytes left over at
+                    // EOF become U+FFFD (last=true tells the decoder no more
+                    // input is coming, so it must commit any pending state).
+                    decoded.clear();
+                    let _ = decoder.decode_to_string(&[], &mut decoded, true);
+                    if !decoded.is_empty() {
+                        if let Some(ch) = channel.lock().unwrap().as_ref() {
+                            ch.send(PtyDataPayload { data: decoded.clone() }).ok();
+                        }
+                    }
+
                     // Mark dead immediately — before emitting pty:exit or calling
                     // on_tab_close — so try_reattach cannot observe reader_alive=true
                     // on a thread that is in the process of exiting.
@@ -132,14 +160,19 @@ fn spawn_reader_thread(
                     break;
                 }
                 Ok(n) => {
-                    let data = String::from_utf8_lossy(&buf[..n]).into_owned();
+                    // Stream-decode this chunk. Partial trailing bytes (1–3 bytes
+                    // of an incomplete UTF-8 sequence) stay inside the decoder's
+                    // state and are prepended to the next chunk automatically.
+                    decoded.clear();
+                    let (_result, _bytes_read, _had_errors) =
+                        decoder.decode_to_string(&buf[..n], &mut decoded, false);
 
                     // Lock briefly to send — released before calling on_output.
                     let send_ok = {
                         let guard = channel.lock().unwrap();
                         match guard.as_ref() {
                             Some(ch) => {
-                                ch.send(PtyDataPayload { data: data.clone() }).is_ok()
+                                ch.send(PtyDataPayload { data: decoded.clone() }).is_ok()
                             }
                             // No channel — WebView is disconnected. Terminal
                             // forwarding is skipped but MODs still receive output
@@ -159,7 +192,9 @@ fn spawn_reader_thread(
                     }
                     // Always forward to MOD engine regardless of channel state —
                     // MOD state (git, CWD, agent detection) must stay current
-                    // even while the WebView is disconnected.
+                    // even while the WebView is disconnected. Pass raw bytes —
+                    // the OSC parser is byte-oriented and unaffected by UTF-8
+                    // boundaries.
                     mod_handle.on_output(&tab_id, buf[..n].to_vec());
                 }
             }


### PR DESCRIPTION
## Summary

Backports the encoding_rs decoder fix from PR #25 (the wterm migration branch) to the xterm.js code path on `main`. The bug, the diagnosis, and the fix are entirely Rust-side and renderer-agnostic — bringing it forward fixes the same UTF-8 corruption visible in TUI agent output (Claude Code, Codex) on the current xterm.js setup, without waiting for the wterm migration to land.

## The bug

`String::from_utf8_lossy(&buf[..n])` in `spawn_reader_thread` was applied **per-chunk with no carry-over state**. PTY `read()` can return a chunk that ends in the middle of a multi-byte UTF-8 sequence — common with TUI agents whose output is dense with multi-byte characters: box drawing (`─` `┌` `└`, 3 bytes each), em-dashes (`—`, 3 bytes), bullets (`•`, 3 bytes), etc. Each multi-byte char that landed on a read boundary was corrupted into U+FFFD replacement chars. Some fonts render U+FFFD as a thin horizontal line, producing the visible "dash between words" / corrupted-box-drawing artifact.

## The fix

Replace the per-chunk lossy call with a long-lived `encoding_rs::UTF_8.new_decoder()`. The decoder maintains internal state across `decode_to_string` calls — partial trailing bytes are buffered and prepended to the next chunk automatically. Same approach node-pty uses on the JS side; one layer up from the PTY read in our case.

EOF flush handles any leftover partial bytes at PTY close (commits them as U+FFFD, which is correct since no future bytes can complete them).

The MOD engine still receives raw bytes via `mod_handle.on_output(&tab_id, buf[..n].to_vec())` — the OSC parser is byte-oriented and unaffected by UTF-8 boundaries.

## Why backport instead of waiting for the wterm PR

- The wterm migration (PR #25) is functionally complete but might land on a longer timeline depending on review.
- This is a Rust-only fix that benefits users on the current xterm.js setup immediately.
- The two PRs touch the same lines, so whichever lands first, the other will need a trivial merge — but the changes are identical, so there's no real conflict risk.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — 19 unit + 6 integration tests pass
- [x] `bun test` — 22 frontend tests pass
- [x] `bun run tauri:dev`; open Claude Code in a tab; long-run output; verify no dash-between-words artifacts

## Reference

Same commit as `8c2fd12` on `feat/wterm-migration` (PR #25). Cherry-picked clean.