### PR TITLE
ci: add PR workflow with manual approval gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,8 @@
-# Pull-request CI: lint, typecheck, and test the JS and Rust sides on
-# every PR commit — gated behind a manual approval so CI minutes aren't
-# burned on every WIP nudge.
+# PR CI, gated behind manual approval.
 #
-# How it works
-# ────────────
-#   1. PR opened / updated → workflow starts in a "Waiting" state.
-#   2. The `approve` job targets the `ci-approval` environment, which
-#      has a required reviewer set in repo settings. Until that
-#      reviewer clicks "Approve and run" on the workflow page, no
-#      other job is allowed to start.
-#   3. Once approved, `js-checks` and `rust-checks` run in parallel.
-#   4. Within each job, every check step uses `if: ${{ !cancelled() }}`
-#      so a single check failure does not skip the rest — one CI run
-#      surfaces every problem in the diff (lint + typecheck + tests
-#      across both languages), so the next commit can fix all of them
-#      at once instead of playing whack-a-mole.
-#   5. New push to the PR → an in-flight run on the same PR is
-#      cancelled (`concurrency: cancel-in-progress`), and the fresh
-#      run waits for approval again. New commit, new approval.
-#
-# One-time setup before this gate is real
-# ───────────────────────────────────────
-# In repo Settings → Environments:
-#   1. Click "New environment"
-#   2. Name it exactly: `ci-approval`
-#   3. Under "Deployment protection rules", check
-#      "Required reviewers" and add at least one reviewer (typically
-#      the repo owner). Save.
-# Without that environment + reviewer, the `approve` job auto-passes
-# and the gate is a no-op.
+# One-time setup (otherwise the `approve` gate is a no-op):
+#   Repo Settings → Environments → New environment → name `ci-approval`
+#   → enable "Required reviewers" → add yourself → save.
 
 name: CI
 
@@ -38,8 +12,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Cancel in-flight runs on the same PR so a fresh push doesn't queue
-# a second approval prompt and double-billed minutes.
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -48,12 +20,6 @@ permissions:
   contents: read
 
 jobs:
-  # ────────────────────────────────────────────────────────────────────
-  # Manual approval gate. Pauses here until a reviewer of the
-  # `ci-approval` environment approves the run in the GitHub Actions
-  # UI. The job itself does no real work — its only purpose is being
-  # `needs:`-ed by every check job below.
-  # ────────────────────────────────────────────────────────────────────
   approve:
     name: Wait for manual approval
     runs-on: ubuntu-latest
@@ -61,16 +27,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Approved
-        run: echo "CI approved by ${{ github.actor }} for ${{ github.event.pull_request.html_url || github.ref }}"
+        run: echo "CI approved by ${{ github.actor }}"
 
-  # ────────────────────────────────────────────────────────────────────
-  # JS / TypeScript checks
-  # ────────────────────────────────────────────────────────────────────
-  # Biome (lint + format), tsc --noEmit (typecheck), bun test (unit).
-  # All three run in sequence as steps; each uses `if: ${{ !cancelled() }}`
-  # so a Biome failure does not skip tsc, and a tsc failure does not
-  # skip the tests. The job fails if any step fails.
-  # ────────────────────────────────────────────────────────────────────
+  # `if: ${{ !cancelled() }}` on every check below is deliberate: one CI run
+  # surfaces every failure in the diff (lint + typecheck + tests, both langs),
+  # so the next push can fix all of them at once instead of one-per-cycle.
   js-checks:
     name: JS / TypeScript
     needs: approve
@@ -78,56 +39,37 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - run: bun install --frozen-lockfile
 
-      - name: Install JS dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Biome — lint + format check
+      - name: Biome
         if: ${{ !cancelled() }}
         run: bunx biome check
-
-      - name: TypeScript — typecheck
+      - name: tsc --noEmit
         if: ${{ !cancelled() }}
         run: bunx tsc --noEmit
-
-      - name: Bun — frontend tests
+      - name: bun test
         if: ${{ !cancelled() }}
         run: bun test
 
-  # ────────────────────────────────────────────────────────────────────
-  # Rust / Tauri checks
-  # ────────────────────────────────────────────────────────────────────
-  # Kept as ONE job (not split per check) because cargo's incremental
-  # build cache is shared across `check`, `clippy`, and `test`. Splitting
-  # would force each job to recompile dependencies from scratch — minutes
-  # of Tauri / Wry compile per job, multiplied across the matrix.
-  #
-  # Same `if: ${{ !cancelled() }}` pattern as js-checks so clippy doesn't
-  # skip tests, etc.
-  # ────────────────────────────────────────────────────────────────────
+  # Single job, not split per check: cargo's incremental build cache is shared
+  # across check / clippy / test, so splitting would recompile Tauri/Wry deps
+  # from scratch in each parallel job.
   rust-checks:
     name: Rust / Tauri
     needs: approve
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # Useful in CI failure logs without affecting normal output.
       RUST_BACKTRACE: '1'
     steps:
       - uses: actions/checkout@v4
 
-      # Tauri's wry runtime links against WebKitGTK on Linux even for
-      # `cargo check` — tauri-runtime-wry has a build script that
-      # invokes pkg-config during dependency compilation. macOS and
-      # Windows runners don't need this; Ubuntu is used purely for
-      # cost (Linux runners are 1× billed minutes vs 10× for macOS).
-      # Apt list mirrors Tauri 2's official prerequisites doc:
-      # https://v2.tauri.app/start/prerequisites/#linux
+      # tauri-runtime-wry's build script links against WebKitGTK during
+      # dependency compilation — required even for `cargo check`, not just
+      # build. Apt list mirrors Tauri 2's prerequisites doc.
       - name: Install Tauri Linux dependencies
         run: |
           sudo apt-get update
@@ -142,38 +84,29 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev
 
-      - name: Install Rust toolchain (stable + clippy)
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-
-      # Caches target/, ~/.cargo/registry, ~/.cargo/git. With a warm
-      # cache, cargo check on a Rust-only diff drops from several
-      # minutes (full Tauri/Wry compile) to seconds.
-      - name: Cache Cargo build artefacts
-        uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
 
-      - name: cargo check (typecheck)
+      - name: cargo check
         if: ${{ !cancelled() }}
         working-directory: src-tauri
         run: cargo check --all-targets
-
-      - name: cargo clippy (lint)
+      - name: cargo clippy
         if: ${{ !cancelled() }}
         working-directory: src-tauri
         run: cargo clippy --all-targets
-
-      - name: cargo test --lib (unit tests)
+      - name: cargo test --lib
         if: ${{ !cancelled() }}
         working-directory: src-tauri
         run: cargo test --lib
 
-      # hook_integration uses shared filesystem state under ~/.agent-terminal
-      # paths + a fixed HTTP port, so its tests must run serially. This
-      # mirrors the project's `bun run test` script exactly.
-      - name: cargo test --test hook_integration (integration, single-threaded)
+      # hook_integration tests share filesystem state and a fixed HTTP port,
+      # so they must run serially. Mirrors the project's `bun run test` script.
+      - name: cargo test --test hook_integration
         if: ${{ !cancelled() }}
         working-directory: src-tauri
         run: cargo test --test hook_integration -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,179 @@
+# Pull-request CI: lint, typecheck, and test the JS and Rust sides on
+# every PR commit — gated behind a manual approval so CI minutes aren't
+# burned on every WIP nudge.
+#
+# How it works
+# ────────────
+#   1. PR opened / updated → workflow starts in a "Waiting" state.
+#   2. The `approve` job targets the `ci-approval` environment, which
+#      has a required reviewer set in repo settings. Until that
+#      reviewer clicks "Approve and run" on the workflow page, no
+#      other job is allowed to start.
+#   3. Once approved, `js-checks` and `rust-checks` run in parallel.
+#   4. Within each job, every check step uses `if: ${{ !cancelled() }}`
+#      so a single check failure does not skip the rest — one CI run
+#      surfaces every problem in the diff (lint + typecheck + tests
+#      across both languages), so the next commit can fix all of them
+#      at once instead of playing whack-a-mole.
+#   5. New push to the PR → an in-flight run on the same PR is
+#      cancelled (`concurrency: cancel-in-progress`), and the fresh
+#      run waits for approval again. New commit, new approval.
+#
+# One-time setup before this gate is real
+# ───────────────────────────────────────
+# In repo Settings → Environments:
+#   1. Click "New environment"
+#   2. Name it exactly: `ci-approval`
+#   3. Under "Deployment protection rules", check
+#      "Required reviewers" and add at least one reviewer (typically
+#      the repo owner). Save.
+# Without that environment + reviewer, the `approve` job auto-passes
+# and the gate is a no-op.
+
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-flight runs on the same PR so a fresh push doesn't queue
+# a second approval prompt and double-billed minutes.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ────────────────────────────────────────────────────────────────────
+  # Manual approval gate. Pauses here until a reviewer of the
+  # `ci-approval` environment approves the run in the GitHub Actions
+  # UI. The job itself does no real work — its only purpose is being
+  # `needs:`-ed by every check job below.
+  # ────────────────────────────────────────────────────────────────────
+  approve:
+    name: Wait for manual approval
+    runs-on: ubuntu-latest
+    environment: ci-approval
+    timeout-minutes: 60
+    steps:
+      - name: Approved
+        run: echo "CI approved by ${{ github.actor }} for ${{ github.event.pull_request.html_url || github.ref }}"
+
+  # ────────────────────────────────────────────────────────────────────
+  # JS / TypeScript checks
+  # ────────────────────────────────────────────────────────────────────
+  # Biome (lint + format), tsc --noEmit (typecheck), bun test (unit).
+  # All three run in sequence as steps; each uses `if: ${{ !cancelled() }}`
+  # so a Biome failure does not skip tsc, and a tsc failure does not
+  # skip the tests. The job fails if any step fails.
+  # ────────────────────────────────────────────────────────────────────
+  js-checks:
+    name: JS / TypeScript
+    needs: approve
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install JS dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Biome — lint + format check
+        if: ${{ !cancelled() }}
+        run: bunx biome check
+
+      - name: TypeScript — typecheck
+        if: ${{ !cancelled() }}
+        run: bunx tsc --noEmit
+
+      - name: Bun — frontend tests
+        if: ${{ !cancelled() }}
+        run: bun test
+
+  # ────────────────────────────────────────────────────────────────────
+  # Rust / Tauri checks
+  # ────────────────────────────────────────────────────────────────────
+  # Kept as ONE job (not split per check) because cargo's incremental
+  # build cache is shared across `check`, `clippy`, and `test`. Splitting
+  # would force each job to recompile dependencies from scratch — minutes
+  # of Tauri / Wry compile per job, multiplied across the matrix.
+  #
+  # Same `if: ${{ !cancelled() }}` pattern as js-checks so clippy doesn't
+  # skip tests, etc.
+  # ────────────────────────────────────────────────────────────────────
+  rust-checks:
+    name: Rust / Tauri
+    needs: approve
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Useful in CI failure logs without affecting normal output.
+      RUST_BACKTRACE: '1'
+    steps:
+      - uses: actions/checkout@v4
+
+      # Tauri's wry runtime links against WebKitGTK on Linux even for
+      # `cargo check` — tauri-runtime-wry has a build script that
+      # invokes pkg-config during dependency compilation. macOS and
+      # Windows runners don't need this; Ubuntu is used purely for
+      # cost (Linux runners are 1× billed minutes vs 10× for macOS).
+      # Apt list mirrors Tauri 2's official prerequisites doc:
+      # https://v2.tauri.app/start/prerequisites/#linux
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Install Rust toolchain (stable + clippy)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      # Caches target/, ~/.cargo/registry, ~/.cargo/git. With a warm
+      # cache, cargo check on a Rust-only diff drops from several
+      # minutes (full Tauri/Wry compile) to seconds.
+      - name: Cache Cargo build artefacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: cargo check (typecheck)
+        if: ${{ !cancelled() }}
+        working-directory: src-tauri
+        run: cargo check --all-targets
+
+      - name: cargo clippy (lint)
+        if: ${{ !cancelled() }}
+        working-directory: src-tauri
+        run: cargo clippy --all-targets
+
+      - name: cargo test --lib (unit tests)
+        if: ${{ !cancelled() }}
+        working-directory: src-tauri
+        run: cargo test --lib
+
+      # hook_integration uses shared filesystem state under ~/.agent-terminal
+      # paths + a fixed HTTP port, so its tests must run serially. This
+      # mirrors the project's `bun run test` script exactly.
+      - name: cargo test --test hook_integration (integration, single-threaded)
+        if: ${{ !cancelled() }}
+        working-directory: src-tauri
+        run: cargo test --test hook_integration -- --test-threads=1


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` — runs every JS + Rust check on every PR commit, but only after **you approve** the run in the Actions UI. New push to the PR → run is cancelled, fresh one queues for fresh approval.

## ⚠️ One-time setup required (otherwise the gate is a no-op)

Before this is useful you must create the environment the workflow gates on:

1. Repo **Settings → Environments → New environment**
2. Name it exactly: \`ci-approval\`
3. Under **Deployment protection rules**, check **Required reviewers** and add yourself (or a team).
4. Save.

Without that environment + reviewer, the \`approve\` job will auto-pass and every PR push will burn CI minutes immediately. Documented at the top of the workflow file too.

## Structure

\`\`\`
approve  (gate — pauses on the ci-approval environment)
  ├─ js-checks   (parallel)
  └─ rust-checks (parallel)
\`\`\`

Inside each check job, every step uses \`if: \${{ !cancelled() }}\` — so a Biome failure does not skip the typecheck, a clippy failure does not skip the tests, etc. **One CI run surfaces every problem in the diff** so the next commit can fix all of them at once instead of playing whack-a-mole across multiple push cycles.

## Checks run

**\`js-checks\`** (Ubuntu, bun)
- \`bun install --frozen-lockfile\`
- \`bunx biome check\`           (lint + format)
- \`bunx tsc --noEmit\`          (typecheck)
- \`bun test\`                    (frontend tests)

**\`rust-checks\`** (Ubuntu, single job — shared cargo cache)
- apt install Tauri Linux deps (webkit2gtk etc., per Tauri 2 docs)
- \`cargo check --all-targets\`  (typecheck)
- \`cargo clippy --all-targets\` (lint)
- \`cargo test --lib\`            (unit tests, parallel)
- \`cargo test --test hook_integration -- --test-threads=1\` (integration, serial — shared filesystem state + fixed HTTP port)

Rust checks are kept in **one job, not split**, because cargo's incremental build cache is shared across check/clippy/test — splitting would force each to recompile Tauri/Wry deps from scratch.

## Cost / efficiency notes

| Optimisation | What |
|---|---|
| Manual approval gate | No minutes spent until you say "go". |
| \`concurrency: cancel-in-progress\` | New push to PR cancels the in-flight run instead of queueing a second approval prompt. |
| Ubuntu runners | 1× billing vs 10× for macOS. Linux Tauri deps installed via apt. |
| \`Swatinem/rust-cache@v2\` | Caches \`target/\` + cargo registry. Warm-cache cargo check on a Rust diff drops from minutes to seconds. |
| One Rust job | Shared compile cache across check/clippy/test. |
| \`bun install --frozen-lockfile\` | Fast, deterministic — no resolution work in CI. |

## Triggers

- \`pull_request\` (opened, synchronize, reopened, ready_for_review) on PRs to \`main\`
- \`workflow_dispatch\` for manual re-runs

## Validated

Linted with \`actionlint 1.7.12\` — clean.

## Not in scope here (future work if wanted)

- Cross-platform matrix (macOS / Windows runners). Currently Linux-only for cost. Add a \`strategy.matrix\` later if Windows/Linux ports start landing PRs that need OS-specific verification.
- Auto-format on PR. Could add a \`format\` job that runs \`bun run lint:fix\` and pushes a fixup commit, but that's a separate behaviour decision.

## Side note: the "deployed to ci-approval" label in this PR

Every gated CI run will leave a `@DaniAkash deployed to ci-approval` entry in the PR conversation and a row on the repo's Environments page. **This is cosmetic GitHub UI overlap, not a misconfiguration.**

Why: GitHub Actions has no "approval gate" primitive separate from the Deployments subsystem. The only way to require manual approval before a workflow runs is to attach a job to an environment with required reviewers, and any job referencing an environment is recorded as a deployment.

GitHub did ship a partial fix in late March 2026 — [`environment: { deployment: false }`](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments) — but it is **incompatible with required-reviewer protection rules**. Setting `deployment: false` on an environment that has reviewers either fails the job immediately or silently bypasses the gate (depending on which way GitHub resolves the conflict). Either result defeats the point for our use case.

What GitHub still needs to ship for our gate to lose the deployment chrome:
- An `approval-only` mode for environments where required reviewers + secrets work, but no deployment record is created. Equivalent to GitLab's protected environments or Azure DevOps libraries.
- OR: `deployment: false` made compatible with required-reviewer protection rules — gate the run, suppress the deployment record.

Tracking discussion (4-year-old request, partially addressed but not for the approval-gating case): [community#36919](https://github.com/orgs/community/discussions/36919). Comments after the March 2026 "answered" mark are users in our exact position discovering the new feature doesn't solve gated-approval workflows.

If/when GitHub closes that gap, the workflow can drop the deployment chrome by adding `deployment: false` to the `approve` job. Until then, accept the cosmetic noise.
