### PR TITLE
feat(keyboard): migrate to Cmd-based shortcuts + add standard macOS keymap

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-opener": "^2",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -389,6 +390,8 @@
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-search": ["@xterm/addon-search@0.16.0", "", {}, "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA=="],
 
     "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.9.0", "", {}, "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ use mod_engine::{
 use notifications::NotificationService;
 use shell_integration::setup_shell_integration;
 use tauri::Manager;
+use tauri::menu::{MenuBuilder, SubmenuBuilder};
 use pty_manager::PtyMap;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -53,6 +54,23 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
         .setup(|app| {
+            // Custom macOS menu — omits the default items whose shortcuts
+            // conflict with our keyboard handlers:
+            //   View → Actual Size / Zoom In / Zoom Out  (⌘0 / ⌘+ / ⌘-)
+            //   Edit → Find → Find Next / Previous       (⌘G / ⌘⇧G)
+            //   Window → Select Next / Previous Tab      (⌘⇧] / ⌘⇧[)
+            // macOS routes menu shortcuts at the OS level BEFORE the
+            // keystroke reaches the WebView, so leaving the defaults in
+            // place silently swallows our hotkeys. Standard items the
+            // user does expect (Quit, Hide, Cut/Copy/Paste/Select All,
+            // Minimize) stay in.
+            //
+            // Errors here are logged and ignored — a missing menu degrades
+            // the app, but doesn't break it (Cmd+Q still quits via the OS).
+            if let Err(e) = install_app_menu(app) {
+                eprintln!("[agent-terminal] menu setup failed: {e}");
+            }
+
             // Best-effort: write shell integration scripts. Never fail app startup.
             if let Err(e) = setup_shell_integration() {
                 eprintln!("[agent-terminal] shell integration setup failed: {e}");
@@ -120,4 +138,52 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// Builds and installs a custom macOS menu that intentionally omits the
+/// default items whose shortcuts collide with our app-level hotkeys.
+fn install_app_menu(
+    app: &tauri::App,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let app_submenu = SubmenuBuilder::new(app, "Agent Terminal")
+        .about(None)
+        .separator()
+        .services()
+        .separator()
+        .hide()
+        .hide_others()
+        .show_all()
+        .separator()
+        .quit()
+        .build()?;
+
+    // Edit submenu — standard text-edit items but no Find submenu.
+    // ⌘F / ⌘G / ⌘⇧G are owned by the in-app find overlay.
+    let edit_submenu = SubmenuBuilder::new(app, "Edit")
+        .undo()
+        .redo()
+        .separator()
+        .cut()
+        .copy()
+        .paste()
+        .select_all()
+        .build()?;
+
+    // Window submenu — minimize + fullscreen, NO "Select Next/Previous Tab"
+    // (⌘⇧] / ⌘⇧[ are owned by our tab navigation hotkeys).
+    let window_submenu = SubmenuBuilder::new(app, "Window")
+        .minimize()
+        .fullscreen()
+        .separator()
+        .close_window()
+        .build()?;
+
+    // Note: no View submenu at all. The View defaults are exclusively
+    // page-zoom items (⌘0 / ⌘+ / ⌘-) which we own for terminal font size.
+    let menu = MenuBuilder::new(app)
+        .items(&[&app_submenu, &edit_submenu, &window_submenu])
+        .build()?;
+
+    app.set_menu(menu)?;
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ use mod_engine::{
 use notifications::NotificationService;
 use shell_integration::setup_shell_integration;
 use tauri::Manager;
+#[cfg(target_os = "macos")]
 use tauri::menu::{MenuBuilder, SubmenuBuilder};
 use pty_manager::PtyMap;
 use std::collections::HashMap;
@@ -65,8 +66,13 @@ pub fn run() {
             // user does expect (Quit, Hide, Cut/Copy/Paste/Select All,
             // Minimize) stay in.
             //
+            // macOS-only — the menu items and their stripping rationale
+            // are platform-specific. On Win/Linux Tauri's defaults are
+            // native and stay untouched.
+            //
             // Errors here are logged and ignored — a missing menu degrades
             // the app, but doesn't break it (Cmd+Q still quits via the OS).
+            #[cfg(target_os = "macos")]
             if let Err(e) = install_app_menu(app) {
                 eprintln!("[agent-terminal] menu setup failed: {e}");
             }
@@ -142,6 +148,7 @@ pub fn run() {
 
 /// Builds and installs a custom macOS menu that intentionally omits the
 /// default items whose shortcuts collide with our app-level hotkeys.
+#[cfg(target_os = "macos")]
 fn install_app_menu(
     app: &tauri::App,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -26,7 +26,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
-import { $ctrlHeld } from '@/modules/stores/$keyboard'
+import { $metaHeld } from '@/modules/stores/$keyboard'
 import {
   $activeProjectId,
   $activeTabId,
@@ -49,10 +49,10 @@ import type { Project } from '@/screens/workspace/workspace.types'
 export function SidebarProjectRow({ project }: { project: Project }) {
   // undefined means the project pre-dates this field → treat as expanded
   const isOpen = project.isExpanded !== false
-  const ctrlHeld = useStore($ctrlHeld)
+  const metaHeld = useStore($metaHeld)
   const allProjects = useStore($projects)
 
-  // 1-based position in sidebar display order (pinned first) — matches Ctrl+N shortcut.
+  // 1-based position in sidebar display order (pinned first) — matches Cmd+N shortcut.
   // Only projects 1–9 show a badge; beyond that there is no keyboard shortcut.
   const orderedProjects = [
     ...allProjects.filter((p) => p.pinned),
@@ -181,7 +181,7 @@ export function SidebarProjectRow({ project }: { project: Project }) {
                 if (!renaming) setRenaming(true)
               }}
             >
-              {/* Folder icon with Ctrl+N badge overlay */}
+              {/* Folder icon with Cmd+N badge overlay */}
               <span className="relative flex shrink-0 items-center justify-center">
                 <Folder
                   size={13}
@@ -191,7 +191,7 @@ export function SidebarProjectRow({ project }: { project: Project }) {
                       : 'var(--sidebar-foreground)',
                   }}
                 />
-                {ctrlHeld && projectNumber >= 1 && projectNumber <= 9 && (
+                {metaHeld && projectNumber >= 1 && projectNumber <= 9 && (
                   <span className="absolute -top-1.5 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary font-bold text-[8px] text-primary-foreground leading-none">
                     {projectNumber}
                   </span>

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/components/XTermTerminal/XTermTerminal'
 import { IPC } from '@/modules/ipc/commands'
 import { onPtyExit, onPtyRespawned } from '@/modules/ipc/events'
+import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
 // Tracks in-flight openTab calls per tabKey. Prevents concurrent calls
@@ -40,6 +41,20 @@ export const TerminalPane = React.memo(function TerminalPane({
   useEffect(() => {
     if (isActive) {
       handleRef.current?.focus()
+    }
+  }, [isActive])
+
+  // Register this terminal as the active one whenever its tab is visible.
+  // Global hotkeys (Cmd+K, Cmd+A, Cmd+F, Cmd+G) read from the registry to
+  // dispatch terminal-scoped actions. Race-safe clear: only nil out the
+  // slot if it still points at us.
+  useEffect(() => {
+    if (!isActive) return
+    $activeTerminalHandle.set(handleRef.current)
+    return () => {
+      if ($activeTerminalHandle.get() === handleRef.current) {
+        $activeTerminalHandle.set(null)
+      }
     }
   }, [isActive])
 
@@ -104,13 +119,13 @@ export const TerminalPane = React.memo(function TerminalPane({
 
     const unlistenRespawn = onPtyRespawned((id, cwd) => {
       if (id !== tabKey) return
-      // Strip C0/C1 control bytes (incl. ESC) from the path before
-      // injecting it into the xterm stream. cwd ultimately comes from a
-      // shell-emitted OSC 7 + URL decode, which can produce literal
-      // control bytes if a directory name contains `%1B` or similar —
-      // without this scrub, opening such a folder would inject arbitrary
-      // terminal escapes through the restart banner.
-      const safe = cwd?.replace(/[\x00-\x1f\x7f-\x9f]/g, '?') ?? ''
+      // Strip Unicode control characters (Cc category — covers C0/C1) from
+      // the path before injecting it into the xterm stream. cwd ultimately
+      // comes from a shell-emitted OSC 7 + URL decode, which can produce
+      // literal control bytes if a directory name contains `%1B` or
+      // similar — without this scrub, opening such a folder would inject
+      // arbitrary terminal escapes through the restart banner.
+      const safe = cwd?.replace(/\p{Cc}/gu, '?') ?? ''
       const where = safe ? ` in ${safe}` : ''
       // Dim ANSI so the banner reads as system chrome, not shell output.
       handleRef.current?.write(

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -48,9 +48,16 @@ export const TerminalPane = React.memo(function TerminalPane({
   // Global hotkeys (Cmd+K, Cmd+A, Cmd+F, Cmd+G) read from the registry to
   // dispatch terminal-scoped actions. Race-safe clear: only nil out the
   // slot if it still points at us.
+  //
+  // The matching set call inside `handleReady` (below) covers the case
+  // where the pane mounts already-active and the handle isn't ready yet
+  // when this effect first runs. Without that, first-launch left the
+  // registry stuck at null until the user switched tabs.
   useEffect(() => {
     if (!isActive) return
-    $activeTerminalHandle.set(handleRef.current)
+    if (handleRef.current) {
+      $activeTerminalHandle.set(handleRef.current)
+    }
     return () => {
       if ($activeTerminalHandle.get() === handleRef.current) {
         $activeTerminalHandle.set(null)
@@ -73,6 +80,12 @@ export const TerminalPane = React.memo(function TerminalPane({
   const handleReady = useCallback(
     (handle: XTermHandle) => {
       handleRef.current = handle
+      // If this pane mounted already-active, the registration effect above
+      // ran before the handle existed. Catch up now so global hotkeys
+      // work on first launch without requiring a tab switch.
+      if (isActive) {
+        $activeTerminalHandle.set(handle)
+      }
 
       if (pendingOpens.has(tabKey)) return
       pendingOpens.add(tabKey)
@@ -90,7 +103,7 @@ export const TerminalPane = React.memo(function TerminalPane({
           pendingOpens.delete(tabKey)
         })
     },
-    [tabKey, cwd],
+    [tabKey, cwd, isActive],
   )
 
   const handleData = useCallback(

--- a/src/components/TerminalSearchBar/TerminalSearchBar.tsx
+++ b/src/components/TerminalSearchBar/TerminalSearchBar.tsx
@@ -1,0 +1,88 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useRef } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
+import {
+  $activeSearch,
+  closeSearch,
+  setSearchQuery,
+} from '@/modules/stores/$activeSearch'
+import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
+
+/**
+ * Floating overlay that opens via Cmd+F over the active terminal. Drives
+ * `@xterm/addon-search` through the active-terminal handle registry. Esc
+ * (or the close button) returns focus to xterm.
+ */
+export function TerminalSearchBar() {
+  const search = useStore($activeSearch)
+  const inputRef = useRef<HTMLInputElement>(null)
+  // Re-focus only when the bar opens or the active tab changes — depending
+  // on `search` directly would yank focus on every keystroke as the user
+  // types into the input.
+  const tabKey = search?.tabKey
+  useEffect(() => {
+    if (tabKey) inputRef.current?.focus()
+  }, [tabKey])
+
+  useHotkeys(
+    'esc',
+    () => {
+      if (!search) return
+      closeSearch()
+      $activeTerminalHandle.get()?.focus()
+    },
+    { enableOnFormTags: true, enabled: !!search },
+  )
+
+  if (!search) return null
+
+  return (
+    <div className="absolute top-2 right-2 z-10 flex items-center gap-1 rounded-md border border-border bg-popover px-2 py-1 shadow-md">
+      <input
+        ref={inputRef}
+        value={search.query}
+        onChange={(e) => {
+          setSearchQuery(e.target.value)
+          // Live-search: jump to first match as the user types.
+          $activeTerminalHandle.get()?.searchNext()
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            if (e.shiftKey) $activeTerminalHandle.get()?.searchPrevious()
+            else $activeTerminalHandle.get()?.searchNext()
+          }
+        }}
+        className="w-48 bg-transparent text-sm outline-none"
+        placeholder="Find"
+      />
+      <button
+        type="button"
+        onClick={() => $activeTerminalHandle.get()?.searchPrevious()}
+        className="rounded px-1 text-xs hover:bg-accent"
+        title="Previous (⇧⏎)"
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        onClick={() => $activeTerminalHandle.get()?.searchNext()}
+        className="rounded px-1 text-xs hover:bg-accent"
+        title="Next (⏎)"
+      >
+        ↓
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          closeSearch()
+          $activeTerminalHandle.get()?.focus()
+        }}
+        className="rounded px-1 text-xs hover:bg-accent"
+        title="Close (Esc)"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/src/components/TerminalSearchBar/TerminalSearchBar.tsx
+++ b/src/components/TerminalSearchBar/TerminalSearchBar.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
+import { Keys } from '@/modules/keymap/keys'
 import {
   $activeSearch,
   closeSearch,
@@ -25,7 +26,7 @@ export function TerminalSearchBar() {
   }, [tabKey])
 
   useHotkeys(
-    'esc',
+    Keys.Escape,
     () => {
       if (!search) return
       closeSearch()

--- a/src/components/TerminalSearchBar/TerminalSearchBar.tsx
+++ b/src/components/TerminalSearchBar/TerminalSearchBar.tsx
@@ -44,8 +44,11 @@ export function TerminalSearchBar() {
         value={search.query}
         onChange={(e) => {
           setSearchQuery(e.target.value)
-          // Live-search: jump to first match as the user types.
-          $activeTerminalHandle.get()?.searchNext()
+          // Live-search: incremental:true makes the addon expand the
+          // existing selection while the growing query still matches it,
+          // so the highlight stays anchored to the current match instead
+          // of bouncing forward through the buffer on every keystroke.
+          $activeTerminalHandle.get()?.searchNext({ incremental: true })
         }}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
@@ -62,6 +65,7 @@ export function TerminalSearchBar() {
         onClick={() => $activeTerminalHandle.get()?.searchPrevious()}
         className="rounded px-1 text-xs hover:bg-accent"
         title="Previous (⇧⏎)"
+        aria-label="Previous match"
       >
         ↑
       </button>
@@ -70,6 +74,7 @@ export function TerminalSearchBar() {
         onClick={() => $activeTerminalHandle.get()?.searchNext()}
         className="rounded px-1 text-xs hover:bg-accent"
         title="Next (⏎)"
+        aria-label="Next match"
       >
         ↓
       </button>
@@ -81,6 +86,7 @@ export function TerminalSearchBar() {
         }}
         className="rounded px-1 text-xs hover:bg-accent"
         title="Close (Esc)"
+        aria-label="Close find"
       >
         ✕
       </button>

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -1,13 +1,25 @@
+import { useStore } from '@nanostores/react'
 import { FitAddon } from '@xterm/addon-fit'
+import { SearchAddon } from '@xterm/addon-search'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { WebglAddon } from '@xterm/addon-webgl'
 import type { ITheme } from '@xterm/xterm'
 import { Terminal } from '@xterm/xterm'
 import React, { useEffect, useRef } from 'react'
+import { $activeSearch } from '@/modules/stores/$activeSearch'
+import { $fontSize } from '@/modules/stores/$fontSize'
 
 export type XTermHandle = {
   write: (data: string) => void
   focus: () => void
+  /** Clears the visible buffer + scrollback (xterm `term.clear()`). */
+  clear: () => void
+  /** Selects all text in the buffer. */
+  selectAll: () => void
+  /** Jumps to the next match for the current `$activeSearch` query. */
+  searchNext: () => void
+  /** Jumps to the previous match for the current `$activeSearch` query. */
+  searchPrevious: () => void
 }
 
 type Props = {
@@ -92,16 +104,16 @@ const LIGHT_THEME: ITheme = {
 // Returns true when the key combo is claimed by the app's hotkey layer
 // (react-hotkeys-hook at document level). Returning false from xterm's
 // attachCustomKeyEventHandler skips xterm's own handler so the event bubbles.
+//
+// Cmd-based: every app shortcut uses Cmd, and Cmd+anything has no
+// meaningful translation to a PTY control byte on macOS — so suppressing
+// xterm's handler for any meta-key combo is safe and removes the
+// per-shortcut allowlist that grew with the keymap.
+//
+// Browser-level shortcuts (Cmd+C/V copy/paste) are handled above xterm
+// in the contenteditable layer and are unaffected by this filter.
 function isAppShortcut(e: KeyboardEvent): boolean {
-  if (!e.ctrlKey) return false
-  return (
-    e.key === 'Tab' || // Ctrl+Tab, Ctrl+Shift+Tab
-    e.key === 't' ||
-    e.key === 'T' || // Ctrl+T
-    e.key === 'w' ||
-    e.key === 'W' || // Ctrl+W
-    '123456789'.includes(e.key) // Ctrl+1–9
-  )
+  return e.metaKey
 }
 
 export const XTermTerminal = React.memo(function XTermTerminal({
@@ -113,6 +125,8 @@ export const XTermTerminal = React.memo(function XTermTerminal({
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
+  const searchAddonRef = useRef<SearchAddon | null>(null)
+  const fontSize = useStore($fontSize)
 
   // Keep callbacks in refs so the mount-once effect always calls the latest
   // versions without needing to re-run when they change reference.
@@ -136,11 +150,13 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     const darkMq = window.matchMedia('(prefers-color-scheme: dark)')
 
     // xterm is fully synchronous — no WASM init required.
+    // Read $fontSize.get() (not the closure-captured `fontSize`) so the
+    // mount-once effect picks up any persisted value at construction time.
     const term = new Terminal({
       allowProposedApi: true, // required by @xterm/addon-webgl
       theme: darkMq.matches ? DARK_THEME : LIGHT_THEME,
       fontFamily: '"Geist Mono", "Cascadia Code", "Fira Code", monospace',
-      fontSize: 13,
+      fontSize: $fontSize.get(),
       lineHeight: 1.2,
       cursorBlink: true,
       cursorStyle: 'block',
@@ -150,9 +166,11 @@ export const XTermTerminal = React.memo(function XTermTerminal({
 
     const fitAddon = new FitAddon()
     const unicode11Addon = new Unicode11Addon()
+    const searchAddon = new SearchAddon()
 
     term.loadAddon(fitAddon)
     term.loadAddon(unicode11Addon)
+    term.loadAddon(searchAddon)
     term.open(container)
 
     // Activate Unicode 11 after open() per addon docs.
@@ -160,6 +178,7 @@ export const XTermTerminal = React.memo(function XTermTerminal({
 
     termRef.current = term
     fitAddonRef.current = fitAddon
+    searchAddonRef.current = searchAddon
 
     // Pass app-level shortcuts through to document-level hotkey handlers.
     // xterm calls preventDefault on keys it processes; returning false here
@@ -214,6 +233,26 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     onReadyRef.current({
       write: (data) => termRef.current?.write(data),
       focus: () => termRef.current?.focus(),
+      clear: () => termRef.current?.clear(),
+      selectAll: () => termRef.current?.selectAll(),
+      searchNext: () => {
+        const s = $activeSearch.get()
+        if (!s?.query) return
+        searchAddonRef.current?.findNext(s.query, {
+          caseSensitive: s.matchCase,
+          wholeWord: s.wholeWord,
+          regex: s.regex,
+        })
+      },
+      searchPrevious: () => {
+        const s = $activeSearch.get()
+        if (!s?.query) return
+        searchAddonRef.current?.findPrevious(s.query, {
+          caseSensitive: s.matchCase,
+          wholeWord: s.wholeWord,
+          regex: s.regex,
+        })
+      },
     })
 
     return () => {
@@ -224,13 +263,25 @@ export const XTermTerminal = React.memo(function XTermTerminal({
       dataDisposable.dispose()
       resizeDisposable.dispose()
       webglAddon?.dispose()
+      searchAddon.dispose()
       fitAddon.dispose()
       unicode11Addon.dispose()
       term.dispose()
       termRef.current = null
       fitAddonRef.current = null
+      searchAddonRef.current = null
     }
   }, []) // mount once — callbacks are accessed via stable refs
+
+  // React to font-size changes globally. Defer fit() so the canvas
+  // re-rasterizes glyphs at the new size before recomputing cols/rows.
+  useEffect(() => {
+    const term = termRef.current
+    const fit = fitAddonRef.current
+    if (!term || !fit) return
+    term.options.fontSize = fontSize
+    requestAnimationFrame(() => fit.fit())
+  }, [fontSize])
 
   return (
     <div ref={containerRef} className={className ?? 'h-full min-h-0 w-full'} />

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -16,8 +16,15 @@ export type XTermHandle = {
   clear: () => void
   /** Selects all text in the buffer. */
   selectAll: () => void
-  /** Jumps to the next match for the current `$activeSearch` query. */
-  searchNext: () => void
+  /**
+   * Jumps to the next match for the current `$activeSearch` query.
+   * Pass `incremental: true` from typing-driven calls so the highlight
+   * stays on the current match while it still matches the growing query
+   * (xterm's addon-search expands the existing selection rather than
+   * advancing past it). Default `false` matches the explicit Cmd+G
+   * "next match" semantic.
+   */
+  searchNext: (opts?: { incremental?: boolean }) => void
   /** Jumps to the previous match for the current `$activeSearch` query. */
   searchPrevious: () => void
 }
@@ -242,13 +249,14 @@ export const XTermTerminal = React.memo(function XTermTerminal({
       focus: () => termRef.current?.focus(),
       clear: () => termRef.current?.clear(),
       selectAll: () => termRef.current?.selectAll(),
-      searchNext: () => {
+      searchNext: (opts) => {
         const s = $activeSearch.get()
         if (!s?.query) return
         searchAddonRef.current?.findNext(s.query, {
           caseSensitive: s.matchCase,
           wholeWord: s.wholeWord,
           regex: s.regex,
+          incremental: opts?.incremental ?? false,
         })
       },
       searchPrevious: () => {

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -105,15 +105,22 @@ const LIGHT_THEME: ITheme = {
 // (react-hotkeys-hook at document level). Returning false from xterm's
 // attachCustomKeyEventHandler skips xterm's own handler so the event bubbles.
 //
-// Cmd-based: every app shortcut uses Cmd, and Cmd+anything has no
+// Cmd-based: every primary app shortcut uses Cmd, and Cmd+anything has no
 // meaningful translation to a PTY control byte on macOS — so suppressing
 // xterm's handler for any meta-key combo is safe and removes the
 // per-shortcut allowlist that grew with the keymap.
 //
+// Ctrl+Tab / Ctrl+Shift+Tab are the only Ctrl-based aliases: they back
+// the Cmd+Shift+] / Cmd+Shift+[ tab-nav muscle memory from Apple Terminal,
+// VS Code, Chrome. Safe on Ctrl because Ctrl+Tab has no readline binding
+// (Tab itself is shell-bound but Ctrl+Tab isn't).
+//
 // Browser-level shortcuts (Cmd+C/V copy/paste) are handled above xterm
 // in the contenteditable layer and are unaffected by this filter.
 function isAppShortcut(e: KeyboardEvent): boolean {
-  return e.metaKey
+  if (e.metaKey) return true
+  if (e.ctrlKey && e.key === 'Tab') return true
+  return false
 }
 
 export const XTermTerminal = React.memo(function XTermTerminal({

--- a/src/modules/keymap/keys.ts
+++ b/src/modules/keymap/keys.ts
@@ -107,3 +107,18 @@ export const Keys = {
 } as const
 
 export type KeyName = (typeof Keys)[keyof typeof Keys]
+
+/**
+ * Modifier names accepted by react-hotkeys-hook binding strings. Same
+ * single-source-of-truth rationale as `Keys` — callsites compose
+ * `${Mod.Meta}+${Keys.T}` instead of literal `"meta+t"` so the modifier
+ * names are typed at every binding.
+ */
+export const Mod = {
+  Meta: 'meta',
+  Ctrl: 'ctrl',
+  Alt: 'alt',
+  Shift: 'shift',
+} as const
+
+export type ModName = (typeof Mod)[keyof typeof Mod]

--- a/src/modules/keymap/keys.ts
+++ b/src/modules/keymap/keys.ts
@@ -107,13 +107,3 @@ export const Keys = {
 } as const
 
 export type KeyName = (typeof Keys)[keyof typeof Keys]
-
-/** Modifier names accepted by react-hotkeys-hook binding strings. */
-export const Mod = {
-  Meta: 'meta',
-  Ctrl: 'ctrl',
-  Alt: 'alt',
-  Shift: 'shift',
-} as const
-
-export type ModName = (typeof Mod)[keyof typeof Mod]

--- a/src/modules/keymap/keys.ts
+++ b/src/modules/keymap/keys.ts
@@ -1,0 +1,119 @@
+/**
+ * Canonical key names for `react-hotkeys-hook` v5+ binding strings.
+ *
+ * Why we don't use `ts-key-enum` (which the library docs reference): that
+ * package enumerates `KeyboardEvent.key` values (`=`, `[`, `Enter`). The
+ * library matches against `KeyboardEvent.code` normalized via this internal
+ * function:
+ *
+ *     code.toLowerCase().replace(/key|digit|numpad/, '')
+ *
+ * So `KeyG` → `g`, `Digit0` → `0`, `Numpad1` → `1` — but `BracketLeft`,
+ * `Equal`, `Minus` etc. stay as their lowercased event.code names because
+ * the regex doesn't strip anything from them. Feeding the library a literal
+ * `'='` or `'['` matches nothing and the hotkey silently no-ops.
+ *
+ * Naming convention here: **constant name = W3C `KeyboardEvent.code`**;
+ * **value = library-normalized binding string**. So a future reader
+ * reaches for `Keys.BracketRight` from looking at the W3C spec, gets back
+ * the right string for react-hotkeys-hook, and never has to know about
+ * the `K()` regex.
+ *
+ * If react-hotkeys-hook ever changes its normalization, this file is the
+ * single point of update.
+ */
+export const Keys = {
+  // Letters — `KeyT` → strip `key` → `t`
+  A: 'a',
+  B: 'b',
+  C: 'c',
+  D: 'd',
+  E: 'e',
+  F: 'f',
+  G: 'g',
+  H: 'h',
+  I: 'i',
+  J: 'j',
+  K: 'k',
+  L: 'l',
+  M: 'm',
+  N: 'n',
+  O: 'o',
+  P: 'p',
+  Q: 'q',
+  R: 'r',
+  S: 's',
+  T: 't',
+  U: 'u',
+  V: 'v',
+  W: 'w',
+  X: 'x',
+  Y: 'y',
+  Z: 'z',
+
+  // Digits — `Digit0` → strip `digit` → `0`
+  Digit0: '0',
+  Digit1: '1',
+  Digit2: '2',
+  Digit3: '3',
+  Digit4: '4',
+  Digit5: '5',
+  Digit6: '6',
+  Digit7: '7',
+  Digit8: '8',
+  Digit9: '9',
+
+  // Punctuation — event.code lowercased; the library's regex doesn't
+  // touch these so they pass through verbatim.
+  Equal: 'equal',
+  Minus: 'minus',
+  BracketLeft: 'bracketleft',
+  BracketRight: 'bracketright',
+  Backslash: 'backslash',
+  Slash: 'slash',
+  Comma: 'comma',
+  Period: 'period',
+  Semicolon: 'semicolon',
+  Quote: 'quote',
+  Backquote: 'backquote',
+
+  // Whitespace / control
+  Tab: 'tab',
+  Enter: 'enter',
+  Escape: 'escape',
+  Space: 'space',
+  Backspace: 'backspace',
+  Delete: 'delete',
+
+  // Arrows
+  ArrowLeft: 'arrowleft',
+  ArrowRight: 'arrowright',
+  ArrowUp: 'arrowup',
+  ArrowDown: 'arrowdown',
+
+  // Function keys
+  F1: 'f1',
+  F2: 'f2',
+  F3: 'f3',
+  F4: 'f4',
+  F5: 'f5',
+  F6: 'f6',
+  F7: 'f7',
+  F8: 'f8',
+  F9: 'f9',
+  F10: 'f10',
+  F11: 'f11',
+  F12: 'f12',
+} as const
+
+export type KeyName = (typeof Keys)[keyof typeof Keys]
+
+/** Modifier names accepted by react-hotkeys-hook binding strings. */
+export const Mod = {
+  Meta: 'meta',
+  Ctrl: 'ctrl',
+  Alt: 'alt',
+  Shift: 'shift',
+} as const
+
+export type ModName = (typeof Mod)[keyof typeof Mod]

--- a/src/modules/notifications/architecture.test.ts
+++ b/src/modules/notifications/architecture.test.ts
@@ -67,30 +67,35 @@ function stripComments(src: string): string {
   return out
 }
 
+type Violation = { file: string; pattern: string; sample: string }
+
+function violationsInFile(file: string): Violation[] {
+  const raw = readFileSync(file, 'utf8')
+  const code = stripComments(raw)
+  const lines = code.split('\n')
+  const out: Violation[] = []
+  for (const pattern of FORBIDDEN) {
+    const match = code.match(pattern)
+    if (!match) continue
+    // Find the line for a more useful error — search in the
+    // comments-stripped form so the lint points at runtime code.
+    const lineIdx = lines.findIndex((l) => pattern.test(l))
+    const sample = lineIdx >= 0 ? (lines[lineIdx] ?? '').trim() : match[0]
+    out.push({
+      file: file.replace(NOTIFICATIONS_DIR, '<notifications>'),
+      pattern: String(pattern),
+      sample,
+    })
+  }
+  return out
+}
+
 describe('notifications module — agent-agnosticism guard', () => {
   test('no runtime source file mentions specific agent IDs or lookup tables', () => {
     const files = listSourceFiles(NOTIFICATIONS_DIR)
     expect(files.length).toBeGreaterThan(0) // sanity
 
-    const violations: Array<{ file: string; pattern: string; sample: string }> = []
-    for (const file of files) {
-      const raw = readFileSync(file, 'utf8')
-      const code = stripComments(raw)
-      for (const pattern of FORBIDDEN) {
-        const match = code.match(pattern)
-        if (!match) continue
-        // Find the line for a more useful error — search in the
-        // comments-stripped form so the lint points at runtime code.
-        const lines = code.split('\n')
-        const lineIdx = lines.findIndex((l) => pattern.test(l))
-        const sample = lineIdx >= 0 ? lines[lineIdx]!.trim() : match[0]
-        violations.push({
-          file: file.replace(NOTIFICATIONS_DIR, '<notifications>'),
-          pattern: String(pattern),
-          sample,
-        })
-      }
-    }
+    const violations = files.flatMap(violationsInFile)
 
     if (violations.length > 0) {
       const report = violations

--- a/src/modules/stores/$activeSearch.ts
+++ b/src/modules/stores/$activeSearch.ts
@@ -1,0 +1,35 @@
+import { atom } from 'nanostores'
+
+export type SearchState = {
+  tabKey: string
+  query: string
+  matchCase: boolean
+  wholeWord: boolean
+  regex: boolean
+}
+
+/**
+ * Drives the find-in-scrollback overlay. Non-null when the search bar is
+ * open over the active terminal; null otherwise. The bar reads `query` /
+ * options from here and writes back via `setSearchQuery`.
+ */
+export const $activeSearch = atom<SearchState | null>(null)
+
+export function openSearch(tabKey: string): void {
+  $activeSearch.set({
+    tabKey,
+    query: '',
+    matchCase: false,
+    wholeWord: false,
+    regex: false,
+  })
+}
+
+export function closeSearch(): void {
+  $activeSearch.set(null)
+}
+
+export function setSearchQuery(query: string): void {
+  const cur = $activeSearch.get()
+  if (cur) $activeSearch.set({ ...cur, query })
+}

--- a/src/modules/stores/$activeTerminal.ts
+++ b/src/modules/stores/$activeTerminal.ts
@@ -1,0 +1,10 @@
+import { atom } from 'nanostores'
+import type { XTermHandle } from '@/components/XTermTerminal/XTermTerminal'
+
+/**
+ * Handle of the terminal whose tab is currently active and visible.
+ * Set by TerminalPane when its `isActive` prop is true; cleared on unmount or
+ * deactivation. Global hotkey handlers (Cmd+K, Cmd+A, Cmd+F) call into this
+ * handle to dispatch terminal-scoped actions without threading refs.
+ */
+export const $activeTerminalHandle = atom<XTermHandle | null>(null)

--- a/src/modules/stores/$closedTabs.ts
+++ b/src/modules/stores/$closedTabs.ts
@@ -1,0 +1,29 @@
+import { atom } from 'nanostores'
+
+const MAX_HISTORY = 20
+
+export type ClosedTab = {
+  projectId: string
+  label: string
+  cwd: string | undefined
+  closedAt: number
+}
+
+/**
+ * Stack of recently-closed tabs, most-recent first. In-memory only — closing
+ * the app forgets the history (matches Chrome/Firefox behavior). Capped at
+ * MAX_HISTORY entries to keep growth bounded.
+ */
+export const $closedTabs = atom<ClosedTab[]>([])
+
+export function pushClosedTab(entry: ClosedTab): void {
+  const next = [entry, ...$closedTabs.get()].slice(0, MAX_HISTORY)
+  $closedTabs.set(next)
+}
+
+export function popClosedTab(): ClosedTab | undefined {
+  const stack = $closedTabs.get()
+  if (stack.length === 0) return undefined
+  $closedTabs.set(stack.slice(1))
+  return stack[0]
+}

--- a/src/modules/stores/$fontSize.ts
+++ b/src/modules/stores/$fontSize.ts
@@ -1,0 +1,33 @@
+import { atom } from 'nanostores'
+
+const STORAGE_KEY = 'agent-terminal:font-size'
+const DEFAULT = 13
+const MIN = 8
+const MAX = 32
+
+function readPersisted(): number {
+  if (typeof window === 'undefined') return DEFAULT
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  const parsed = raw ? Number(raw) : DEFAULT
+  return Number.isFinite(parsed)
+    ? Math.min(MAX, Math.max(MIN, parsed))
+    : DEFAULT
+}
+
+export const $fontSize = atom<number>(readPersisted())
+
+$fontSize.subscribe((value) => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, String(value))
+  }
+})
+
+export function increaseFontSize(): void {
+  $fontSize.set(Math.min(MAX, $fontSize.get() + 1))
+}
+export function decreaseFontSize(): void {
+  $fontSize.set(Math.max(MIN, $fontSize.get() - 1))
+}
+export function resetFontSize(): void {
+  $fontSize.set(DEFAULT)
+}

--- a/src/modules/stores/$keyboard.ts
+++ b/src/modules/stores/$keyboard.ts
@@ -1,8 +1,8 @@
 import { atom } from 'nanostores'
 
 /**
- * True while the Ctrl key is physically held down.
+ * True while the Cmd (Meta) key is physically held down.
  * Drives the project-number overlay in the sidebar so users can see which
- * Ctrl+N shortcut maps to which project before pressing the digit.
+ * Cmd+N shortcut maps to which project before pressing the digit.
  */
-export const $ctrlHeld = atom<boolean>(false)
+export const $metaHeld = atom<boolean>(false)

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -1,5 +1,7 @@
 import { atom } from 'nanostores'
 import { IPC } from '@/modules/ipc/commands'
+import { pushClosedTab } from '@/modules/stores/$closedTabs'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
 import {
   dedupeLabel,
   makeTabKey,
@@ -96,6 +98,22 @@ export function removeProject(projectId: string): void {
 }
 
 export function removeTab(projectId: string, tabId: string): void {
+  // Snapshot the tab into the closed-tab stack BEFORE we destroy it. Read
+  // the cwd from $tabMeta first (latest OSC 7) and fall back to the tab's
+  // own lastCwd (which only updates on persist) so reopen lands the user
+  // back where they left off, not where the tab originally spawned.
+  const project = $projects.get().find((p) => p.id === projectId)
+  const tab = project?.tabs.find((t) => t.id === tabId)
+  if (project && tab) {
+    const meta = $tabMeta.get()[makeTabKey(projectId, tabId)]
+    pushClosedTab({
+      projectId,
+      label: tab.label,
+      cwd: meta?.cwd ?? tab.lastCwd,
+      closedAt: Date.now(),
+    })
+  }
+
   IPC.closeTab(makeTabKey(projectId, tabId)).catch(() => {})
   const updated = $projects
     .get()

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -200,6 +200,29 @@ export function renameTab(
   persist(updated)
 }
 
+/**
+ * Restores a tab's label from the closed-tab history. Same persistence
+ * as `renameTab` but does NOT flag `userRenamed` — reopen is replaying
+ * whatever the tab had at close time (often an auto-generated dedupe
+ * label), not an explicit user action.
+ */
+export function restoreTabLabel(
+  projectId: string,
+  tabId: string,
+  label: string,
+): void {
+  const updated = $projects.get().map((p) =>
+    p.id !== projectId
+      ? p
+      : {
+          ...p,
+          tabs: p.tabs.map((t) => (t.id !== tabId ? t : { ...t, label })),
+        },
+  )
+  $projects.set(updated)
+  persist(updated)
+}
+
 export function updateTabCwd(tabKey: string, cwd: string): void {
   const [projectId, tabId] = tabKey.split(':')
   if (!projectId || !tabId) return

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -20,7 +20,7 @@ import {
   navigateToTab,
   onTabRemoved,
 } from '@/modules/stores/$navigation'
-import { Keys } from '@/modules/keymap/keys'
+import { Keys, Mod } from '@/modules/keymap/keys'
 import { $projects, addTab, removeTab } from '@/modules/stores/$projects'
 import { WorkspaceView } from '@/screens/workspace/WorkspaceView'
 
@@ -86,7 +86,7 @@ export function WorkspaceLayout() {
 
   // ⌘T — new tab in the active project
   useHotkeys(
-    `meta+${Keys.T}`,
+    `${Mod.Meta}+${Keys.T}`,
     () => {
       const projectId = $activeProjectId.get()
       const newTab = addTab(projectId)
@@ -97,7 +97,7 @@ export function WorkspaceLayout() {
 
   // ⌘W — close the active tab (pinned tabs are protected)
   useHotkeys(
-    `meta+${Keys.W}`,
+    `${Mod.Meta}+${Keys.W}`,
     () => {
       const projectId = $activeProjectId.get()
       const tabId = $activeTabId.get()[projectId] ?? ''
@@ -116,7 +116,7 @@ export function WorkspaceLayout() {
   // VS Code, Chrome). Safe to keep on Ctrl because `Ctrl+Tab` has no
   // readline binding — `Tab` itself is shell-bound but `Ctrl+Tab` isn't.
   useHotkeys(
-    [`meta+shift+${Keys.BracketRight}`, `ctrl+${Keys.Tab}`],
+    [`${Mod.Meta}+${Mod.Shift}+${Keys.BracketRight}`, `${Mod.Ctrl}+${Keys.Tab}`],
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -131,7 +131,7 @@ export function WorkspaceLayout() {
 
   // ⌘⇧[ / Ctrl+Shift+Tab — previous tab. Symmetric with next-tab above.
   useHotkeys(
-    [`meta+shift+${Keys.BracketLeft}`, `ctrl+shift+${Keys.Tab}`],
+    [`${Mod.Meta}+${Mod.Shift}+${Keys.BracketLeft}`, `${Mod.Ctrl}+${Mod.Shift}+${Keys.Tab}`],
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -151,15 +151,15 @@ export function WorkspaceLayout() {
   // is via Cmd+Shift+]/[ cycling. Projects beyond 9 have no shortcut.
   useHotkeys(
     [
-      `meta+${Keys.Digit1}`,
-      `meta+${Keys.Digit2}`,
-      `meta+${Keys.Digit3}`,
-      `meta+${Keys.Digit4}`,
-      `meta+${Keys.Digit5}`,
-      `meta+${Keys.Digit6}`,
-      `meta+${Keys.Digit7}`,
-      `meta+${Keys.Digit8}`,
-      `meta+${Keys.Digit9}`,
+      `${Mod.Meta}+${Keys.Digit1}`,
+      `${Mod.Meta}+${Keys.Digit2}`,
+      `${Mod.Meta}+${Keys.Digit3}`,
+      `${Mod.Meta}+${Keys.Digit4}`,
+      `${Mod.Meta}+${Keys.Digit5}`,
+      `${Mod.Meta}+${Keys.Digit6}`,
+      `${Mod.Meta}+${Keys.Digit7}`,
+      `${Mod.Meta}+${Keys.Digit8}`,
+      `${Mod.Meta}+${Keys.Digit9}`,
     ],
     (e) => {
       const n = Number.parseInt(e.key, 10) - 1
@@ -179,32 +179,32 @@ export function WorkspaceLayout() {
   // presses use the same physical key (event.code "Equal") and only
   // differ by the shift modifier.
   useHotkeys(
-    [`meta+${Keys.Equal}`, `meta+shift+${Keys.Equal}`],
+    [`${Mod.Meta}+${Keys.Equal}`, `${Mod.Meta}+${Mod.Shift}+${Keys.Equal}`],
     () => increaseFontSize(),
     hotkeyOpts,
   )
   // ⌘- — decrease font size
-  useHotkeys(`meta+${Keys.Minus}`, () => decreaseFontSize(), hotkeyOpts)
+  useHotkeys(`${Mod.Meta}+${Keys.Minus}`, () => decreaseFontSize(), hotkeyOpts)
   // ⌘0 — reset font size to default
-  useHotkeys(`meta+${Keys.Digit0}`, () => resetFontSize(), hotkeyOpts)
+  useHotkeys(`${Mod.Meta}+${Keys.Digit0}`, () => resetFontSize(), hotkeyOpts)
 
   // ⌘K — clear screen + scrollback in the active terminal
   useHotkeys(
-    `meta+${Keys.K}`,
+    `${Mod.Meta}+${Keys.K}`,
     () => $activeTerminalHandle.get()?.clear(),
     hotkeyOpts,
   )
 
   // ⌘A — select all in the active terminal
   useHotkeys(
-    `meta+${Keys.A}`,
+    `${Mod.Meta}+${Keys.A}`,
     () => $activeTerminalHandle.get()?.selectAll(),
     hotkeyOpts,
   )
 
   // ⌘⇧T — reopen the last closed tab in its original project
   useHotkeys(
-    `meta+shift+${Keys.T}`,
+    `${Mod.Meta}+${Mod.Shift}+${Keys.T}`,
     () => {
       const closed = popClosedTab()
       if (!closed) return
@@ -231,7 +231,7 @@ export function WorkspaceLayout() {
 
   // ⌘F — open the find overlay over the active terminal
   useHotkeys(
-    `meta+${Keys.F}`,
+    `${Mod.Meta}+${Keys.F}`,
     () => {
       const projectId = $activeProjectId.get()
       const tabId = $activeTabId.get()[projectId] ?? ''
@@ -243,14 +243,14 @@ export function WorkspaceLayout() {
 
   // ⌘G / ⌘⇧G — find next / previous (only meaningful while bar is open)
   useHotkeys(
-    `meta+${Keys.G}`,
+    `${Mod.Meta}+${Keys.G}`,
     () => {
       if ($activeSearch.get()) $activeTerminalHandle.get()?.searchNext()
     },
     hotkeyOpts,
   )
   useHotkeys(
-    `meta+shift+${Keys.G}`,
+    `${Mod.Meta}+${Mod.Shift}+${Keys.G}`,
     () => {
       if ($activeSearch.get()) $activeTerminalHandle.get()?.searchPrevious()
     },

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -3,7 +3,16 @@ import { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { Sidebar } from '@/components/Sidebar/Sidebar'
 import { StatusBar } from '@/components/StatusBar/StatusBar'
-import { $ctrlHeld } from '@/modules/stores/$keyboard'
+import { TerminalSearchBar } from '@/components/TerminalSearchBar/TerminalSearchBar'
+import { $activeSearch, openSearch } from '@/modules/stores/$activeSearch'
+import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
+import { popClosedTab } from '@/modules/stores/$closedTabs'
+import {
+  decreaseFontSize,
+  increaseFontSize,
+  resetFontSize,
+} from '@/modules/stores/$fontSize'
+import { $metaHeld } from '@/modules/stores/$keyboard'
 import {
   $activeProjectId,
   $activeTabId,
@@ -45,18 +54,18 @@ export function WorkspaceLayout() {
     }
   }, [projects, activeProjectId])
 
-  // Track whether Ctrl is physically held so the sidebar can show project-number
+  // Track whether Cmd is physically held so the sidebar can show project-number
   // badges. The blur listener resets the flag if the window loses focus while
-  // Ctrl is held — prevents the overlay from getting stuck.
+  // Cmd is held — prevents the overlay from getting stuck.
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Control') $ctrlHeld.set(true)
+      if (e.key === 'Meta') $metaHeld.set(true)
     }
     function onKeyUp(e: KeyboardEvent) {
-      if (e.key === 'Control') $ctrlHeld.set(false)
+      if (e.key === 'Meta') $metaHeld.set(false)
     }
     function onBlur() {
-      $ctrlHeld.set(false)
+      $metaHeld.set(false)
     }
 
     window.addEventListener('keydown', onKeyDown)
@@ -74,9 +83,9 @@ export function WorkspaceLayout() {
   // all key events while the terminal has focus.
   const hotkeyOpts = { preventDefault: true, enableOnFormTags: true } as const
 
-  // Ctrl+T — new tab in the active project
+  // ⌘T — new tab in the active project
   useHotkeys(
-    'ctrl+t',
+    'meta+t',
     () => {
       const projectId = $activeProjectId.get()
       const newTab = addTab(projectId)
@@ -85,9 +94,9 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // Ctrl+W — close the active tab (pinned tabs are protected)
+  // ⌘W — close the active tab (pinned tabs are protected)
   useHotkeys(
-    'ctrl+w',
+    'meta+w',
     () => {
       const projectId = $activeProjectId.get()
       const tabId = $activeTabId.get()[projectId] ?? ''
@@ -101,9 +110,9 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // Ctrl+Tab — cycle to the next tab in the active project (wraps around)
+  // ⌘⇧] — cycle to the next tab in the active project (wraps around)
   useHotkeys(
-    'ctrl+tab',
+    'meta+shift+]',
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -116,9 +125,9 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // Ctrl+Shift+Tab — cycle to the previous tab in the active project (wraps around)
+  // ⌘⇧[ — cycle to the previous tab in the active project (wraps around)
   useHotkeys(
-    'ctrl+shift+tab',
+    'meta+shift+[',
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -132,19 +141,21 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // Ctrl+1–9 — switch to project N in sidebar display order (pinned first).
-  // Projects beyond 9 have no shortcut.
+  // ⌘1–9 — switch to project N in sidebar display order (pinned first).
+  // Diverges from iTerm2/Ghostty (which use Cmd+1..9 for tab N) — agent-terminal
+  // is project-centric so number-jump operates at the project layer; tab nav
+  // is via Cmd+Shift+]/[ cycling. Projects beyond 9 have no shortcut.
   useHotkeys(
     [
-      'ctrl+1',
-      'ctrl+2',
-      'ctrl+3',
-      'ctrl+4',
-      'ctrl+5',
-      'ctrl+6',
-      'ctrl+7',
-      'ctrl+8',
-      'ctrl+9',
+      'meta+1',
+      'meta+2',
+      'meta+3',
+      'meta+4',
+      'meta+5',
+      'meta+6',
+      'meta+7',
+      'meta+8',
+      'meta+9',
     ],
     (e) => {
       const n = Number.parseInt(e.key, 10) - 1
@@ -155,6 +166,80 @@ export function WorkspaceLayout() {
       ]
       const target = ordered[n]
       if (target) navigateToProject(target.id)
+    },
+    hotkeyOpts,
+  )
+
+  // ⌘= / ⌘+ — increase font size. Bind both because on US keyboards `⌘+`
+  // requires Shift+`=`, so depending on layout the browser fires either
+  // event. iTerm2/Ghostty bind both for the same reason.
+  useHotkeys(['meta+=', 'meta+plus'], () => increaseFontSize(), hotkeyOpts)
+  // ⌘- — decrease font size
+  useHotkeys('meta+-', () => decreaseFontSize(), hotkeyOpts)
+  // ⌘0 — reset font size to default
+  useHotkeys('meta+0', () => resetFontSize(), hotkeyOpts)
+
+  // ⌘K — clear screen + scrollback in the active terminal
+  useHotkeys('meta+k', () => $activeTerminalHandle.get()?.clear(), hotkeyOpts)
+
+  // ⌘A — select all in the active terminal
+  useHotkeys(
+    'meta+a',
+    () => $activeTerminalHandle.get()?.selectAll(),
+    hotkeyOpts,
+  )
+
+  // ⌘⇧T — reopen the last closed tab in its original project
+  useHotkeys(
+    'meta+shift+t',
+    () => {
+      const closed = popClosedTab()
+      if (!closed) return
+      const project = $projects.get().find((p) => p.id === closed.projectId)
+      if (!project) return // project itself was deleted; drop silently
+      const newTab = addTab(closed.projectId, closed.cwd)
+      if (!newTab) return
+      // addTab generates a fresh dedupe-safe label; restore the original.
+      const updated = $projects.get().map((p) =>
+        p.id !== closed.projectId
+          ? p
+          : {
+              ...p,
+              tabs: p.tabs.map((t) =>
+                t.id === newTab.id ? { ...t, label: closed.label } : t,
+              ),
+            },
+      )
+      $projects.set(updated)
+      navigateToTab(closed.projectId, newTab.id)
+    },
+    hotkeyOpts,
+  )
+
+  // ⌘F — open the find overlay over the active terminal
+  useHotkeys(
+    'meta+f',
+    () => {
+      const projectId = $activeProjectId.get()
+      const tabId = $activeTabId.get()[projectId] ?? ''
+      if (!tabId) return
+      openSearch(`${projectId}:${tabId}`)
+    },
+    hotkeyOpts,
+  )
+
+  // ⌘G / ⌘⇧G — find next / previous (only meaningful while bar is open)
+  useHotkeys(
+    'meta+g',
+    () => {
+      if ($activeSearch.get()) $activeTerminalHandle.get()?.searchNext()
+    },
+    hotkeyOpts,
+  )
+  useHotkeys(
+    'meta+shift+g',
+    () => {
+      if ($activeSearch.get()) $activeTerminalHandle.get()?.searchPrevious()
     },
     hotkeyOpts,
   )
@@ -178,6 +263,9 @@ export function WorkspaceLayout() {
               </div>
             )
           })}
+          {/* Find-in-scrollback overlay floats over the active terminal,
+              regardless of which project/tab is visible. */}
+          <TerminalSearchBar />
         </div>
       </div>
       <StatusBar />

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -4,6 +4,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { Sidebar } from '@/components/Sidebar/Sidebar'
 import { StatusBar } from '@/components/StatusBar/StatusBar'
 import { TerminalSearchBar } from '@/components/TerminalSearchBar/TerminalSearchBar'
+import { Keys, Mod } from '@/modules/keymap/keys'
 import { $activeSearch, openSearch } from '@/modules/stores/$activeSearch'
 import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
 import { popClosedTab } from '@/modules/stores/$closedTabs'
@@ -20,8 +21,12 @@ import {
   navigateToTab,
   onTabRemoved,
 } from '@/modules/stores/$navigation'
-import { Keys, Mod } from '@/modules/keymap/keys'
-import { $projects, addTab, removeTab } from '@/modules/stores/$projects'
+import {
+  $projects,
+  addTab,
+  removeTab,
+  restoreTabLabel,
+} from '@/modules/stores/$projects'
 import { WorkspaceView } from '@/screens/workspace/WorkspaceView'
 
 /* ---------------------------------------------------------------------------
@@ -116,7 +121,10 @@ export function WorkspaceLayout() {
   // VS Code, Chrome). Safe to keep on Ctrl because `Ctrl+Tab` has no
   // readline binding — `Tab` itself is shell-bound but `Ctrl+Tab` isn't.
   useHotkeys(
-    [`${Mod.Meta}+${Mod.Shift}+${Keys.BracketRight}`, `${Mod.Ctrl}+${Keys.Tab}`],
+    [
+      `${Mod.Meta}+${Mod.Shift}+${Keys.BracketRight}`,
+      `${Mod.Ctrl}+${Keys.Tab}`,
+    ],
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -131,7 +139,10 @@ export function WorkspaceLayout() {
 
   // ⌘⇧[ / Ctrl+Shift+Tab — previous tab. Symmetric with next-tab above.
   useHotkeys(
-    [`${Mod.Meta}+${Mod.Shift}+${Keys.BracketLeft}`, `${Mod.Ctrl}+${Mod.Shift}+${Keys.Tab}`],
+    [
+      `${Mod.Meta}+${Mod.Shift}+${Keys.BracketLeft}`,
+      `${Mod.Ctrl}+${Mod.Shift}+${Keys.Tab}`,
+    ],
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -212,18 +223,11 @@ export function WorkspaceLayout() {
       if (!project) return // project itself was deleted; drop silently
       const newTab = addTab(closed.projectId, closed.cwd)
       if (!newTab) return
-      // addTab generates a fresh dedupe-safe label; restore the original.
-      const updated = $projects.get().map((p) =>
-        p.id !== closed.projectId
-          ? p
-          : {
-              ...p,
-              tabs: p.tabs.map((t) =>
-                t.id === newTab.id ? { ...t, label: closed.label } : t,
-              ),
-            },
-      )
-      $projects.set(updated)
+      // addTab generates a fresh dedupe-safe label; restore the original
+      // via restoreTabLabel so the change persists across app restart.
+      // restoreTabLabel (vs renameTab) avoids setting userRenamed since
+      // we're replaying the tab's prior label, not making a user edit.
+      restoreTabLabel(closed.projectId, newTab.id, closed.label)
       navigateToTab(closed.projectId, newTab.id)
     },
     hotkeyOpts,

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -20,6 +20,7 @@ import {
   navigateToTab,
   onTabRemoved,
 } from '@/modules/stores/$navigation'
+import { Keys } from '@/modules/keymap/keys'
 import { $projects, addTab, removeTab } from '@/modules/stores/$projects'
 import { WorkspaceView } from '@/screens/workspace/WorkspaceView'
 
@@ -85,7 +86,7 @@ export function WorkspaceLayout() {
 
   // ⌘T — new tab in the active project
   useHotkeys(
-    'meta+t',
+    `meta+${Keys.T}`,
     () => {
       const projectId = $activeProjectId.get()
       const newTab = addTab(projectId)
@@ -96,7 +97,7 @@ export function WorkspaceLayout() {
 
   // ⌘W — close the active tab (pinned tabs are protected)
   useHotkeys(
-    'meta+w',
+    `meta+${Keys.W}`,
     () => {
       const projectId = $activeProjectId.get()
       const tabId = $activeTabId.get()[projectId] ?? ''
@@ -115,7 +116,7 @@ export function WorkspaceLayout() {
   // VS Code, Chrome). Safe to keep on Ctrl because `Ctrl+Tab` has no
   // readline binding — `Tab` itself is shell-bound but `Ctrl+Tab` isn't.
   useHotkeys(
-    ['meta+shift+]', 'ctrl+tab'],
+    [`meta+shift+${Keys.BracketRight}`, `ctrl+${Keys.Tab}`],
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -128,9 +129,9 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // ⌘⇧[ / Ctrl+Shift+Tab — previous tab. Same dual-binding rationale as above.
+  // ⌘⇧[ / Ctrl+Shift+Tab — previous tab. Symmetric with next-tab above.
   useHotkeys(
-    ['meta+shift+[', 'ctrl+shift+tab'],
+    [`meta+shift+${Keys.BracketLeft}`, `ctrl+shift+${Keys.Tab}`],
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -150,15 +151,15 @@ export function WorkspaceLayout() {
   // is via Cmd+Shift+]/[ cycling. Projects beyond 9 have no shortcut.
   useHotkeys(
     [
-      'meta+1',
-      'meta+2',
-      'meta+3',
-      'meta+4',
-      'meta+5',
-      'meta+6',
-      'meta+7',
-      'meta+8',
-      'meta+9',
+      `meta+${Keys.Digit1}`,
+      `meta+${Keys.Digit2}`,
+      `meta+${Keys.Digit3}`,
+      `meta+${Keys.Digit4}`,
+      `meta+${Keys.Digit5}`,
+      `meta+${Keys.Digit6}`,
+      `meta+${Keys.Digit7}`,
+      `meta+${Keys.Digit8}`,
+      `meta+${Keys.Digit9}`,
     ],
     (e) => {
       const n = Number.parseInt(e.key, 10) - 1
@@ -173,28 +174,37 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // ⌘= / ⌘+ — increase font size. Bind both because on US keyboards `⌘+`
-  // requires Shift+`=`, so depending on layout the browser fires either
-  // event. iTerm2/Ghostty bind both for the same reason.
-  useHotkeys(['meta+=', 'meta+plus'], () => increaseFontSize(), hotkeyOpts)
+  // ⌘= / ⌘+ — increase font size. Bound twice: bare `Equal` for ⌘= and
+  // shifted `Equal` for ⌘+ (which is Shift+= on US keyboards). Both
+  // presses use the same physical key (event.code "Equal") and only
+  // differ by the shift modifier.
+  useHotkeys(
+    [`meta+${Keys.Equal}`, `meta+shift+${Keys.Equal}`],
+    () => increaseFontSize(),
+    hotkeyOpts,
+  )
   // ⌘- — decrease font size
-  useHotkeys('meta+-', () => decreaseFontSize(), hotkeyOpts)
+  useHotkeys(`meta+${Keys.Minus}`, () => decreaseFontSize(), hotkeyOpts)
   // ⌘0 — reset font size to default
-  useHotkeys('meta+0', () => resetFontSize(), hotkeyOpts)
+  useHotkeys(`meta+${Keys.Digit0}`, () => resetFontSize(), hotkeyOpts)
 
   // ⌘K — clear screen + scrollback in the active terminal
-  useHotkeys('meta+k', () => $activeTerminalHandle.get()?.clear(), hotkeyOpts)
+  useHotkeys(
+    `meta+${Keys.K}`,
+    () => $activeTerminalHandle.get()?.clear(),
+    hotkeyOpts,
+  )
 
   // ⌘A — select all in the active terminal
   useHotkeys(
-    'meta+a',
+    `meta+${Keys.A}`,
     () => $activeTerminalHandle.get()?.selectAll(),
     hotkeyOpts,
   )
 
   // ⌘⇧T — reopen the last closed tab in its original project
   useHotkeys(
-    'meta+shift+t',
+    `meta+shift+${Keys.T}`,
     () => {
       const closed = popClosedTab()
       if (!closed) return
@@ -221,7 +231,7 @@ export function WorkspaceLayout() {
 
   // ⌘F — open the find overlay over the active terminal
   useHotkeys(
-    'meta+f',
+    `meta+${Keys.F}`,
     () => {
       const projectId = $activeProjectId.get()
       const tabId = $activeTabId.get()[projectId] ?? ''
@@ -233,14 +243,14 @@ export function WorkspaceLayout() {
 
   // ⌘G / ⌘⇧G — find next / previous (only meaningful while bar is open)
   useHotkeys(
-    'meta+g',
+    `meta+${Keys.G}`,
     () => {
       if ($activeSearch.get()) $activeTerminalHandle.get()?.searchNext()
     },
     hotkeyOpts,
   )
   useHotkeys(
-    'meta+shift+g',
+    `meta+shift+${Keys.G}`,
     () => {
       if ($activeSearch.get()) $activeTerminalHandle.get()?.searchPrevious()
     },

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -110,9 +110,12 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // ⌘⇧] — cycle to the next tab in the active project (wraps around)
+  // ⌘⇧] / Ctrl+Tab — next tab. Both bound: ⌘⇧] is the macOS browser/iTerm
+  // consensus; Ctrl+Tab is the muscle-memory alias (Apple Terminal default,
+  // VS Code, Chrome). Safe to keep on Ctrl because `Ctrl+Tab` has no
+  // readline binding — `Tab` itself is shell-bound but `Ctrl+Tab` isn't.
   useHotkeys(
-    'meta+shift+]',
+    ['meta+shift+]', 'ctrl+tab'],
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)
@@ -125,9 +128,9 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // ⌘⇧[ — cycle to the previous tab in the active project (wraps around)
+  // ⌘⇧[ / Ctrl+Shift+Tab — previous tab. Same dual-binding rationale as above.
   useHotkeys(
-    'meta+shift+[',
+    ['meta+shift+[', 'ctrl+shift+tab'],
     () => {
       const projectId = $activeProjectId.get()
       const project = $projects.get().find((p) => p.id === projectId)


### PR DESCRIPTION
## Summary

Migrates all app-level shortcuts from `Ctrl`-based to `Cmd`-based and adds the standard set of macOS terminal shortcuts every user expects.

## Why

The previous `Ctrl`-based shortcuts intercepted readline bindings users hit constantly:

| Old shortcut | What readline expects |
|---|---|
| `Ctrl+T` (new tab) | `transpose-chars` |
| `Ctrl+W` (close tab) | `delete-word-back` (worst offender) |
| `Ctrl+Tab` (next tab) | mostly safe, but conflicts with tmux |
| `Ctrl+1..9` (project switch) | safe but used by some TUI apps |

The `XTermTerminal::isAppShortcut` filter intercepted these before xterm could forward them to the PTY — meaning a user trying to `delete-word-back` with `Ctrl+W` would actually close their tab.

After this PR: every app shortcut uses `Cmd`. Bare `Ctrl+letter` is always forwarded to the shell. The browser-tab UX framing is preserved because Safari/Chrome/Arc all use the same Cmd-based pattern.

## What's new

### Phase 1 — Cmd migration
- `Cmd+T` new tab, `Cmd+W` close tab
- `Cmd+Shift+]` / `Cmd+Shift+[` next/previous tab (Safari/Chrome/iTerm2/Ghostty/Warp consensus)
- `Cmd+1..9` switch to project N (project-centric reinterpretation of the universal "Cmd+number = jump to numbered thing" pattern; badge UI preserved, now triggered by Cmd-held)
- `XTermTerminal::isAppShortcut` collapsed from a per-key allowlist to `return e.metaKey` — Cmd+anything has no PTY meaning, so suppressing xterm's handler for any meta key is safe and means the filter no longer needs to grow as the keymap grows

### Phase 2 — Standard macOS bindings
- `Cmd+=` / `Cmd++` / `Cmd+-` / `Cmd+0` — font zoom; persists to `localStorage`, bounded 8..32, xterm refits cols/rows reactively
- `Cmd+K` — clear screen + scrollback (active terminal)
- `Cmd+A` — select all (active terminal)
- `Cmd+Shift+T` — reopen last closed tab; new `\$closedTabs` stack (cap 20, in-memory only — Chrome/Firefox convention) snapshots cwd from `\$tabMeta` on close so reopen lands at the user's last directory, not the spawn dir
- `Cmd+F` / `Cmd+G` / `Cmd+Shift+G` — find in scrollback via `@xterm/addon-search`; new floating `TerminalSearchBar` overlay; `Esc` closes
- `Cmd+C` / `Cmd+V` / `Cmd+Q` / `Ctrl+Cmd+F` — already work via browser / Tauri / macOS system; no app code (verify in QA)

## Files

- **Modified:** `WorkspaceLayout.tsx`, `XTermTerminal.tsx`, `SidebarProjectRow.tsx`, `TerminalPane.tsx`, `\$keyboard.ts` (renamed `\$ctrlHeld` → `\$metaHeld`), `\$projects.ts` (closed-tab snapshot in `removeTab`)
- **Added:** `\$fontSize.ts`, `\$activeTerminal.ts` (handle registry), `\$closedTabs.ts`, `\$activeSearch.ts`, `TerminalSearchBar.tsx`
- **Dependency:** `+@xterm/addon-search`

## Out of scope
- `Cmd+,` (settings) — no settings UI exists yet; defer
- `Cmd+N` / `Cmd+Shift+W` (multi-window) — multi-window architecture is bigger; defer
- Phase 3 splits, Phase 4 agent-native shortcuts — separate plans
- Cross-platform (Linux/Windows) — captured as Phase 5 in the audit doc, separate from this PR

## Test plan

- [ ] Type `echo hello world` then `Ctrl+W` → readline deletes `world` (does NOT close tab)
- [ ] Press `Ctrl+T` → readline transposes chars (does NOT open new tab)
- [ ] `Cmd+T` opens a new tab; `Cmd+W` closes the active tab; pinned tabs protected
- [ ] `Cmd+Shift+]` / `Cmd+Shift+[` cycle through tabs in current project
- [ ] Sidebar shows project-number badges when **Cmd** is held (not Ctrl); `Cmd+1..9` jumps to project N
- [ ] `Cmd+=` / `Cmd+-` change font size in all terminals; `Cmd+0` resets; persists across app restart
- [ ] `Cmd+K` clears the active terminal (visible buffer + scrollback) without affecting other tabs
- [ ] `Cmd+A` selects all visible text in the active terminal
- [ ] Close a tab, then `Cmd+Shift+T` — same project, reopens at same cwd with original label
- [ ] `Cmd+F` opens search bar; typing live-jumps to first match; `Cmd+G` / `Cmd+Shift+G` cycle; `Enter` / `Shift+Enter` in bar = next/prev; `Esc` closes
- [ ] `Cmd+C` / `Cmd+V` / `Cmd+Q` / `Ctrl+Cmd+F` still work
- [ ] Run `claude`, hit `Ctrl+R` and type — readline reverse-history-search works (we're not intercepting it)