### PR TITLE
fix(pty): auto-respawn shell on self-exit, restore last cwd

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,6 +2,7 @@ use crate::mod_engine::ModEngine;
 use crate::pty_manager::{spawn_pty, try_reattach, PtyDataPayload, PtyMap, ReattachResult};
 use portable_pty::PtySize;
 use std::io::Write;
+use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Emitter, State};
 use tauri::ipc::Channel;
 
@@ -31,7 +32,14 @@ pub async fn open_tab(
     //
     // 3. Expired / NotFound — child exited or no entry. Fall through to a fresh
     //    spawn_pty. Returns true.
-    match try_reattach(app.clone(), &pty_map, mod_engine.handle(), &tab_id, on_data.clone()) {
+    match try_reattach(
+        app.clone(),
+        &pty_map,
+        mod_engine.handle(),
+        mod_engine.cwd_table(),
+        &tab_id,
+        on_data.clone(),
+    ) {
         Ok(ReattachResult::ChannelUpdated) | Ok(ReattachResult::Reattached) => {
             // The [Reconnected] banner is written directly to the data channel
             // inside try_reattach — no listener timing gap. This event is emitted
@@ -46,7 +54,16 @@ pub async fn open_tab(
         Err(e) => return Err(e),
     }
 
-    spawn_pty(app, &pty_map, mod_engine.handle(), tab_id, cwd, shell, on_data)?;
+    spawn_pty(
+        app,
+        &pty_map,
+        mod_engine.handle(),
+        mod_engine.cwd_table(),
+        tab_id,
+        cwd,
+        shell,
+        on_data,
+    )?;
     Ok(true)
 }
 
@@ -98,11 +115,18 @@ pub async fn close_tab(
     pty_map: State<'_, PtyMap>,
     tab_id: String,
 ) -> Result<(), String> {
-    // MOD on_close is triggered by the PTY read thread exiting (pty:exit), not
-    // here — close_tab only drops the master/writer, causing the thread to see
-    // EOF and fire on_close itself. This avoids a double on_close if the shell
-    // exits on its own before close_tab is called.
-    pty_map.lock().unwrap().remove(&tab_id);
+    // The reader thread reads `closing` on EOF to decide between emitting
+    // pty:exit (user close, current path) and respawning the shell at the
+    // last known cwd (self-exit). Setting the flag and dropping the entry
+    // under the same lock means there's no torn state: by the time the
+    // reader reads `closing`, either we've already set it (and the entry
+    // is gone — exit path) or we haven't yet (entry still present —
+    // respawn path).
+    let mut map = pty_map.lock().unwrap();
+    if let Some(handle) = map.get(&tab_id) {
+        handle.closing.store(true, Ordering::Release);
+    }
+    map.remove(&tab_id);
     Ok(())
 }
 

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -1,10 +1,16 @@
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use super::context::{AgentSignal, AgentSignalKind, CwdUpdate, ModContext, ModEvent};
 use super::Mod;
 use crate::hook_server::HookPayload;
 use tauri::{AppHandle, Emitter, async_runtime};
 use tokio::sync::mpsc;
+
+/// Shared `tab_id → cwd` table, written by the engine task whenever
+/// `DirTrackerMod` parses an OSC 7 sequence and read by `pty_manager` when
+/// it needs to respawn a shell at the last known location.
+pub type CwdTable = Arc<Mutex<HashMap<String, String>>>;
 
 pub(super) enum ModMessage {
     Open { tab_id: String, shell_pid: u32 },
@@ -90,6 +96,10 @@ impl ModEngineBuilder {
 /// `ModEngineHandle` for dispatching; the PTY read thread clones that handle.
 pub struct ModEngine {
     handle: ModEngineHandle,
+    /// Shared snapshot of the last CWD seen per tab. Lives outside the
+    /// engine task so the PTY layer can read it synchronously when a shell
+    /// self-exits and needs to respawn at the same location.
+    cwd_table: CwdTable,
     /// Keeps the hook channel alive for the engine's full lifetime. The
     /// dispatcher's `select!` arm calls `hook_rx.recv()`, which returns `None`
     /// when the last sender is dropped. If `start_hook_server()` fails to
@@ -113,6 +123,12 @@ impl ModEngine {
         self.handle.clone()
     }
 
+    /// Cheap clone of the shared CWD table. Hand to `pty_manager` so the
+    /// reader thread can look up the last-known CWD when respawning a shell.
+    pub fn cwd_table(&self) -> CwdTable {
+        self.cwd_table.clone()
+    }
+
     fn start(
         mods: Vec<Box<dyn Mod>>,
         hook_tx_keepalive: mpsc::UnboundedSender<HookPayload>,
@@ -130,46 +146,54 @@ impl ModEngine {
         // Agent lifecycle channel: unbounded so lifecycle signals are never dropped.
         let (agent_tx, mut agent_rx) = mpsc::unbounded_channel::<AgentSignal>();
 
+        let cwd_table: CwdTable = Arc::new(Mutex::new(HashMap::new()));
+        let cwd_table_task = cwd_table.clone();
+
         let event_tx_dispatch = event_tx.clone();
         async_runtime::spawn(async move {
             let mut mods = mods;
-            // Internal CWD table: tab_id → current cwd.
-            let mut cwd_table: HashMap<String, String> = HashMap::new();
-            // Shell PID table: tab_id → shell process PID.
+            // Shell PID table stays local — pty_manager doesn't need this
+            // and a single async task is the only writer/reader.
             let mut shell_pid_table: HashMap<String, u32> = HashMap::new();
 
-            // Macro to dispatch a ModMessage and drain CWD updates.
+            // Snapshot the shared cwd table for THIS dispatch round so the
+            // ModContext only carries an Option<String>, not a guard.
             macro_rules! handle_mod_msg {
                 ($msg:expr) => {{
                     match $msg {
                         ModMessage::Open { tab_id, shell_pid } => {
                             shell_pid_table.insert(tab_id.clone(), shell_pid);
-                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let current_cwd = cwd_table_task.lock().unwrap().get(&tab_id).cloned();
                             let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                             for m in &mut mods { m.on_open(&ctx); }
                         }
                         ModMessage::Close { tab_id } => {
-                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let current_cwd = cwd_table_task.lock().unwrap().get(&tab_id).cloned();
                             let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
                             let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                             for m in &mut mods { m.on_close(&ctx); }
-                            cwd_table.remove(&tab_id);
+                            // Don't drop the cwd_table entry — pty_manager
+                            // may still want to respawn the same tab id and
+                            // restore the user's last cwd. The entry is
+                            // overwritten on the next OSC 7 anyway, and a
+                            // tab id is never reused after a real close
+                            // (frontend rolls a fresh uuid).
                             shell_pid_table.remove(&tab_id);
                         }
                         ModMessage::Output { tab_id, data } => {
-                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let current_cwd = cwd_table_task.lock().unwrap().get(&tab_id).cloned();
                             let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
                             let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                             for m in &mut mods { m.on_output(&data, &ctx); }
                         }
                         ModMessage::Input { tab_id, data } => {
-                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let current_cwd = cwd_table_task.lock().unwrap().get(&tab_id).cloned();
                             let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
                             let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                             for m in &mut mods { m.on_input(&data, &ctx); }
                         }
                         ModMessage::Resize { tab_id, cols, rows } => {
-                            let current_cwd = cwd_table.get(&tab_id).cloned();
+                            let current_cwd = cwd_table_task.lock().unwrap().get(&tab_id).cloned();
                             let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
                             let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                             for m in &mut mods { m.on_resize(cols, rows, &ctx); }
@@ -178,7 +202,7 @@ impl ModEngine {
                     // Drain CWD updates produced during this dispatch round.
                     let mut cwd_updates: Vec<(String, String)> = Vec::new();
                     while let Ok(upd) = cwd_rx.try_recv() {
-                        cwd_table.insert(upd.tab_id.clone(), upd.cwd.clone());
+                        cwd_table_task.lock().unwrap().insert(upd.tab_id.clone(), upd.cwd.clone());
                         cwd_updates.push((upd.tab_id, upd.cwd));
                     }
                     for (tab_id, cwd) in &cwd_updates {
@@ -205,7 +229,7 @@ impl ModEngine {
                     // state transitions when an agent starts or exits.
                     sig = agent_rx.recv() => {
                         let Some(sig) = sig else { break };
-                        let current_cwd = cwd_table.get(&sig.tab_id).cloned();
+                        let current_cwd = cwd_table_task.lock().unwrap().get(&sig.tab_id).cloned();
                         let shell_pid = shell_pid_table.get(&sig.tab_id).copied().unwrap_or(0);
                         let ctx = ModContext::new(&sig.tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                         match sig.kind {
@@ -243,6 +267,7 @@ impl ModEngine {
 
         Self {
             handle: ModEngineHandle { tx: msg_tx, lifecycle_tx },
+            cwd_table,
             _hook_tx_keepalive: hook_tx_keepalive,
         }
     }

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -10,6 +10,18 @@ use tokio::sync::mpsc;
 /// Shared `tab_id → cwd` table, written by the engine task whenever
 /// `DirTrackerMod` parses an OSC 7 sequence and read by `pty_manager` when
 /// it needs to respawn a shell at the last known location.
+///
+/// TODO(respawn-cwd-staleness): the path from PTY read → engine task → this
+/// table is best-effort: `ModEngineHandle::on_output` uses `try_send` on a
+/// 512-bounded channel and `ctx.set_cwd` does the same. Under a heavy PTY
+/// burst, the chunk carrying the latest OSC 7 can be dropped or still
+/// queued when `pty_manager::respawn_in_place` reads the cwd, so the
+/// restarted shell may come back one `cd` behind. Mitigation would be to
+/// parse OSC 7 inline in pty_manager's reader thread and write straight
+/// into a dedicated cwd snapshot, decoupling respawn from the engine's
+/// queue. Deferred — practical impact is low (worst case = "respawn at
+/// one cd ago"), and the cleanest fix lives next to a future output-replay
+/// buffer rather than in this PR.
 pub type CwdTable = Arc<Mutex<HashMap<String, String>>>;
 
 pub(super) enum ModMessage {
@@ -172,12 +184,17 @@ impl ModEngine {
                             let shell_pid = shell_pid_table.get(&tab_id).copied().unwrap_or(0);
                             let ctx = ModContext::new(&tab_id, &event_tx_dispatch, &cwd_tx, &agent_tx, current_cwd, shell_pid);
                             for m in &mut mods { m.on_close(&ctx); }
-                            // Don't drop the cwd_table entry — pty_manager
-                            // may still want to respawn the same tab id and
-                            // restore the user's last cwd. The entry is
-                            // overwritten on the next OSC 7 anyway, and a
-                            // tab id is never reused after a real close
-                            // (frontend rolls a fresh uuid).
+                            // Drop the cwd entry too. Respawn doesn't need
+                            // it preserved here — `respawn_in_place` reads
+                            // the cwd into a local variable BEFORE issuing
+                            // its own on_tab_close, so the close message
+                            // arrives with the cwd already captured.
+                            // Keeping closed-tab entries around would leak
+                            // for the app's lifetime AND let a 4-hex
+                            // randomSuffix() collision on a brand-new tab
+                            // inherit a stale cwd until the new shell's
+                            // first OSC 7.
+                            cwd_table_task.lock().unwrap().remove(&tab_id);
                             shell_pid_table.remove(&tab_id);
                         }
                         ModMessage::Output { tab_id, data } => {

--- a/src-tauri/src/mod_engine/mod.rs
+++ b/src-tauri/src/mod_engine/mod.rs
@@ -5,7 +5,7 @@ pub mod osc_parser;
 
 #[allow(unused_imports)]
 pub use context::{AgentSignal, AgentSignalKind, AsyncAgentSignaler, AsyncEmitter, CwdUpdate, ModContext, ModEvent};
-pub use engine::{ModEngine, ModEngineHandle};
+pub use engine::{CwdTable, ModEngine, ModEngineHandle};
 
 /// The trait every MOD implements.
 ///

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -1,30 +1,32 @@
-use crate::mod_engine::ModEngineHandle;
+use crate::mod_engine::{CwdTable, ModEngineHandle};
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 use tauri::ipc::Channel;
 
-/// Sent directly to the frontend via the per-tab Channel.
-/// No tabId field — the channel is already bound to a specific tab.
 #[derive(Serialize, Clone)]
 pub struct PtyDataPayload {
     pub data: String,
 }
 
-/// Emitted as a global event on shell exit. Fires rarely so the event bus
-/// overhead is acceptable; no Channel needed.
 #[derive(Serialize, Clone)]
 pub struct PtyExitPayload {
     #[serde(rename = "tabId")]
     pub tab_id: String,
 }
 
-/// The active frontend channel, shared between the reader thread and open_tab.
-///
+#[derive(Serialize, Clone)]
+pub struct PtyRespawnPayload {
+    #[serde(rename = "tabId")]
+    pub tab_id: String,
+    pub cwd: Option<String>,
+}
+
 /// Wrapped in Arc<Mutex<Option<...>>> so open_tab can swap in a new Channel
 /// when the WebView reconnects without stopping or restarting the reader thread.
 /// The Option is None when the WebView is disconnected — the reader discards
@@ -45,20 +47,37 @@ pub struct PtyHandle {
     /// The live frontend channel. Swapped by open_tab on reconnect without
     /// touching the reader thread or the PTY process.
     pub channel: SharedChannel,
+    /// Set true by `close_tab` BEFORE the entry is removed from PtyMap. Reader
+    /// thread checks this on EOF: true → user closed the tab, emit pty:exit
+    /// and quit; false → shell exited on its own (typed `exit`, segfault,
+    /// etc.), trigger respawn.
+    pub closing: Arc<AtomicBool>,
+    /// Resolved absolute shell path (e.g. `/bin/zsh`). Captured at spawn time
+    /// so respawn uses identically-resolved shell regardless of any later
+    /// $SHELL change.
+    pub shell_path: String,
+    /// CWD passed at original tab open. Used as the respawn fallback when
+    /// the engine's cwd_table has nothing for this tab — happens when the
+    /// shell exits before any OSC 7 has been emitted (e.g. `exit` at the
+    /// very first prompt).
+    pub spawn_cwd: Option<String>,
+    /// Timestamps of recent respawns. The reader thread checks this before
+    /// respawning: if more than RESPAWN_RATE_MAX events fall inside
+    /// RESPAWN_RATE_WINDOW, it bails out and emits pty:exit instead. Stops
+    /// a broken `.zshrc` from looping forever.
+    pub respawn_history: Arc<Mutex<Vec<Instant>>>,
 }
 
 pub type PtyMap = Arc<Mutex<HashMap<String, PtyHandle>>>;
 
-/// 256 KB read buffer. A single read() call can return up to this many bytes
-/// when the kernel has burst output ready (build tools, cat, find). This IS
-/// the coalescing — no separate accumulation loop is needed.
-///
-/// For interactive use (prompt, keystroke echo) the kernel returns a small
-/// number of bytes immediately and read() blocks again. Those bytes are sent
-/// right away so the terminal never freezes waiting for a threshold.
 const READ_BUF_SIZE: usize = 256 * 1024;
 
-/// Outcome returned by try_reattach — tells open_tab what happened.
+/// More than RESPAWN_RATE_MAX respawns in this window → stop respawning and
+/// surface as a normal exit. A user with a broken shell init file sees the
+/// failure mode quickly instead of an infinite spin.
+const RESPAWN_RATE_WINDOW: Duration = Duration::from_secs(10);
+const RESPAWN_RATE_MAX: usize = 3;
+
 pub enum ReattachResult {
     /// Channel was updated and the reader thread is still running. open_tab
     /// should return false; the reader picks up the new channel on next output.
@@ -73,147 +92,220 @@ pub enum ReattachResult {
     NotFound,
 }
 
-/// Spawns a dedicated reader thread that forwards PTY output to the frontend.
-///
-/// # Channel failure behaviour (self-healing contract)
-///
-/// When on_data.send() fails (WebView disconnected, Channel JS object dropped),
-/// the reader thread does NOT exit. It clears the shared channel and keeps
-/// reading, discarding output until open_tab swaps in a new Channel.
-///
-/// This is the critical design choice that makes reconnection work regardless
-/// of timing: even if the reader thread is blocked on read() when the WebView
-/// disconnects, open_tab can safely hand it a new channel and the reader will
-/// start forwarding again on the very next byte of PTY output — no thread
-/// restart, no race on reader_alive.
-///
-/// # Known limitations
-///
-/// - **No output replay**: bytes sent to the terminal between disconnect and
-///   reconnect are discarded. Output still in the kernel PTY buffer at the
-///   moment the channel is cleared may or may not be delivered — it depends on
-///   whether the send error is detected before or after that read() returns.
-///   A VS Code-style ring buffer would close this gap but is not implemented.
-///
-/// - **Mid-session drops only heal on next open_tab**: if the IPC channel dies
-///   while the WebView is still running (not a WebView restart), the reader
-///   clears its channel and goes silent — but nothing triggers open_tab again.
-///   A heartbeat/ping mechanism would be needed to detect and surface this.
-///
-/// - **Full-app crash**: if the Tauri process exits, all PTY sessions are lost.
-///   A separate long-lived pty-host process (VS Code model) would be needed
-///   for crash survival, and is out of scope for now.
-fn spawn_reader_thread(
+/// Bundle of long-lived references the reader thread needs to perform an
+/// in-place respawn on shell self-exit. Grouped into a struct so
+/// `spawn_reader_thread` doesn't take a 10-param signature.
+struct ReaderCtx {
     app: AppHandle,
     tab_id: String,
-    mut reader: Box<dyn Read + Send>,
     channel: SharedChannel,
     mod_handle: ModEngineHandle,
     reader_alive: Arc<AtomicBool>,
+    closing: Arc<AtomicBool>,
+    pty_map: PtyMap,
+    cwd_table: CwdTable,
+}
+
+/// Spawns the reader thread that forwards PTY bytes to the frontend.
+///
+/// On EOF the thread either emits pty:exit (user-initiated close) or hands
+/// off to `respawn_in_place` (shell self-exit). If respawn fails or the rate
+/// limit fires, it falls back to pty:exit. See module-level discussion of
+/// closing vs self-exit.
+fn spawn_reader_thread(
+    ctx: ReaderCtx,
+    mut reader: Box<dyn Read + Send>,
 ) {
     std::thread::spawn(move || {
         let mut buf = [0u8; READ_BUF_SIZE];
 
         // Stateful UTF-8 decoder. PTY read() can return a chunk that ends in
         // the middle of a multi-byte UTF-8 sequence — common with TUI agents
-        // (Claude Code, Codex) that emit dense Unicode (box drawing, em-dashes,
-        // emoji). String::from_utf8_lossy would replace those partial bytes
-        // with U+FFFD on every chunk boundary, corrupting roughly one character
-        // per multi-byte char that lands on a read boundary.
-        //
-        // encoding_rs::Decoder maintains internal state across decode_to_string
-        // calls — partial trailing bytes are buffered and prepended to the
-        // next chunk. Same approach node-pty uses, just one layer up from the
-        // PTY read in our case.
+        // (Claude Code, Codex) that emit dense Unicode. String::from_utf8_lossy
+        // would replace those partial bytes with U+FFFD on every chunk
+        // boundary, corrupting roughly one character per multi-byte char that
+        // lands on a read boundary.
         let mut decoder = encoding_rs::UTF_8.new_decoder();
-        // Pre-sized for roughly one read's worth of decoded output. For valid
-        // UTF-8, the decoded text is about the same size as the input bytes,
-        // but malformed sequences or an EOF flush of trailing partial bytes
-        // can emit U+FFFD and expand the UTF-8 byte length. This is just a
-        // reasonable starting capacity, not a strict upper bound.
         let mut decoded = String::with_capacity(READ_BUF_SIZE + 4);
 
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => {
-                    // PTY process exited or master fd closed (close_tab called).
-                    // Flush the decoder — any partial UTF-8 bytes left over at
-                    // EOF become U+FFFD (last=true tells the decoder no more
-                    // input is coming, so it must commit any pending state).
+                    // Flush any partial UTF-8 bytes so the tail of the
+                    // session output doesn't go missing.
                     decoded.clear();
                     let _ = decoder.decode_to_string(&[], &mut decoded, true);
                     if !decoded.is_empty() {
-                        if let Some(ch) = channel.lock().unwrap().as_ref() {
+                        if let Some(ch) = ctx.channel.lock().unwrap().as_ref() {
                             ch.send(PtyDataPayload { data: decoded.clone() }).ok();
                         }
                     }
 
-                    // Mark dead immediately — before emitting pty:exit or calling
-                    // on_tab_close — so try_reattach cannot observe reader_alive=true
-                    // on a thread that is in the process of exiting.
-                    reader_alive.store(false, Ordering::Relaxed);
-                    channel.lock().unwrap().take();
-                    app.emit(
-                        "pty:exit",
-                        PtyExitPayload { tab_id: tab_id.clone() },
-                    )
-                    .ok();
-                    mod_handle.on_tab_close(&tab_id);
-                    break;
+                    // Mark dead first so try_reattach can't observe
+                    // reader_alive=true on a thread that's already on the
+                    // way out.
+                    ctx.reader_alive.store(false, Ordering::Release);
+
+                    if ctx.closing.load(Ordering::Acquire) {
+                        // User clicked the tab close button. Final cleanup
+                        // path: drop the live channel, tell the frontend
+                        // and mods, then exit the thread.
+                        ctx.channel.lock().unwrap().take();
+                        ctx.app.emit(
+                            "pty:exit",
+                            PtyExitPayload { tab_id: ctx.tab_id.clone() },
+                        ).ok();
+                        ctx.mod_handle.on_tab_close(&ctx.tab_id);
+                        break;
+                    }
+
+                    // Shell exited on its own — try to respawn in place at
+                    // the last known CWD. If that fails (rate limit, handle
+                    // gone, OS error), fall through to the same exit path
+                    // as a user close.
+                    match respawn_in_place(&ctx) {
+                        Ok(()) => break,
+                        Err(e) => {
+                            eprintln!(
+                                "[pty_manager] respawn failed for {}: {e}",
+                                ctx.tab_id
+                            );
+                            ctx.channel.lock().unwrap().take();
+                            ctx.app.emit(
+                                "pty:exit",
+                                PtyExitPayload { tab_id: ctx.tab_id.clone() },
+                            ).ok();
+                            ctx.mod_handle.on_tab_close(&ctx.tab_id);
+                            break;
+                        }
+                    }
                 }
                 Ok(n) => {
-                    // Stream-decode this chunk. Partial trailing bytes (1–3 bytes
-                    // of an incomplete UTF-8 sequence) stay inside the decoder's
-                    // state and are prepended to the next chunk automatically.
                     decoded.clear();
                     let (_result, _bytes_read, _had_errors) =
                         decoder.decode_to_string(&buf[..n], &mut decoded, false);
 
-                    // Lock briefly to send — released before calling on_output.
                     let send_ok = {
-                        let guard = channel.lock().unwrap();
+                        let guard = ctx.channel.lock().unwrap();
                         match guard.as_ref() {
                             Some(ch) => {
                                 ch.send(PtyDataPayload { data: decoded.clone() }).is_ok()
                             }
-                            // No channel — WebView is disconnected. Terminal
-                            // forwarding is skipped but MODs still receive output
-                            // so their state stays current for when the frontend
-                            // reconnects.
+                            // No channel — WebView disconnected. Skip the
+                            // forward but still feed mods so per-tab state
+                            // stays current for reconnect.
                             None => true,
                         }
                     };
 
                     if !send_ok {
-                        // Channel dropped mid-flight (WebView disconnected while
-                        // we were sending). Clear the dead channel and keep the
-                        // reader thread alive — the PTY process is still running
-                        // and open_tab will swap in a new channel on reconnect.
-                        // Output from this read is lost; no replay buffer.
-                        channel.lock().unwrap().take();
+                        // Channel dropped mid-flight (WebView vanished while
+                        // we were sending). Clear the dead channel; the
+                        // process is fine, open_tab will swap in a new one.
+                        ctx.channel.lock().unwrap().take();
                     }
-                    // Always forward to MOD engine regardless of channel state —
-                    // MOD state (git, CWD, agent detection) must stay current
-                    // even while the WebView is disconnected. Pass raw bytes —
-                    // the OSC parser is byte-oriented and unaffected by UTF-8
-                    // boundaries.
-                    mod_handle.on_output(&tab_id, buf[..n].to_vec());
+                    ctx.mod_handle.on_output(&ctx.tab_id, buf[..n].to_vec());
                 }
             }
         }
     });
 }
 
-/// Checks whether an existing PtyMap entry can be reconnected, and if so,
-/// wires up the new Channel and (if needed) a new reader thread.
+/// Replaces the master/writer/child of an existing PtyHandle with a freshly
+/// spawned shell at the last-known CWD, and starts a new reader thread.
 ///
-/// Must be called before spawn_pty in open_tab. Acts on the result:
-/// - ChannelUpdated / Reattached → emit pty:reconnected, return Ok(false)
-/// - Expired / NotFound          → call spawn_pty, return Ok(true)
+/// The handle's tab_id, channel, and PtyMap entry stay the same — frontend
+/// keeps writing to the same xterm instance and never sees a tab swap.
+fn respawn_in_place(ctx: &ReaderCtx) -> Result<(), String> {
+    let mut map = ctx.pty_map.lock().unwrap();
+    let Some(handle) = map.get_mut(&ctx.tab_id) else {
+        return Err("PtyMap entry vanished before respawn".to_string());
+    };
+
+    // Rate limit: if too many respawns happened recently, surface as a
+    // real exit so a broken `.zshrc` doesn't loop the user out of the app.
+    let now = Instant::now();
+    {
+        let mut hist = handle.respawn_history.lock().unwrap();
+        hist.retain(|t| now.duration_since(*t) < RESPAWN_RATE_WINDOW);
+        if hist.len() >= RESPAWN_RATE_MAX {
+            return Err(format!(
+                "respawn rate limit exceeded ({} in {}s)",
+                hist.len() + 1,
+                RESPAWN_RATE_WINDOW.as_secs(),
+            ));
+        }
+        hist.push(now);
+    }
+
+    let cwd = ctx
+        .cwd_table
+        .lock()
+        .unwrap()
+        .get(&ctx.tab_id)
+        .cloned()
+        .or_else(|| handle.spawn_cwd.clone())
+        .or_else(|| dirs::home_dir().and_then(|p| p.to_str().map(String::from)));
+
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+        .map_err(|e| e.to_string())?;
+
+    let cmd = build_shell_command(&handle.shell_path, cwd.as_deref(), &ctx.tab_id);
+    let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let new_pid = child.process_id().unwrap_or(0);
+
+    let new_reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
+    let new_writer = pair.master.take_writer().map_err(|e| e.to_string())?;
+
+    // Reset per-tab mod state — the old shell took its agent/process/git
+    // observations to the grave. Pretending they still apply would surface
+    // lies in the status bar.
+    ctx.mod_handle.on_tab_close(&ctx.tab_id);
+    ctx.mod_handle.on_tab_open(&ctx.tab_id, new_pid);
+
+    let new_alive = Arc::new(AtomicBool::new(true));
+    handle.master = pair.master;
+    handle.writer = new_writer;
+    handle.child = child;
+    handle.reader_alive = new_alive.clone();
+    // closing stays whatever it was (false here, since we only respawn on
+    // self-exit). Channel arc stays shared so frontend keeps writing into
+    // the same xterm.
+
+    drop(map);
+
+    spawn_reader_thread(
+        ReaderCtx {
+            app: ctx.app.clone(),
+            tab_id: ctx.tab_id.clone(),
+            channel: ctx.channel.clone(),
+            mod_handle: ctx.mod_handle.clone(),
+            reader_alive: new_alive,
+            closing: ctx.closing.clone(),
+            pty_map: ctx.pty_map.clone(),
+            cwd_table: ctx.cwd_table.clone(),
+        },
+        new_reader,
+    );
+
+    ctx.app.emit(
+        "pty:respawned",
+        PtyRespawnPayload {
+            tab_id: ctx.tab_id.clone(),
+            cwd,
+        },
+    ).ok();
+
+    Ok(())
+}
+
 pub fn try_reattach(
     app: AppHandle,
     pty_map: &PtyMap,
     mod_handle: ModEngineHandle,
+    cwd_table: CwdTable,
     tab_id: &str,
     on_data: Channel<PtyDataPayload>,
 ) -> Result<ReattachResult, String> {
@@ -223,29 +315,20 @@ pub fn try_reattach(
         return Ok(ReattachResult::NotFound);
     };
 
-    // If the child has exited, the PTY is truly dead — remove the stale entry
-    // so the caller can spawn a fresh PTY.
     if matches!(handle.child.try_wait(), Ok(Some(_))) {
+        // Child fully exited and (somehow) wasn't respawned — stale entry,
+        // let the caller spawn a fresh PTY.
         map.remove(tab_id);
         return Ok(ReattachResult::Expired);
     }
 
-    // Child is still running (or indeterminate). Swap in the new channel.
-    // The reader thread — whether blocking on read() or actively discarding —
-    // will forward output via this channel on its next iteration.
     {
         let mut ch = handle.channel.lock().unwrap();
         *ch = Some(on_data);
 
-        // Write the reconnect banner directly through the data channel before
-        // returning. This is intentionally synchronous — the Channel.onmessage
-        // handler on the JS side is registered before invoke() is called, so
-        // this send is guaranteed to arrive without any listener timing issues.
-        //
-        // Writing via the data channel (rather than a Tauri event) avoids the
-        // async listen() race: Tauri events need listen() to resolve (a Promise)
-        // before the listener is active, but that Promise may not resolve before
-        // pty:reconnected fires. The data channel has no such gap.
+        // Send the reconnect banner via the data channel, not a Tauri event:
+        // the channel's onmessage handler is registered before invoke()
+        // resolves, so this send has no listener-timing gap. listen() does.
         if let Some(ch_ref) = ch.as_ref() {
             ch_ref
                 .send(PtyDataPayload {
@@ -255,64 +338,55 @@ pub fn try_reattach(
         }
     }
 
-    if handle.reader_alive.load(Ordering::Relaxed) {
-        // Reader is running. Channel is updated. No thread restart needed.
+    if handle.reader_alive.load(Ordering::Acquire) {
         return Ok(ReattachResult::ChannelUpdated);
     }
 
-    // reader_alive is false but try_wait() did not confirm child exit. This
-    // happens when the PTY process exits and the reader thread sets reader_alive
-    // to false, but the OS has not yet reaped the zombie by the time try_wait()
-    // runs. Spawn a fresh reader on the same master fd — it will see EOF
-    // immediately and emit pty:exit on its own.
+    // reader_alive is false but try_wait() didn't confirm exit — the reader
+    // set the flag and is in the middle of exiting. Spawn a fresh reader on
+    // the same master fd; it'll see EOF immediately and take the normal
+    // exit-or-respawn path.
     let new_alive = Arc::new(AtomicBool::new(true));
     handle.reader_alive = new_alive.clone();
     let reader = handle.master.try_clone_reader().map_err(|e| e.to_string())?;
     let channel = handle.channel.clone();
-    drop(map); // release the PtyMap lock before spawning
+    let closing = handle.closing.clone();
+    drop(map);
 
-    spawn_reader_thread(app, tab_id.to_string(), reader, channel, mod_handle, new_alive);
+    spawn_reader_thread(
+        ReaderCtx {
+            app,
+            tab_id: tab_id.to_string(),
+            channel,
+            mod_handle,
+            reader_alive: new_alive,
+            closing,
+            pty_map: pty_map.clone(),
+            cwd_table,
+        },
+        reader,
+    );
     Ok(ReattachResult::Reattached)
 }
 
-pub fn spawn_pty(
-    app: AppHandle,
-    pty_map: &PtyMap,
-    mod_handle: ModEngineHandle,
-    tab_id: String,
-    cwd: Option<String>,
-    shell: Option<String>,
-    on_data: Channel<PtyDataPayload>,
-) -> Result<(), String> {
-    let pty_system = native_pty_system();
-    let pair = pty_system
-        .openpty(PtySize {
-            rows: 24,
-            cols: 80,
-            pixel_width: 0,
-            pixel_height: 0,
-        })
-        .map_err(|e| e.to_string())?;
+/// Builds the full shell command (env, args, cwd) used for both the initial
+/// spawn and any subsequent respawn. Centralised so respawn picks up the
+/// same shell-integration shims, login-shell flags, and AGENT_TERMINAL_TAB_ID
+/// injection — without that, the new shell wouldn't emit OSC 7, breaking
+/// the next respawn's CWD lookup.
+fn build_shell_command(
+    shell_path: &str,
+    cwd: Option<&str>,
+    tab_id: &str,
+) -> CommandBuilder {
+    let mut cmd = CommandBuilder::new(shell_path);
+    cmd.env("AGENT_TERMINAL_TAB_ID", tab_id);
 
-    let shell_path = shell.unwrap_or_else(|| {
-        std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
-    });
-
-    let mut cmd = CommandBuilder::new(&shell_path);
-    cmd.env("AGENT_TERMINAL_TAB_ID", &tab_id);
-
-    // Critical for production GUI launches: macOS launchd starts the .app
-    // with a minimal environment (no TERM, no user PATH). Without TERM, zsh
-    // can't initialize zle (its line editor) and the user sees doubled
-    // keystrokes (kernel TTY echo + shell echo, neither suppressed). Without
-    // user PATH, Homebrew/fnm/codex/etc. aren't on PATH and every command
-    // fails with "command not found".
-    //
-    // Setting TERM here matches what every terminal emulator does. PATH and
-    // language vars are loaded by the shell itself once we (a) make it a
-    // login shell so /etc/zprofile + path_helper run, and (b) ensure our
-    // ZDOTDIR shims source the user's real .zshenv/.zprofile (see
-    // shell_integration.rs).
+    // macOS launchd starts GUI apps with a minimal env (no TERM, no user
+    // PATH). Without TERM zsh can't initialize zle and the user sees doubled
+    // keystrokes; without user PATH every brewed binary fails with "command
+    // not found". TERM is set here; PATH is loaded by the shell itself
+    // once we make it a login shell + ZDOTDIR-shim its rc files.
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
     if let Ok(lang) = std::env::var("LANG") {
@@ -321,21 +395,17 @@ pub fn spawn_pty(
         cmd.env("LANG", "en_US.UTF-8");
     }
 
-    if let Some(ref dir) = cwd {
+    if let Some(dir) = cwd {
         cmd.cwd(dir);
     }
 
-    // Inject shell integration based on the shell binary name
-    let shell_name = std::path::Path::new(&shell_path)
+    let shell_name = std::path::Path::new(shell_path)
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("")
         .to_lowercase();
 
     if shell_name == "zsh" {
-        // ZDOTDIR redirect: zsh loads .zshenv/.zprofile/.zshrc from
-        // ~/.config/agent-terminal/zsh/ instead of $HOME. Our shim files
-        // there source the user's real ones.
         let at_zsh_dir = dirs::home_dir()
             .map(|h| h.join(".config").join("agent-terminal").join("zsh"))
             .and_then(|p| p.to_str().map(|s| s.to_string()));
@@ -348,14 +418,10 @@ pub fn spawn_pty(
             cmd.env("ZDOTDIR_ORIG", &home);
         }
 
-        // -l makes it a login shell so /etc/zprofile (path_helper) runs and
-        // adds /usr/local/bin, /opt/homebrew/bin, /opt/homebrew/sbin to PATH.
-        // Combined with our .zprofile shim sourcing the user's real .zprofile,
-        // this gives the spawned shell the same PATH the user sees in
-        // Terminal.app. Without -l, GUI-launched builds get a stub PATH.
+        // Login shell so /etc/zprofile (path_helper) runs and adds the
+        // homebrew/system bins to PATH.
         cmd.arg("-l");
     } else if shell_name == "bash" {
-        // --init-file replaces ~/.bashrc for non-login shells
         let init_file = dirs::home_dir()
             .map(|h| h.join(".config").join("agent-terminal").join("bash-integration.bash"))
             .and_then(|p| p.to_str().map(|s| s.to_string()));
@@ -365,33 +431,72 @@ pub fn spawn_pty(
             cmd.arg(&init);
         }
     }
-    // Other shells: no injection
 
+    cmd
+}
+
+pub fn spawn_pty(
+    app: AppHandle,
+    pty_map: &PtyMap,
+    mod_handle: ModEngineHandle,
+    cwd_table: CwdTable,
+    tab_id: String,
+    cwd: Option<String>,
+    shell: Option<String>,
+    on_data: Channel<PtyDataPayload>,
+) -> Result<(), String> {
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+        .map_err(|e| e.to_string())?;
+
+    let shell_path = shell.unwrap_or_else(|| {
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
+    });
+
+    let cmd = build_shell_command(&shell_path, cwd.as_deref(), &tab_id);
     let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     let shell_pid = child.process_id().unwrap_or(0);
 
     let reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
 
-    // Notify MODs before the read thread starts so on_open is always processed
-    // before any on_output messages in the engine's ordered channel.
+    // on_open before reader starts, so the engine sees on_open ahead of any
+    // on_output from the same tab.
     mod_handle.on_tab_open(&tab_id, shell_pid);
 
     let channel: SharedChannel = Arc::new(Mutex::new(Some(on_data)));
     let reader_alive = Arc::new(AtomicBool::new(true));
-
-    spawn_reader_thread(
-        app,
-        tab_id.clone(),
-        reader,
-        channel.clone(),
-        mod_handle,
-        reader_alive.clone(),
-    );
+    let closing = Arc::new(AtomicBool::new(false));
+    let respawn_history = Arc::new(Mutex::new(Vec::new()));
 
     pty_map.lock().unwrap().insert(
-        tab_id,
-        PtyHandle { master: pair.master, writer, child, reader_alive, channel },
+        tab_id.clone(),
+        PtyHandle {
+            master: pair.master,
+            writer,
+            child,
+            reader_alive: reader_alive.clone(),
+            channel: channel.clone(),
+            closing: closing.clone(),
+            shell_path,
+            spawn_cwd: cwd,
+            respawn_history,
+        },
+    );
+
+    spawn_reader_thread(
+        ReaderCtx {
+            app,
+            tab_id,
+            channel,
+            mod_handle,
+            reader_alive,
+            closing,
+            pty_map: pty_map.clone(),
+            cwd_table,
+        },
+        reader,
     );
 
     Ok(())

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -160,11 +160,17 @@ fn spawn_reader_thread(
                     }
 
                     // Shell exited on its own — try to respawn in place at
-                    // the last known CWD. If that fails (rate limit, handle
-                    // gone, OS error), fall through to the same exit path
-                    // as a user close.
+                    // the last known CWD. Three outcomes:
+                    //   * Respawned        → silent exit (new reader took over)
+                    //   * SkippedExternally → silent exit (try_reattach already
+                    //     reclaimed the entry and open_tab is spawning a fresh
+                    //     PTY for this tab id; emitting pty:exit here would
+                    //     clobber the new shell's state)
+                    //   * Err              → fall through to the user-close path
+                    //     (rate limit hit, OS error, etc.)
                     match respawn_in_place(&ctx) {
-                        Ok(()) => break,
+                        Ok(RespawnOutcome::Respawned)
+                        | Ok(RespawnOutcome::SkippedExternally) => break,
                         Err(e) => {
                             eprintln!(
                                 "[pty_manager] respawn failed for {}: {e}",
@@ -211,15 +217,30 @@ fn spawn_reader_thread(
     });
 }
 
+/// What `respawn_in_place` did, so the reader thread knows whether to stay
+/// silent or fall through to the user-close exit path.
+enum RespawnOutcome {
+    /// Replaced the handle's master/writer/child and started a new reader.
+    Respawned,
+    /// PtyMap entry was already gone — `try_reattach` reclaimed it and
+    /// `open_tab` is spawning a fresh PTY for the same tab id. Emitting
+    /// `pty:exit` from here would clobber that new shell's state.
+    SkippedExternally,
+}
+
 /// Replaces the master/writer/child of an existing PtyHandle with a freshly
 /// spawned shell at the last-known CWD, and starts a new reader thread.
 ///
 /// The handle's tab_id, channel, and PtyMap entry stay the same — frontend
 /// keeps writing to the same xterm instance and never sees a tab swap.
-fn respawn_in_place(ctx: &ReaderCtx) -> Result<(), String> {
+fn respawn_in_place(ctx: &ReaderCtx) -> Result<RespawnOutcome, String> {
     let mut map = ctx.pty_map.lock().unwrap();
     let Some(handle) = map.get_mut(&ctx.tab_id) else {
-        return Err("PtyMap entry vanished before respawn".to_string());
+        // Race with try_reattach: it called `child.try_wait()`, saw the
+        // dead child, removed the entry, and `open_tab` is now spawning a
+        // fresh PTY for this tab id. Stay silent — the new spawn owns the
+        // tab now.
+        return Ok(RespawnOutcome::SkippedExternally);
     };
 
     // Rate limit: if too many respawns happened recently, surface as a
@@ -247,9 +268,19 @@ fn respawn_in_place(ctx: &ReaderCtx) -> Result<(), String> {
         .or_else(|| handle.spawn_cwd.clone())
         .or_else(|| dirs::home_dir().and_then(|p| p.to_str().map(String::from)));
 
+    // Carry the current PTY size across so full-screen apps in the new
+    // shell render correctly. Without this the replacement starts at the
+    // 80x24 default and stays there until the user manually resizes the
+    // pane (xterm doesn't fire a resize when its container size hasn't
+    // changed).
+    let size = handle
+        .master
+        .get_size()
+        .unwrap_or(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 });
+
     let pty_system = native_pty_system();
     let pair = pty_system
-        .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+        .openpty(size)
         .map_err(|e| e.to_string())?;
 
     let cmd = build_shell_command(&handle.shell_path, cwd.as_deref(), &ctx.tab_id);
@@ -298,7 +329,7 @@ fn respawn_in_place(ctx: &ReaderCtx) -> Result<(), String> {
         },
     ).ok();
 
-    Ok(())
+    Ok(RespawnOutcome::Respawned)
 }
 
 pub fn try_reattach(

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -4,7 +4,7 @@ import {
   XTermTerminal,
 } from '@/components/XTermTerminal/XTermTerminal'
 import { IPC } from '@/modules/ipc/commands'
-import { onPtyExit } from '@/modules/ipc/events'
+import { onPtyExit, onPtyRespawned } from '@/modules/ipc/events'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
 // Tracks in-flight openTab calls per tabKey. Prevents concurrent calls
@@ -93,12 +93,27 @@ export const TerminalPane = React.memo(function TerminalPane({
   )
 
   useEffect(() => {
+    // pty:exit only fires when the user closed the tab — the backend now
+    // respawns automatically when the shell self-exits (typed `exit`,
+    // segfault, etc.) and emits pty:respawned instead. So this banner
+    // shouldn't actually show up in normal use; kept as a safety net for
+    // the rate-limit fallback path.
     const unlistenExit = onPtyExit((id) => {
       if (id === tabKey) handleRef.current?.write('\r\n[Process exited]\r\n')
     })
 
+    const unlistenRespawn = onPtyRespawned((id, cwd) => {
+      if (id !== tabKey) return
+      const where = cwd ? ` in ${cwd}` : ''
+      // Dim ANSI so the banner reads as system chrome, not shell output.
+      handleRef.current?.write(
+        `\r\n\x1b[2m[Shell restarted${where}]\x1b[0m\r\n`,
+      )
+    })
+
     return () => {
       unlistenExit.then((fn) => fn())
+      unlistenRespawn.then((fn) => fn())
       // Do NOT close the pty here. Pty lifetime is tied to the tab's
       // existence in the store. removeTab() calls IPC.closeTab() when
       // the user explicitly closes the tab.

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -104,7 +104,14 @@ export const TerminalPane = React.memo(function TerminalPane({
 
     const unlistenRespawn = onPtyRespawned((id, cwd) => {
       if (id !== tabKey) return
-      const where = cwd ? ` in ${cwd}` : ''
+      // Strip C0/C1 control bytes (incl. ESC) from the path before
+      // injecting it into the xterm stream. cwd ultimately comes from a
+      // shell-emitted OSC 7 + URL decode, which can produce literal
+      // control bytes if a directory name contains `%1B` or similar —
+      // without this scrub, opening such a folder would inject arbitrary
+      // terminal escapes through the restart banner.
+      const safe = cwd?.replace(/[\x00-\x1f\x7f-\x9f]/g, '?') ?? ''
+      const where = safe ? ` in ${safe}` : ''
       // Dim ANSI so the banner reads as system chrome, not shell output.
       handleRef.current?.write(
         `\r\n\x1b[2m[Shell restarted${where}]\x1b[0m\r\n`,

--- a/src/modules/ipc/events.ts
+++ b/src/modules/ipc/events.ts
@@ -18,3 +18,11 @@ export const onPtyExit = (cb: (tabId: string) => void) =>
  */
 export const onPtyReconnected = (cb: (tabId: string) => void) =>
   listen<{ tabId: string }>('pty:reconnected', (e) => cb(e.payload.tabId))
+
+/** Fires when the backend respawns a shell after self-exit (e.g. user typed `exit`). */
+export const onPtyRespawned = (
+  cb: (tabId: string, cwd: string | null) => void,
+) =>
+  listen<{ tabId: string; cwd: string | null }>('pty:respawned', (e) =>
+    cb(e.payload.tabId, e.payload.cwd),
+  )


### PR DESCRIPTION
## Summary

Fixes the second high-priority post-v0.1.0 bug: typing \`exit\` (or any other shell self-exit) left xterm frozen, with no recovery short of restarting the whole app. The backend now respawns a fresh shell in-place at the last known cwd while keeping the same tab id, channel, and scrollback.

## Behavior

| Trigger | Before | After |
|---|---|---|
| User types \`exit\` in the shell | xterm shows dead buffer, no input accepted | New shell spawns in same tab at the cwd the user was last in; \`[Shell restarted in <cwd>]\` banner |
| User clicks the tab close button | Tab disappears | Same — no respawn (a \`closing\` flag distinguishes the paths) |
| Shell crashes repeatedly (broken \`.zshrc\`) | xterm froze on first crash | First 3 respawns within 10s; after that falls through to the same exit banner so the user sees the failure mode quickly |

## How

**Backend**

- New \`closing: AtomicBool\` on \`PtyHandle\`, flipped by \`close_tab\` before the entry is removed. Reader thread reads it on EOF to pick: emit \`pty:exit\` (user close) vs \`respawn_in_place\` (self-exit).
- New \`spawn_cwd\` and \`respawn_history\` on \`PtyHandle\` for the cwd fallback chain (cwd_table → spawn_cwd → \`$HOME\`) and the rate limit.
- \`ModEngine\`'s cwd_table promoted to a shared \`Arc<Mutex<HashMap>>\` so pty_manager can read it synchronously at respawn time. Entries are no longer dropped on tab close — preserved across respawn.
- \`build_shell_command\` extracted from \`spawn_pty\` so respawn re-uses the exact same env (TERM, AGENT_TERMINAL_TAB_ID, ZDOTDIR shims) and login-shell flag. Critical: without the ZDOTDIR shim the new shell wouldn't emit OSC 7 and the *next* respawn's cwd lookup would break.
- Reader thread cycles per-tab mod state on respawn (\`on_tab_close\` → \`on_tab_open\`) so the old shell's stale agent/process/git observations don't bleed into the new one.
- Rate limit: 3 respawns in 10s, then fall through to \`pty:exit\`.

**Frontend**

- New \`pty:respawned\` event with \`{tabId, cwd}\` payload
- TerminalPane writes a dim \`[Shell restarted in <cwd>]\` banner
- Existing \`pty:exit\` listener kept; only fires now on user-close or rate-limit fallback

## Why no new backend unit tests

The respawn paths run inside the PTY reader thread and depend on a real Tauri \`AppHandle\` (for \`app.emit\`) plus actual portable_pty subprocesses. Both are awkward to stand up in cargo unit tests. Manual QA below covers the behavior end-to-end. Existing test suite (27 unit + 9 integration + 23 frontend) all green.

## Test plan

- [x] Merge
- [x] Pull a fresh prod build
- [x] Open a tab, \`cd /tmp\`, type \`exit\` → respawn at \`/tmp\` with the banner
- [x] Open a tab, type \`exit\` immediately at the first prompt → respawn at the project root (spawn_cwd fallback)
- [x] Run \`claude\` in a tab, kill it with Ctrl+C, type \`exit\` → respawn fine; status bar shows no leftover claude state
- [x] Click the tab close button → tab disappears, no respawn
- [x] Add a broken line to \`.zshrc\` that causes the shell to exit immediately → after 3 fast respawns, shows \`[Process exited]\`, doesn't loop