### PR TITLE
fix: drop danger badge from top tab bar; sidebar badge uses shadcn tooltip

### DIFF
--- a/src/components/DangerBadge.tsx
+++ b/src/components/DangerBadge.tsx
@@ -1,3 +1,10 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
 /**
  * 🤘 badge shown when an agent tab is running with full permissions.
  *
@@ -5,24 +12,36 @@
  * - codex:       --yolo
  *
  * The badge and tooltip are the same regardless of which flag triggered it.
+ *
+ * Uses the shadcn Tooltip (base-ui under the hood) so the hover hint matches
+ * the rest of the app's tooltips — consistent styling and timing — instead of
+ * the OS-default native `title` attribute.
  */
 export function DangerBadge({ size = 12 }: { size?: number }) {
   return (
-    <span
-      role="img"
-      title="All permissions enabled"
-      aria-label="All permissions enabled"
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexShrink: 0,
-        fontSize: size,
-        lineHeight: 1,
-        cursor: 'help',
-      }}
-    >
-      🤘
-    </span>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span
+              role="img"
+              aria-label="All permissions enabled"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+                fontSize: size,
+                lineHeight: 1,
+                cursor: 'help',
+              }}
+            >
+              🤘
+            </span>
+          }
+        />
+        <TooltipContent side="top">All permissions enabled</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }

--- a/src/components/DangerBadge.tsx
+++ b/src/components/DangerBadge.tsx
@@ -24,17 +24,8 @@ export function DangerBadge({ size = 12 }: { size?: number }) {
         <TooltipTrigger
           render={
             <span
-              role="img"
-              aria-label="All permissions enabled"
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
-                fontSize: size,
-                lineHeight: 1,
-                cursor: 'help',
-              }}
+              className="inline-flex shrink-0 items-center justify-center leading-none"
+              style={{ fontSize: size }}
             >
               🤘
             </span>

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -14,8 +14,6 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
 import { Pin, X } from 'lucide-react'
-import { hasDangerFlag } from '@/components/agent.helpers'
-import { DangerBadge } from '@/components/DangerBadge'
 import { TabStatusIcon } from '@/components/TabStatusIcon'
 import {
   ContextMenu,
@@ -106,9 +104,9 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
               <span className="truncate" style={{ fontFamily: MONO_FONT }}>
                 {resolveTabLabel(tab, tabMeta?.cwd)}
               </span>
-              {tabMeta?.type === 'agent' && hasDangerFlag(tabMeta.agentCmd) && (
-                <DangerBadge size={11} />
-              )}
+              {/* Danger indicator intentionally omitted here — the sidebar
+                  already shows it for the same tab; duplicating it on the
+                  top tab bar adds visual noise without new information. */}
             </button>
 
             {/* Pin / close action — sibling of nav button, not nested */}


### PR DESCRIPTION
## Summary

Two small UX touch-ups around the 🤘 \"all permissions enabled\" indicator:

1. **Stop duplicating the badge on the top tab bar** — the sidebar already shows it for the same tab, so adding it again on the top tab is just visual noise.
2. **Switch the badge's hover hint from native \`title\` to the shadcn Tooltip** so it matches the rest of the app's tooltip styling and timing instead of the OS-default chrome.

## What changed

| File | Change |
|---|---|
| \`src/components/TabBar/TabBar.tsx\` | Removed DangerBadge usage + imports (\`hasDangerFlag\`, \`DangerBadge\`). Left a one-line comment explaining the deliberate omission. |
| \`src/components/DangerBadge.tsx\` | Wrapped the badge in shadcn \`<Tooltip>\` (base-ui under the hood). Hint copy unchanged (\"All permissions enabled\"). |

The badge keeps rendering as a \`<span>\` (via \`Tooltip.Trigger\`'s \`render\` prop) — the default button-shaped trigger would be invalid HTML inside the sidebar tab/project nav buttons that host the badge.

## What didn't change

- Sidebar still shows the badge in both places (\`SidebarTabItem\` for tabs, \`SidebarProjectRow\` for the collapsed-project rollup).
- The \`hasDangerFlag\` helper is still used by both sidebar files; it's just no longer referenced from TabBar.

## Verified

- \`bunx tsc --noEmit\` — clean
- \`bunx biome check\` — clean
- \`bun run build\` — clean prod bundle