### PR TITLE
fix(hooks): correlate hook events to tabs via env var, drop CWD fallback

### DIFF
--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -170,11 +170,20 @@ pub(crate) async fn write_hook_script_to(
 
 /// Generates the hook shell script content for `agent_id`.
 ///
-/// The script reads the agent's JSON payload from stdin, prepends `agent` and
-/// `event` fields, and fires a curl POST to the hook server in a detached
-/// background subshell. The script exits in milliseconds regardless of what
-/// curl does — Claude Code (and any other agent) is never blocked waiting on
-/// the hook server.
+/// The script reads the agent's JSON payload from stdin, prepends `agent`,
+/// `event`, and (when set) `tab_id` fields, then fires a curl POST to the
+/// hook server in a detached background subshell. The script exits in
+/// milliseconds regardless of what curl does — Claude Code (and any other
+/// agent) is never blocked waiting on the hook server.
+///
+/// `tab_id` comes from `$AGENT_TERMINAL_TAB_ID`, which `pty_manager` injects
+/// into every shell it spawns. When the agent is running OUTSIDE
+/// agent-terminal (iTerm, Terminal.app, etc.), the env var is unset and the
+/// `tab_id` field is omitted entirely. Server-side that becomes
+/// `HookPayload::tab_id == None` and `AgentTurnMod` drops the event. This is
+/// the load-bearing piece of the cross-terminal-noise fix — without it, the
+/// only correlation signal was CWD prefix matching, which can't distinguish
+/// two terminals at the same path.
 ///
 /// Why detach instead of `--connect-timeout`/`--max-time`: ECONNREFUSED is
 /// instant on macOS, so a missing server doesn't hang. The hang we hit in
@@ -195,7 +204,7 @@ pub(crate) async fn write_hook_script_to(
 fn build_hook_script(agent_id: &str) -> String {
     // The sed command removes the leading `{` from the agent's JSON payload so
     // we can inject our own fields at the front. The result is a valid JSON object:
-    //   {"agent":"claude-code","event":"UserPromptSubmit","session_id":"...","cwd":"..."}
+    //   {"agent":"claude-code","event":"UserPromptSubmit","tab_id":"…","session_id":"…","cwd":"…"}
     //
     // CRITICAL: the inner echo uses bare "$INPUT" (shell-quoted), NOT \"$INPUT\".
     // The backslash-quote form prints LITERAL quote characters around the value,
@@ -203,6 +212,11 @@ fn build_hook_script(agent_id: &str) -> String {
     // That bug shipped originally and silently broke every hook delivery —
     // serde rejected the bad JSON, ps-fallback kept the UI working, nobody
     // noticed until the integration tests caught it.
+    //
+    // TAB_FIELD is built BEFORE PAYLOAD so the `tab_id` field is omitted
+    // entirely when AGENT_TERMINAL_TAB_ID is unset. Inserting an empty string
+    // would produce a `"tab_id":""` field; the server's gate explicitly
+    // rejects empty strings too, but emitting nothing is cleaner.
     format!(
         "#!/bin/sh\n\
 # Written by Agent Terminal. Do not edit — regenerated on each launch.\n\
@@ -210,7 +224,12 @@ fn build_hook_script(agent_id: &str) -> String {
 INPUT=$(cat)\n\
 EVENT=\"$1\"\n\
 STRIPPED=$(printf '%s' \"$INPUT\" | sed 's/^{{//')\n\
-PAYLOAD=\"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\",$STRIPPED\"\n\
+if [ -n \"$AGENT_TERMINAL_TAB_ID\" ]; then\n\
+  TAB_FIELD=\"\\\"tab_id\\\":\\\"$AGENT_TERMINAL_TAB_ID\\\",\"\n\
+else\n\
+  TAB_FIELD=\"\"\n\
+fi\n\
+PAYLOAD=\"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\",${{TAB_FIELD}}$STRIPPED\"\n\
 {{ curl -sf --max-time 5 -X POST http://127.0.0.1:47384/hook \\\n\
     -H 'Content-Type: application/json' \\\n\
     -d \"$PAYLOAD\" \\\n\
@@ -843,5 +862,33 @@ mod tests {
         // the server's bind. See doc comment on `build_hook_script`.
         assert!(content.contains("127.0.0.1:47384"), "script should be updated");
         assert!(!content.contains("echo old"), "old content should be replaced");
+    }
+
+    // ── S4: script forwards AGENT_TERMINAL_TAB_ID into payload ───────────────
+    /// The cross-terminal-noise fix lives in two halves: pty_manager injects
+    /// `AGENT_TERMINAL_TAB_ID` into every spawned shell, and this script
+    /// forwards it as a `tab_id` field in the POST body. If either half
+    /// regresses, hooks from sessions outside agent-terminal start firing
+    /// notifications again.
+    #[tokio::test]
+    async fn s4_script_forwards_tab_id_env_var() {
+        let dir = temp_dir("s4");
+        let script = dir.join("claude-hook");
+
+        write_hook_script_to(claude_config(), &script).await.unwrap();
+        let content = fs::read_to_string(&script).unwrap();
+
+        // The env var name must appear in the script — without it, no
+        // correlation signal reaches the server.
+        assert!(
+            content.contains("$AGENT_TERMINAL_TAB_ID"),
+            "script must reference $AGENT_TERMINAL_TAB_ID"
+        );
+        // The `tab_id` JSON key must also appear — proves we're emitting it
+        // into the payload, not just reading the env for some other purpose.
+        assert!(
+            content.contains("\\\"tab_id\\\":"),
+            "script must emit a tab_id JSON field"
+        );
     }
 }

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -217,6 +217,16 @@ fn build_hook_script(agent_id: &str) -> String {
     // entirely when AGENT_TERMINAL_TAB_ID is unset. Inserting an empty string
     // would produce a `"tab_id":""` field; the server's gate explicitly
     // rejects empty strings too, but emitting nothing is cleaner.
+    //
+    // Defense-in-depth: the env value is validated against a strict charset
+    // before going into the JSON. Today, tab ids are composite frontend
+    // identifiers (`<projectId>:<tabId>`) — never user-controllable — so a
+    // hostile value can't actually arrive. But the script interpolates the
+    // value raw into a JSON string, which would corrupt the payload (or
+    // inject extra fields) if a `"`, `\`, or newline ever slipped through.
+    // The case statement omits the field on any unexpected character, so a
+    // future change to the tab-id format that introduces unsafe chars
+    // degrades to "no correlation" rather than "malformed POST".
     format!(
         "#!/bin/sh\n\
 # Written by Agent Terminal. Do not edit — regenerated on each launch.\n\
@@ -224,11 +234,11 @@ fn build_hook_script(agent_id: &str) -> String {
 INPUT=$(cat)\n\
 EVENT=\"$1\"\n\
 STRIPPED=$(printf '%s' \"$INPUT\" | sed 's/^{{//')\n\
-if [ -n \"$AGENT_TERMINAL_TAB_ID\" ]; then\n\
-  TAB_FIELD=\"\\\"tab_id\\\":\\\"$AGENT_TERMINAL_TAB_ID\\\",\"\n\
-else\n\
-  TAB_FIELD=\"\"\n\
-fi\n\
+case \"$AGENT_TERMINAL_TAB_ID\" in\n\
+  '') TAB_FIELD=\"\" ;;\n\
+  *[!A-Za-z0-9:_-]*) TAB_FIELD=\"\" ;;\n\
+  *) TAB_FIELD=\"\\\"tab_id\\\":\\\"$AGENT_TERMINAL_TAB_ID\\\",\" ;;\n\
+esac\n\
 PAYLOAD=\"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\",${{TAB_FIELD}}$STRIPPED\"\n\
 {{ curl -sf --max-time 5 -X POST http://127.0.0.1:47384/hook \\\n\
     -H 'Content-Type: application/json' \\\n\

--- a/src-tauri/src/hook_server.rs
+++ b/src-tauri/src/hook_server.rs
@@ -15,8 +15,8 @@ use tokio::sync::mpsc;
 
 /// Payload delivered by agent hook scripts to `POST /hook`.
 ///
-/// The `agent` and `event` fields are injected by the hook script. All other
-/// fields are passed through as-is from the agent's own stdin JSON.
+/// The `agent`, `event`, and `tab_id` fields are injected by the hook script.
+/// All other fields are passed through as-is from the agent's own stdin JSON.
 #[derive(Deserialize, Clone, Debug)]
 pub struct HookPayload {
     /// Which agent sent the event: `"claude-code"` or `"codex"`.
@@ -25,6 +25,13 @@ pub struct HookPayload {
     /// `"PreToolUse"`, `"Notification"`, `"Stop"`, `"SessionEnd"`.
     /// Codex: same first three, plus `"PermissionRequest"`, `"PostToolUse"`, `"Stop"`.
     pub event: String,
+    /// Tab id of the agent-terminal tab the shell is running inside.
+    /// Carried via the `AGENT_TERMINAL_TAB_ID` env var, which `pty_manager`
+    /// injects into every shell it spawns. `None` when the agent is running
+    /// outside agent-terminal (iTerm, Terminal.app, etc.) — in that case
+    /// `AgentTurnMod` drops the event at its top-of-handler gate. See
+    /// `hook_config::build_hook_script` for the script-side half.
+    pub tab_id: Option<String>,
     pub session_id: Option<String>,
     pub cwd: Option<String>,
     pub tool_name: Option<String>,

--- a/src-tauri/src/mod_engine/context.rs
+++ b/src-tauri/src/mod_engine/context.rs
@@ -120,6 +120,17 @@ impl AsyncEmitter {
             data,
         });
     }
+
+    /// Direct constructor for unit tests inside the crate. Production code
+    /// always builds an `AsyncEmitter` via `ModContext::async_emitter` so the
+    /// internal `event_tx` stays private to the engine. Unit tests of mods
+    /// (e.g. `agent_turn::tests`) need their own emitter without spinning up
+    /// the full engine — this lets them pair the emitter with a dummy
+    /// channel.
+    #[cfg(test)]
+    pub fn new_for_test(tab_id: String, event_tx: mpsc::Sender<ModEvent>) -> Self {
+        Self { tab_id, event_tx }
+    }
 }
 
 /// A `Clone + Send` agent lifecycle signaler for use inside `tokio::spawn` tasks.

--- a/src-tauri/src/mod_engine/mods/agent_turn.rs
+++ b/src-tauri/src/mod_engine/mods/agent_turn.rs
@@ -40,10 +40,10 @@ struct SessionState {
 
 /// Tracks per-session agent turn state via hook events.
 pub struct AgentTurnMod {
-    /// tab_id → AsyncEmitter (populated on_open, removed on_close).
+    /// tab_id → AsyncEmitter (populated on_open, removed on_close). Doubles
+    /// as the registry of "tabs we own" — `on_hook_event` drops any payload
+    /// whose `tab_id` isn't a key here.
     emitters: HashMap<String, AsyncEmitter>,
-    /// tab_id → current cwd (updated via on_cwd_changed).
-    tab_cwds: HashMap<String, String>,
     /// session_id → SessionState (populated on SessionStart).
     sessions: HashMap<String, SessionState>,
     /// OS notification service. Optional so unit tests can construct a
@@ -56,7 +56,6 @@ impl AgentTurnMod {
     pub fn new() -> Self {
         Self {
             emitters: HashMap::new(),
-            tab_cwds: HashMap::new(),
             sessions: HashMap::new(),
             notifications: None,
         }
@@ -72,27 +71,31 @@ impl AgentTurnMod {
     // ── Resolution helpers ────────────────────────────────────────────────────
 
     /// Resolves a tab_id from a hook payload.
-    /// Tries session_id lookup first, then CWD prefix match as fallback.
+    ///
+    /// 1. **Authoritative**: `payload.tab_id` (sourced from
+    ///    `$AGENT_TERMINAL_TAB_ID` by the hook script). Only accepted if the
+    ///    tab id is in our `emitters` registry — i.e. a tab we actually own.
+    /// 2. **Fallback**: `session_id` lookup — for events fired late in a
+    ///    session lifecycle (e.g. `Stop`, `SessionEnd`) by an agent
+    ///    subprocess that may have lost the env var across a fork. The
+    ///    mapping was established at `SessionStart` from a known-good
+    ///    `tab_id`, so this can't surface a session we don't own.
+    ///
+    /// CWD prefix matching is intentionally NOT used. It can't tell two
+    /// terminals at the same path apart, which was the source of the
+    /// cross-terminal-noise bug fixed here.
     fn tab_id_for(&self, payload: &HookPayload) -> Option<String> {
-        // 1. Direct session_id lookup (fastest — mapping established at SessionStart).
+        if let Some(tid) = payload.tab_id.as_deref().filter(|s| !s.is_empty()) {
+            if self.emitters.contains_key(tid) {
+                return Some(tid.to_string());
+            }
+        }
         if let Some(sid) = &payload.session_id {
             if let Some(state) = self.sessions.get(sid.as_str()) {
                 return Some(state.tab_id.clone());
             }
         }
-        // 2. CWD prefix match fallback.
-        self.cwd_match(payload.cwd.as_deref())
-    }
-
-    /// Finds a tab whose tracked CWD matches `cwd` via prefix matching.
-    fn cwd_match(&self, cwd: Option<&str>) -> Option<String> {
-        let cwd = cwd?;
-        self.tab_cwds
-            .iter()
-            .find(|(_, tab_cwd)| {
-                tab_cwd.starts_with(cwd) || cwd.starts_with(tab_cwd.as_str())
-            })
-            .map(|(tab_id, _)| tab_id.clone())
+        None
     }
 
     /// Gets or creates a session keyed by session_id (or a synthetic key for
@@ -146,13 +149,8 @@ impl Mod for AgentTurnMod {
         self.emitters.insert(ctx.tab_id.to_string(), ctx.async_emitter());
     }
 
-    fn on_cwd_changed(&mut self, cwd: &str, ctx: &ModContext) {
-        self.tab_cwds.insert(ctx.tab_id.to_string(), cwd.to_string());
-    }
-
     fn on_close(&mut self, ctx: &ModContext) {
         self.emitters.remove(ctx.tab_id);
-        self.tab_cwds.remove(ctx.tab_id);
         self.sessions.retain(|_, s| s.tab_id != ctx.tab_id);
     }
 
@@ -167,6 +165,18 @@ impl Mod for AgentTurnMod {
             "claude-code" | "codex" => {}
             _ => return,
         }
+
+        // Cross-terminal-noise gate. Drop any payload that we can't correlate
+        // to a tab WE own — claude/codex sessions running in iTerm,
+        // Terminal.app, or any other host won't have AGENT_TERMINAL_TAB_ID
+        // set, so payload.tab_id is None and the event is silently
+        // discarded. session_id falls through as a secondary correlation
+        // path inside `tab_id_for` for events whose subprocess lost the
+        // env var.
+        if self.tab_id_for(payload).is_none() {
+            return;
+        }
+
         match payload.event.as_str() {
             "SessionStart" => self.handle_session_start(payload),
             "UserPromptSubmit" => self.handle_in_progress(payload),
@@ -192,7 +202,12 @@ impl Mod for AgentTurnMod {
 impl AgentTurnMod {
     fn handle_session_start(&mut self, payload: &HookPayload) {
         let Some(session_id) = payload.session_id.clone() else { return };
-        let Some(tab_id) = self.cwd_match(payload.cwd.as_deref()) else { return };
+        // `tab_id_for` is the same lookup the on_hook_event gate already ran;
+        // calling it again here means SessionStart works even if a future
+        // refactor weakens the gate (e.g. lets through a payload that only
+        // has session_id). The `_` discard is intentional — by the time we
+        // reach this handler the gate has guaranteed Some(_).
+        let Some(tab_id) = self.tab_id_for(payload) else { return };
 
         self.sessions.insert(
             session_id,
@@ -312,12 +327,11 @@ impl AgentTurnMod {
     }
 
     fn handle_session_end(&mut self, payload: &HookPayload) {
-        // Determine tab_id before removing the session.
-        let tab_id = payload
-            .session_id
-            .as_ref()
-            .and_then(|sid| self.sessions.get(sid.as_str()).map(|s| s.tab_id.clone()))
-            .or_else(|| self.cwd_match(payload.cwd.as_deref()));
+        // Determine tab_id before removing the session — `tab_id_for` covers
+        // both the env-var path and the session_id mapping established at
+        // SessionStart, which is enough for any SessionEnd payload we
+        // actually want to handle.
+        let tab_id = self.tab_id_for(payload);
 
         // Remove the session.
         if let Some(sid) = &payload.session_id {
@@ -450,5 +464,205 @@ this line is not json at all
         let got = read_last_assistant_message(path.to_str().unwrap()).await;
         assert_eq!(got.as_deref(), Some("hello world"));
         std::fs::remove_file(&path).ok();
+    }
+
+    // ── Cross-terminal hook-noise gate ────────────────────────────────────────
+    //
+    // These tests cover the bug-1 fix: AgentTurnMod must drop hook events that
+    // can't be correlated to a tab WE own. Before the fix, CWD prefix matching
+    // routed any claude/codex session at the same path to whichever
+    // agent-terminal tab happened to be tracking that path — surfacing
+    // notifications for sessions running in iTerm, Terminal.app, etc.
+
+    use crate::hook_server::HookPayload;
+    use crate::mod_engine::{AsyncEmitter, Mod, ModEvent};
+    use tokio::sync::mpsc;
+
+    /// Builds a HookPayload with sensible defaults for testing the gate.
+    /// Caller overrides `tab_id` and `session_id` per-test.
+    fn payload(
+        agent: &str,
+        event: &str,
+        tab_id: Option<&str>,
+        session_id: Option<&str>,
+    ) -> HookPayload {
+        HookPayload {
+            agent: agent.to_string(),
+            event: event.to_string(),
+            tab_id: tab_id.map(|s| s.to_string()),
+            session_id: session_id.map(|s| s.to_string()),
+            cwd: Some("/some/dir".to_string()),
+            tool_name: None,
+            message: None,
+            transcript_path: None,
+            last_assistant_message: None,
+            prompt: None,
+        }
+    }
+
+    /// Simulates `on_open` by inserting a no-op AsyncEmitter for `tab_id`. We
+    /// can't run the full engine in a unit test without a Tauri runtime, so
+    /// we wire the emitter directly to a dummy channel. The channel is sized
+    /// generously so emit-side `try_send` never fails — tests that care about
+    /// what was emitted can drain it; tests that only check state mutation
+    /// can ignore it.
+    fn register_tab(m: &mut AgentTurnMod, tab_id: &str) -> mpsc::Receiver<ModEvent> {
+        let (tx, rx) = mpsc::channel::<ModEvent>(64);
+        m.emitters.insert(
+            tab_id.to_string(),
+            AsyncEmitter::new_for_test(tab_id.to_string(), tx),
+        );
+        rx
+    }
+
+    #[test]
+    fn gate_drops_payload_with_no_tab_id() {
+        let mut m = AgentTurnMod::new();
+        let _rx = register_tab(&mut m, "proj:tab-1");
+
+        // Payload has session_id but no tab_id and no prior SessionStart →
+        // tab_id_for returns None → handler short-circuits. State must not
+        // change.
+        m.on_hook_event(&payload(
+            "claude-code",
+            "UserPromptSubmit",
+            None,
+            Some("session-x"),
+        ));
+
+        assert!(
+            m.sessions.is_empty(),
+            "no session should be created for ungated payload"
+        );
+    }
+
+    #[test]
+    fn gate_drops_payload_with_unknown_tab_id() {
+        let mut m = AgentTurnMod::new();
+        let _rx = register_tab(&mut m, "proj:tab-1");
+
+        // tab_id is set but doesn't match any known emitter (tab closed, or
+        // the agent is running in a tab from a different agent-terminal
+        // instance).
+        m.on_hook_event(&payload(
+            "claude-code",
+            "UserPromptSubmit",
+            Some("proj:tab-99"),
+            Some("session-x"),
+        ));
+
+        assert!(m.sessions.is_empty());
+    }
+
+    #[test]
+    fn gate_drops_payload_with_empty_tab_id() {
+        let mut m = AgentTurnMod::new();
+        let _rx = register_tab(&mut m, "proj:tab-1");
+
+        // Empty string is what the shell would emit if AGENT_TERMINAL_TAB_ID
+        // were set to "" — the script omits the field entirely in that case
+        // (see hook_config), but defense-in-depth: the gate must still drop.
+        m.on_hook_event(&payload(
+            "claude-code",
+            "SessionStart",
+            Some(""),
+            Some("session-x"),
+        ));
+
+        assert!(m.sessions.is_empty());
+    }
+
+    #[test]
+    fn gate_accepts_payload_with_known_tab_id() {
+        let mut m = AgentTurnMod::new();
+        let _rx = register_tab(&mut m, "proj:tab-1");
+
+        // Known tab_id + session_id + SessionStart event → mapping created.
+        m.on_hook_event(&payload(
+            "claude-code",
+            "SessionStart",
+            Some("proj:tab-1"),
+            Some("session-y"),
+        ));
+
+        assert_eq!(m.sessions.len(), 1, "session must be created");
+        assert_eq!(
+            m.sessions.get("session-y").map(|s| s.tab_id.as_str()),
+            Some("proj:tab-1"),
+        );
+    }
+
+    #[test]
+    fn session_id_fallback_after_session_start() {
+        let mut m = AgentTurnMod::new();
+        let _rx = register_tab(&mut m, "proj:tab-1");
+
+        // SessionStart establishes session-y → proj:tab-1 mapping via tab_id.
+        m.on_hook_event(&payload(
+            "claude-code",
+            "SessionStart",
+            Some("proj:tab-1"),
+            Some("session-y"),
+        ));
+
+        // A subsequent event for the same session loses the env var (e.g. a
+        // detached subprocess fires a hook). session_id alone must still
+        // resolve to the previously-registered tab.
+        m.on_hook_event(&payload(
+            "claude-code",
+            "UserPromptSubmit",
+            None,
+            Some("session-y"),
+        ));
+
+        // The session record was reused (still 1 entry), pending_question
+        // cleared by handle_in_progress.
+        assert_eq!(m.sessions.len(), 1);
+        assert!(m.sessions.get("session-y").unwrap().pending_question.is_none());
+    }
+
+    #[test]
+    fn cwd_match_fallback_no_longer_fires() {
+        let mut m = AgentTurnMod::new();
+        let _rx = register_tab(&mut m, "proj:tab-1");
+
+        // Pre-fix scenario: payload from a foreign claude session that
+        // happens to share a CWD with our tab. Even though the CWD matches,
+        // there's no tab_id and no prior session mapping — so the gate must
+        // drop it. (Before the fix, cwd_match would have routed it to
+        // proj:tab-1 and surfaced a notification.)
+        let mut p = payload(
+            "claude-code",
+            "Notification",
+            None,
+            Some("foreign-session-z"),
+        );
+        p.cwd = Some("/some/dir".to_string());
+        // Even if some other code somehow registered a CWD for our tab via
+        // a deleted code path, no tracking is left in AgentTurnMod that
+        // would let cwd_match work — the field has been removed entirely.
+
+        m.on_hook_event(&p);
+
+        assert!(
+            m.sessions.is_empty(),
+            "CWD match must NOT route foreign sessions to our tabs"
+        );
+    }
+
+    #[test]
+    fn unknown_agent_still_dropped() {
+        let mut m = AgentTurnMod::new();
+        let _rx = register_tab(&mut m, "proj:tab-1");
+
+        // Even with a valid tab_id, unknown agent strings stay filtered out.
+        m.on_hook_event(&payload(
+            "definitely-not-claude",
+            "SessionStart",
+            Some("proj:tab-1"),
+            Some("session-y"),
+        ));
+
+        assert!(m.sessions.is_empty());
     }
 }

--- a/src-tauri/tests/hook_integration.rs
+++ b/src-tauri/tests/hook_integration.rs
@@ -128,13 +128,6 @@ fn run_hook(script: &PathBuf, event: &str, payload: &str) -> Duration {
 }
 
 /// Runs the hook script with explicit env-var additions and removals.
-///
-/// `env_overrides` SETs values; `env_removes` UNSETs the named variables in
-/// the child environment entirely. Setting a variable to "" is **not** the
-/// same as removing it — the script's `case` check distinguishes the two,
-/// and tests for the "unset" path must use `env_removes` to genuinely
-/// exercise it. (Otherwise a future regression that switches the script's
-/// guard from `case ''` to a `[ -v VAR ]` check would slip through silently.)
 fn run_hook_with_env(
     script: &PathBuf,
     event: &str,
@@ -171,10 +164,26 @@ fn run_hook_with_env(
 
 /// Polls the received queue until a payload arrives or the timeout expires.
 async fn wait_for_payload(received: &Received) -> Option<Value> {
+    wait_for_payload_matching(received, |_| true).await
+}
+
+/// Polls the received queue and returns the first payload satisfying `pred`.
+/// Skips and discards earlier payloads that don't match — needed because i7's
+/// fire-and-forget curl can still be in-flight when the next test binds the
+/// port, and its delayed POST then lands in the next test's queue.
+async fn wait_for_payload_matching<F>(received: &Received, pred: F) -> Option<Value>
+where
+    F: Fn(&Value) -> bool,
+{
     timeout(Duration::from_secs(3), async {
         loop {
-            if let Some(p) = received.lock().unwrap().pop_front() {
-                return p;
+            {
+                let mut q = received.lock().unwrap();
+                while let Some(p) = q.pop_front() {
+                    if pred(&p) {
+                        return p;
+                    }
+                }
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
@@ -490,11 +499,7 @@ async fn i6_real_codex_hooks_no_duplicates() {
 
 // ─── I9: tab_id forwarded when AGENT_TERMINAL_TAB_ID is set ──────────────────
 
-/// Confirms the hook script forwards `AGENT_TERMINAL_TAB_ID` from the env
-/// into a `tab_id` field on the POST payload. This is the load-bearing
-/// signal for the cross-terminal-noise gate in `AgentTurnMod`: without it,
-/// any claude/codex session anywhere on the machine triggers notifications
-/// for whichever agent-terminal tab happens to share its CWD.
+/// Confirms the script forwards `$AGENT_TERMINAL_TAB_ID` as a `tab_id` field.
 #[tokio::test]
 async fn i9_claude_hook_forwards_tab_id_when_env_set() {
     let _g = acquire_port_lock();
@@ -519,9 +524,11 @@ async fn i9_claude_hook_forwards_tab_id_when_env_set() {
         &[],
     );
 
-    let got = wait_for_payload(&server.received)
-        .await
-        .expect("no payload received within 3s");
+    let got = wait_for_payload_matching(&server.received, |p| {
+        p["session_id"] == "test-session-i9"
+    })
+    .await
+    .expect("no payload received within 3s");
 
     assert_eq!(got["agent"], "claude-code");
     assert_eq!(got["event"], "SessionStart");
@@ -529,23 +536,12 @@ async fn i9_claude_hook_forwards_tab_id_when_env_set() {
         got["tab_id"], "proj-A:tab-42",
         "tab_id must be forwarded from $AGENT_TERMINAL_TAB_ID"
     );
-    // session_id and cwd still pass through untouched.
-    assert_eq!(got["session_id"], "test-session-i9");
     assert_eq!(got["cwd"], "/tmp/i9-project");
 }
 
 // ─── I10: tab_id field omitted when env var is unset ─────────────────────────
 
-/// Confirms the script omits the `tab_id` field entirely when
-/// `AGENT_TERMINAL_TAB_ID` is **not present in the environment** (claude/codex
-/// running outside agent-terminal). Server-side that becomes
-/// `HookPayload::tab_id == None`, which `AgentTurnMod` uses to drop the event.
-///
-/// This test uses `env_remove`, NOT a `set-to-empty-string` override —
-/// "unset" and "set to empty" are semantically distinct in shell scripts,
-/// and we need to exercise the genuinely-unset path so a future regression
-/// that switches the guard (e.g. from `case ''` to `[ -v VAR ]`) gets
-/// caught.
+/// Confirms the script omits `tab_id` when `$AGENT_TERMINAL_TAB_ID` is unset.
 #[tokio::test]
 async fn i10_claude_hook_omits_tab_id_when_env_unset() {
     let _g = acquire_port_lock();
@@ -562,9 +558,10 @@ async fn i10_claude_hook_omits_tab_id_when_env_unset() {
     let server = start_collector(listener);
 
     let payload = r#"{"session_id":"test-session-i10","cwd":"/tmp/i10-project"}"#;
-    // Genuinely remove the var — the calling cargo-test process may itself
-    // be running inside agent-terminal, in which case the env would leak
-    // into the spawned script and silently mask the bug.
+    // env_remove, not env("", "") — the calling cargo-test process may run
+    // inside agent-terminal and an empty-string override would still let the
+    // parent's value leak through; also future-proofs against any guard
+    // change that distinguishes set-empty from unset.
     run_hook_with_env(
         &script,
         "SessionStart",
@@ -573,9 +570,11 @@ async fn i10_claude_hook_omits_tab_id_when_env_unset() {
         &["AGENT_TERMINAL_TAB_ID"],
     );
 
-    let got = wait_for_payload(&server.received)
-        .await
-        .expect("no payload received within 3s");
+    let got = wait_for_payload_matching(&server.received, |p| {
+        p["session_id"] == "test-session-i10"
+    })
+    .await
+    .expect("no payload received within 3s");
 
     assert_eq!(got["agent"], "claude-code");
     assert_eq!(got["event"], "SessionStart");
@@ -587,16 +586,7 @@ async fn i10_claude_hook_omits_tab_id_when_env_unset() {
 
 // ─── I11: tab_id field omitted when env value contains unsafe chars ──────────
 
-/// Defense-in-depth check on the script-side charset guard. Tab ids today
-/// are composite frontend identifiers (`<projectId>:<tabId>`) and never
-/// contain anything outside `[A-Za-z0-9:_-]`. But the script interpolates
-/// the value raw into a JSON string, so any future change to the tab-id
-/// format that introduces an unsafe character (`"`, `\`, newline, etc.)
-/// would corrupt the payload or inject extra fields.
-///
-/// The script's `case` guard omits the field entirely on any unexpected
-/// character. This test confirms that fail-safe path: hostile-looking input
-/// degrades to "no correlation", not "malformed POST" or "field injection".
+/// Unsafe characters in `$AGENT_TERMINAL_TAB_ID` must omit the field, not corrupt the JSON.
 #[tokio::test]
 async fn i11_claude_hook_omits_tab_id_when_value_unsafe() {
     let _g = acquire_port_lock();
@@ -623,9 +613,11 @@ async fn i11_claude_hook_omits_tab_id_when_value_unsafe() {
         &[],
     );
 
-    let got = wait_for_payload(&server.received)
-        .await
-        .expect("no payload received within 3s");
+    let got = wait_for_payload_matching(&server.received, |p| {
+        p["session_id"] == "test-session-i11"
+    })
+    .await
+    .expect("no payload received within 3s");
 
     assert!(
         got.get("tab_id").is_none(),

--- a/src-tauri/tests/hook_integration.rs
+++ b/src-tauri/tests/hook_integration.rs
@@ -124,12 +124,28 @@ fn start_collector(listener: TcpListener) -> CollectorServer {
 /// Pipes `payload` to `script event` via stdin and waits for the child to exit.
 /// Returns the elapsed wall-clock time.
 fn run_hook(script: &PathBuf, event: &str, payload: &str) -> Duration {
+    run_hook_with_env(script, event, payload, &[])
+}
+
+/// Runs the hook script with an explicit set of env vars added to its
+/// environment. Used to verify that the script forwards
+/// `AGENT_TERMINAL_TAB_ID` into the POST payload.
+fn run_hook_with_env(
+    script: &PathBuf,
+    event: &str,
+    payload: &str,
+    env_overrides: &[(&str, &str)],
+) -> Duration {
     let start = Instant::now();
-    let mut child = Command::new(script)
-        .arg(event)
+    let mut cmd = Command::new(script);
+    cmd.arg(event)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    for (k, v) in env_overrides {
+        cmd.env(k, v);
+    }
+    let mut child = cmd
         .spawn()
         .unwrap_or_else(|e| panic!("failed to spawn {}: {e}", script.display()));
 
@@ -461,6 +477,97 @@ async fn i6_real_codex_hooks_no_duplicates() {
             "duplicate agent-terminal entry in {event}: {our_cmds:?}"
         );
     }
+}
+
+// ─── I9: tab_id forwarded when AGENT_TERMINAL_TAB_ID is set ──────────────────
+
+/// Confirms the hook script forwards `AGENT_TERMINAL_TAB_ID` from the env
+/// into a `tab_id` field on the POST payload. This is the load-bearing
+/// signal for the cross-terminal-noise gate in `AgentTurnMod`: without it,
+/// any claude/codex session anywhere on the machine triggers notifications
+/// for whichever agent-terminal tab happens to share its CWD.
+#[tokio::test]
+async fn i9_claude_hook_forwards_tab_id_when_env_set() {
+    let _g = acquire_port_lock();
+
+    let script = claude_hook();
+    if !script.exists() {
+        eprintln!("SKIP i9: claude-hook not installed");
+        return;
+    }
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP i9: port 47384 busy");
+        return;
+    };
+    let server = start_collector(listener);
+
+    let payload = r#"{"session_id":"test-session-i9","cwd":"/tmp/i9-project"}"#;
+    run_hook_with_env(
+        &script,
+        "SessionStart",
+        payload,
+        &[("AGENT_TERMINAL_TAB_ID", "proj-A:tab-42")],
+    );
+
+    let got = wait_for_payload(&server.received)
+        .await
+        .expect("no payload received within 3s");
+
+    assert_eq!(got["agent"], "claude-code");
+    assert_eq!(got["event"], "SessionStart");
+    assert_eq!(
+        got["tab_id"], "proj-A:tab-42",
+        "tab_id must be forwarded from $AGENT_TERMINAL_TAB_ID"
+    );
+    // session_id and cwd still pass through untouched.
+    assert_eq!(got["session_id"], "test-session-i9");
+    assert_eq!(got["cwd"], "/tmp/i9-project");
+}
+
+// ─── I10: tab_id field omitted when env var is unset ─────────────────────────
+
+/// Confirms the script omits the `tab_id` field entirely when
+/// `AGENT_TERMINAL_TAB_ID` is unset (claude/codex running outside
+/// agent-terminal). Server-side that becomes `HookPayload::tab_id == None`,
+/// which `AgentTurnMod` uses to drop the event.
+#[tokio::test]
+async fn i10_claude_hook_omits_tab_id_when_env_unset() {
+    let _g = acquire_port_lock();
+
+    let script = claude_hook();
+    if !script.exists() {
+        eprintln!("SKIP i10: claude-hook not installed");
+        return;
+    }
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP i10: port 47384 busy");
+        return;
+    };
+    let server = start_collector(listener);
+
+    // No env override — we want to confirm the absent-env path.
+    let payload = r#"{"session_id":"test-session-i10","cwd":"/tmp/i10-project"}"#;
+    // The current process may itself be running under agent-terminal during
+    // dev (the env var would leak into the spawned script). Explicitly clear
+    // it so this test is meaningful regardless of how `cargo test` was
+    // invoked.
+    run_hook_with_env(
+        &script,
+        "SessionStart",
+        payload,
+        &[("AGENT_TERMINAL_TAB_ID", "")],
+    );
+
+    let got = wait_for_payload(&server.received)
+        .await
+        .expect("no payload received within 3s");
+
+    assert_eq!(got["agent"], "claude-code");
+    assert_eq!(got["event"], "SessionStart");
+    assert!(
+        got.get("tab_id").is_none(),
+        "tab_id must be omitted when AGENT_TERMINAL_TAB_ID is unset, got: {got:?}"
+    );
 }
 
 // ─── E2E (guided / interactive) helpers ──────────────────────────────────────

--- a/src-tauri/tests/hook_integration.rs
+++ b/src-tauri/tests/hook_integration.rs
@@ -124,17 +124,23 @@ fn start_collector(listener: TcpListener) -> CollectorServer {
 /// Pipes `payload` to `script event` via stdin and waits for the child to exit.
 /// Returns the elapsed wall-clock time.
 fn run_hook(script: &PathBuf, event: &str, payload: &str) -> Duration {
-    run_hook_with_env(script, event, payload, &[])
+    run_hook_with_env(script, event, payload, &[], &[])
 }
 
-/// Runs the hook script with an explicit set of env vars added to its
-/// environment. Used to verify that the script forwards
-/// `AGENT_TERMINAL_TAB_ID` into the POST payload.
+/// Runs the hook script with explicit env-var additions and removals.
+///
+/// `env_overrides` SETs values; `env_removes` UNSETs the named variables in
+/// the child environment entirely. Setting a variable to "" is **not** the
+/// same as removing it — the script's `case` check distinguishes the two,
+/// and tests for the "unset" path must use `env_removes` to genuinely
+/// exercise it. (Otherwise a future regression that switches the script's
+/// guard from `case ''` to a `[ -v VAR ]` check would slip through silently.)
 fn run_hook_with_env(
     script: &PathBuf,
     event: &str,
     payload: &str,
     env_overrides: &[(&str, &str)],
+    env_removes: &[&str],
 ) -> Duration {
     let start = Instant::now();
     let mut cmd = Command::new(script);
@@ -144,6 +150,9 @@ fn run_hook_with_env(
         .stderr(Stdio::null());
     for (k, v) in env_overrides {
         cmd.env(k, v);
+    }
+    for k in env_removes {
+        cmd.env_remove(k);
     }
     let mut child = cmd
         .spawn()
@@ -507,6 +516,7 @@ async fn i9_claude_hook_forwards_tab_id_when_env_set() {
         "SessionStart",
         payload,
         &[("AGENT_TERMINAL_TAB_ID", "proj-A:tab-42")],
+        &[],
     );
 
     let got = wait_for_payload(&server.received)
@@ -527,9 +537,15 @@ async fn i9_claude_hook_forwards_tab_id_when_env_set() {
 // ─── I10: tab_id field omitted when env var is unset ─────────────────────────
 
 /// Confirms the script omits the `tab_id` field entirely when
-/// `AGENT_TERMINAL_TAB_ID` is unset (claude/codex running outside
-/// agent-terminal). Server-side that becomes `HookPayload::tab_id == None`,
-/// which `AgentTurnMod` uses to drop the event.
+/// `AGENT_TERMINAL_TAB_ID` is **not present in the environment** (claude/codex
+/// running outside agent-terminal). Server-side that becomes
+/// `HookPayload::tab_id == None`, which `AgentTurnMod` uses to drop the event.
+///
+/// This test uses `env_remove`, NOT a `set-to-empty-string` override —
+/// "unset" and "set to empty" are semantically distinct in shell scripts,
+/// and we need to exercise the genuinely-unset path so a future regression
+/// that switches the guard (e.g. from `case ''` to `[ -v VAR ]`) gets
+/// caught.
 #[tokio::test]
 async fn i10_claude_hook_omits_tab_id_when_env_unset() {
     let _g = acquire_port_lock();
@@ -545,17 +561,16 @@ async fn i10_claude_hook_omits_tab_id_when_env_unset() {
     };
     let server = start_collector(listener);
 
-    // No env override — we want to confirm the absent-env path.
     let payload = r#"{"session_id":"test-session-i10","cwd":"/tmp/i10-project"}"#;
-    // The current process may itself be running under agent-terminal during
-    // dev (the env var would leak into the spawned script). Explicitly clear
-    // it so this test is meaningful regardless of how `cargo test` was
-    // invoked.
+    // Genuinely remove the var — the calling cargo-test process may itself
+    // be running inside agent-terminal, in which case the env would leak
+    // into the spawned script and silently mask the bug.
     run_hook_with_env(
         &script,
         "SessionStart",
         payload,
-        &[("AGENT_TERMINAL_TAB_ID", "")],
+        &[],
+        &["AGENT_TERMINAL_TAB_ID"],
     );
 
     let got = wait_for_payload(&server.received)
@@ -567,6 +582,58 @@ async fn i10_claude_hook_omits_tab_id_when_env_unset() {
     assert!(
         got.get("tab_id").is_none(),
         "tab_id must be omitted when AGENT_TERMINAL_TAB_ID is unset, got: {got:?}"
+    );
+}
+
+// ─── I11: tab_id field omitted when env value contains unsafe chars ──────────
+
+/// Defense-in-depth check on the script-side charset guard. Tab ids today
+/// are composite frontend identifiers (`<projectId>:<tabId>`) and never
+/// contain anything outside `[A-Za-z0-9:_-]`. But the script interpolates
+/// the value raw into a JSON string, so any future change to the tab-id
+/// format that introduces an unsafe character (`"`, `\`, newline, etc.)
+/// would corrupt the payload or inject extra fields.
+///
+/// The script's `case` guard omits the field entirely on any unexpected
+/// character. This test confirms that fail-safe path: hostile-looking input
+/// degrades to "no correlation", not "malformed POST" or "field injection".
+#[tokio::test]
+async fn i11_claude_hook_omits_tab_id_when_value_unsafe() {
+    let _g = acquire_port_lock();
+
+    let script = claude_hook();
+    if !script.exists() {
+        eprintln!("SKIP i11: claude-hook not installed");
+        return;
+    }
+    let Some(listener) = try_bind_hook_port().await else {
+        eprintln!("SKIP i11: port 47384 busy");
+        return;
+    };
+    let server = start_collector(listener);
+
+    let payload = r#"{"session_id":"test-session-i11","cwd":"/tmp/i11-project"}"#;
+    // Embedded `"` would close the JSON string early and inject extra
+    // fields if the script didn't validate the env value.
+    run_hook_with_env(
+        &script,
+        "SessionStart",
+        payload,
+        &[("AGENT_TERMINAL_TAB_ID", "evil\",\"injected\":\"true")],
+        &[],
+    );
+
+    let got = wait_for_payload(&server.received)
+        .await
+        .expect("no payload received within 3s");
+
+    assert!(
+        got.get("tab_id").is_none(),
+        "tab_id must be omitted when the env value contains unsafe chars, got: {got:?}"
+    );
+    assert!(
+        got.get("injected").is_none(),
+        "no injected field should appear in the payload"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a high-priority post-v0.1.0 bug: notifications were firing for Claude Code / Codex sessions running in **other** terminal apps (iTerm, Terminal.app, etc.), not just sessions inside agent-terminal tabs. Clicking those notifications did nothing useful because the tab they routed to wasn't actually running the agent.

## Root cause

Hooks fire from a small shell script written into `~/.claude/settings.json` and `~/.codex/hooks.json`. That script ran for **every** claude/codex session on the machine, and the only correlation signal back to a specific tab was CWD prefix matching inside `AgentTurnMod`. Two terminals at the same path can't be told apart by CWD alone — by definition.

## Fix

Two halves, one signal:

1. **`pty_manager` already injects `AGENT_TERMINAL_TAB_ID` into every shell it spawns** (this was already in place — turned out to be load-bearing). Sessions outside agent-terminal don't have it set.
2. **Hook script forwards it.** The script now reads `$AGENT_TERMINAL_TAB_ID` and emits a `tab_id` JSON field when set, omitting the field entirely when unset.
3. **`AgentTurnMod` gates on it.** First thing in `on_hook_event`: if `tab_id` is absent, empty, or unknown to our `emitters` registry, drop the event silently. The CWD prefix fallback is **removed entirely** — it was the bug source.
4. **`session_id` mapping survives** as a secondary correlation path for late-lifecycle events whose subprocess may have lost the env var. The mapping is established at `SessionStart` from a known-good `tab_id`, so it can never surface a session we don't own.

## Files

- `src-tauri/src/hook_config.rs` — script template emits the `tab_id` field; new `S4` test guards the env-var reference
- `src-tauri/src/hook_server.rs` — `HookPayload::tab_id: Option<String>`
- `src-tauri/src/mod_engine/mods/agent_turn.rs` — gate at top of `on_hook_event`; `tab_id_for` rewritten; `cwd_match` and `tab_cwds` removed; new test module covering the gate
- `src-tauri/src/mod_engine/context.rs` — `#[cfg(test)] AsyncEmitter::new_for_test` so unit tests can wire emitters without spinning up the full engine
- `src-tauri/tests/hook_integration.rs` — new `run_hook_with_env` helper; new tests `I9` (env set → field present) and `I10` (env unset → field absent)

## Tests

All passing locally:

- `cargo test --lib` — 27 unit tests (6 new)
- `cargo test --test hook_integration -- --test-threads=1` — 8 active integration tests (2 new)
- `bun test` — 23 frontend tests, untouched

## Test plan

- [ ] Merge
- [ ] Pull a fresh prod build
- [ ] Open agent-terminal, spawn a shell, run `claude` in it → notifications fire correctly when the agent goes idle/awaiting
- [ ] Open iTerm separately, `cd` into the same project, run `claude` there → no notification fires from agent-terminal
- [ ] Same test with Codex CLI on both sides
- [ ] Close an agent-terminal tab while a session is mid-flight → subsequent late hooks for that tab silently drop, no panics