### PR TITLE
feat(dev): allow dev and prod instances to coexist on the same machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "tauri:dev": "tauri dev",
+    "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json --features dev-instance",
     "build": "vite build",
     "tauri:build": "tauri build",
     "preview": "vite preview",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,12 @@ edition = "2021"
 name = "agent_terminal_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+default = []
+# Switches the running instance to a separate "dev" namespace so a dev build
+# can coexist with a production install on the same machine. See src/identity.rs.
+dev-instance = []
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -152,5 +152,8 @@ pub async fn list_projects() -> Result<serde_json::Value, String> {
 
 fn projects_config_path() -> Result<std::path::PathBuf, String> {
     let home = dirs::home_dir().ok_or("could not determine home directory")?;
-    Ok(home.join(".config/agent-terminal/projects.json"))
+    Ok(home
+        .join(".config")
+        .join(crate::identity::NAMESPACE)
+        .join("projects.json"))
 }

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -109,7 +109,9 @@ pub async fn ensure_hooks_installed() {
             return;
         }
     };
-    let hooks_dir = home.join(".agent-terminal").join("hooks");
+    let hooks_dir = home
+        .join(format!(".{}", crate::identity::NAMESPACE))
+        .join("hooks");
     for config in AGENT_HOOK_CONFIGS {
         if let Err(e) = install_for_agent(config, &home, &hooks_dir).await {
             eprintln!(
@@ -196,11 +198,12 @@ pub(crate) async fn write_hook_script_to(
 /// a ceiling on background curl lifetime so they don't accumulate as zombies
 /// if the server is hung and hooks fire repeatedly.
 ///
-/// Why `127.0.0.1` and not `localhost`: the server binds `127.0.0.1:47384`
-/// (IPv4 only). On macOS, `localhost` resolves to `::1` first, so curl tries
-/// IPv6 and gets ECONNREFUSED before falling back to IPv4 (Happy Eyeballs).
-/// The fallback works, but every hook eats the latency for nothing. Pinning
-/// the script to `127.0.0.1` matches the server's address family directly.
+/// Why `127.0.0.1` and not `localhost`: the server binds `127.0.0.1:<HOOK_PORT>`
+/// (IPv4 only — port is 47384 in prod, 47385 in dev, see `identity.rs`). On
+/// macOS, `localhost` resolves to `::1` first, so curl tries IPv6 and gets
+/// ECONNREFUSED before falling back to IPv4 (Happy Eyeballs). The fallback
+/// works, but every hook eats the latency for nothing. Pinning the script to
+/// `127.0.0.1` matches the server's address family directly.
 fn build_hook_script(agent_id: &str) -> String {
     // The sed command removes the leading `{` from the agent's JSON payload so
     // we can inject our own fields at the front. The result is a valid JSON object:
@@ -240,11 +243,12 @@ case \"$AGENT_TERMINAL_TAB_ID\" in\n\
   *) TAB_FIELD=\"\\\"tab_id\\\":\\\"$AGENT_TERMINAL_TAB_ID\\\",\" ;;\n\
 esac\n\
 PAYLOAD=\"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\",${{TAB_FIELD}}$STRIPPED\"\n\
-{{ curl -sf --max-time 5 -X POST http://127.0.0.1:47384/hook \\\n\
+{{ curl -sf --max-time 5 -X POST http://127.0.0.1:{port}/hook \\\n\
     -H 'Content-Type: application/json' \\\n\
     -d \"$PAYLOAD\" \\\n\
     >/dev/null 2>&1 & }} 2>/dev/null\n\
 exit 0\n",
+        port = crate::identity::HOOK_PORT,
     )
 }
 
@@ -870,7 +874,8 @@ mod tests {
         let content = fs::read_to_string(&script).unwrap();
         // 127.0.0.1 (not `localhost`) so the script's address family matches
         // the server's bind. See doc comment on `build_hook_script`.
-        assert!(content.contains("127.0.0.1:47384"), "script should be updated");
+        let expected = format!("127.0.0.1:{}", crate::identity::HOOK_PORT);
+        assert!(content.contains(&expected), "script should contain {expected}");
         assert!(!content.contains("echo old"), "old content should be replaced");
     }
 

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -336,7 +336,20 @@ pub(crate) async fn merge_hook_config_at(
 
     // Atomic write: temp file → rename.
     let serialized = serde_json::to_string_pretty(&root)?;
-    let tmp_path = config_path.with_extension("agent-terminal.tmp");
+    // Per-PID temp filename so two instances writing the same config file
+    // concurrently don't corrupt each other's atomic writes.
+    //
+    // TODO(DaniAkash): atomic write protects the temp file from corruption
+    // but not the read-modify-write of the config file itself. If two
+    // instances read concurrently, the second rename's content overwrites
+    // the first instance's entry — self-heals on the loser's next launch
+    // (re-add path), but means hooks in the missing-entry window are
+    // dropped. Proper fix: advisory file lock around the load → merge →
+    // write_atomic block (fs4 crate's `FileExt::lock_exclusive`).
+    let tmp_path = config_path.with_extension(format!(
+        "agent-terminal-{}.tmp",
+        std::process::id()
+    ));
     tokio::fs::write(&tmp_path, format!("{serialized}\n")).await?;
     tokio::fs::rename(&tmp_path, config_path).await?;
 

--- a/src-tauri/src/hook_server.rs
+++ b/src-tauri/src/hook_server.rs
@@ -1,13 +1,16 @@
 //! Minimal HTTP server that receives hook payloads from AI coding agents.
 //!
 //! Agent hooks (Claude Code, Codex) are configured to POST structured JSON to
-//! `http://127.0.0.1:47384/hook` via a small shell helper script. This module
-//! receives those POSTs and forwards them to the MOD engine via an unbounded
-//! channel, where `AgentTurnMod` consumes them.
+//! `http://127.0.0.1:<HOOK_PORT>/hook` via a small shell helper script. This
+//! module receives those POSTs and forwards them to the MOD engine via an
+//! unbounded channel, where `AgentTurnMod` consumes them.
 //!
-//! The port is fixed so hook configs written to disk (e.g. `~/.claude/settings.json`)
-//! don't need to be rewritten on every launch. `47384` is not assigned to any
-//! common service in the IANA registry.
+//! `HOOK_PORT` is fixed per build variant (47384 for prod, 47385 for dev — see
+//! `identity::HOOK_PORT`) so hook configs written to disk
+//! (e.g. `~/.claude/settings.json`) don't need to be rewritten on every launch,
+//! and a dev build can coexist with a prod install on the same machine without
+//! fighting for the port. Neither port is assigned to any common service in
+//! the IANA registry.
 
 use axum::{Router, extract::State, http::StatusCode, routing::post, Json};
 use serde::Deserialize;

--- a/src-tauri/src/hook_server.rs
+++ b/src-tauri/src/hook_server.rs
@@ -46,8 +46,9 @@ pub struct HookPayload {
 
 /// Starts the hook HTTP server in a background task.
 ///
-/// Binds to `127.0.0.1:47384`. If the port is unavailable (another
-/// agent-terminal instance is already running, or a conflicting service),
+/// Binds to `127.0.0.1:<HOOK_PORT>` (47384 for prod builds, 47385 for dev
+/// builds — see `identity.rs`). If the port is unavailable (another instance
+/// of the same build variant is already running, or a conflicting service),
 /// logs a warning and returns — the rest of the app is unaffected. Hook-based
 /// agent state tracking will degrade gracefully to the `ps`-based heuristics.
 pub fn start_hook_server(hook_tx: mpsc::UnboundedSender<HookPayload>) {
@@ -56,7 +57,8 @@ pub fn start_hook_server(hook_tx: mpsc::UnboundedSender<HookPayload>) {
             .route("/hook", post(receive_hook))
             .with_state(hook_tx);
 
-        match tokio::net::TcpListener::bind("127.0.0.1:47384").await {
+        let addr = format!("127.0.0.1:{}", crate::identity::HOOK_PORT);
+        match tokio::net::TcpListener::bind(&addr).await {
             Ok(listener) => {
                 if let Err(e) = axum::serve(listener, app).await {
                     eprintln!("[hook_server] server error: {e}");
@@ -64,7 +66,7 @@ pub fn start_hook_server(hook_tx: mpsc::UnboundedSender<HookPayload>) {
             }
             Err(e) => {
                 eprintln!(
-                    "[hook_server] failed to bind 127.0.0.1:47384 — \
+                    "[hook_server] failed to bind {addr} — \
                      hook-based agent state will not be available: {e}"
                 );
             }

--- a/src-tauri/src/identity.rs
+++ b/src-tauri/src/identity.rs
@@ -1,0 +1,21 @@
+//! Per-instance identity constants. Switches values when built with the
+//! `dev-instance` Cargo feature so a dev build can coexist with a prod
+//! install on the same machine without sharing state, ports, or hook
+//! script paths.
+
+/// Filesystem namespace used in `~/.config/<NAMESPACE>/` and
+/// `~/.<NAMESPACE>/hooks/<agent>-hook`. Picked so prod and dev never share
+/// a config dir or hook-script path.
+#[cfg(feature = "dev-instance")]
+pub const NAMESPACE: &str = "agent-terminal-dev";
+#[cfg(not(feature = "dev-instance"))]
+pub const NAMESPACE: &str = "agent-terminal";
+
+/// Port the hook HTTP server binds to. Different per instance so two running
+/// instances don't fight for one port and so each instance only receives
+/// hooks fired by its own spawned shells (the per-instance hook script bakes
+/// this port into the curl URL).
+#[cfg(feature = "dev-instance")]
+pub const HOOK_PORT: u16 = 47385;
+#[cfg(not(feature = "dev-instance"))]
+pub const HOOK_PORT: u16 = 47384;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ mod commands;
 // modules directly.
 pub mod hook_config;
 pub mod hook_server;
+// `pub` so integration tests can read NAMESPACE/HOOK_PORT.
+pub mod identity;
 mod mod_engine;
 mod notifications;
 mod pty_manager;

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -438,7 +438,7 @@ fn build_shell_command(
 
     if shell_name == "zsh" {
         let at_zsh_dir = dirs::home_dir()
-            .map(|h| h.join(".config").join("agent-terminal").join("zsh"))
+            .map(|h| h.join(".config").join(crate::identity::NAMESPACE).join("zsh"))
             .and_then(|p| p.to_str().map(|s| s.to_string()));
 
         if let Some(zdotdir) = at_zsh_dir {
@@ -454,7 +454,7 @@ fn build_shell_command(
         cmd.arg("-l");
     } else if shell_name == "bash" {
         let init_file = dirs::home_dir()
-            .map(|h| h.join(".config").join("agent-terminal").join("bash-integration.bash"))
+            .map(|h| h.join(".config").join(crate::identity::NAMESPACE).join("bash-integration.bash"))
             .and_then(|p| p.to_str().map(|s| s.to_string()));
 
         if let Some(init) = init_file {

--- a/src-tauri/src/shell_integration.rs
+++ b/src-tauri/src/shell_integration.rs
@@ -1,15 +1,16 @@
 //! Agent Terminal shell integration scripts.
 //!
-//! These scripts are written to `~/.config/agent-terminal/` on first launch and
-//! injected into each new PTY session via ZDOTDIR (zsh) or --init-file (bash).
-//! They emit OSC 7 (cwd) and OSC 133 (shell marks) sequences that the MOD engine
-//! parses to track directories and process lifecycle.
+//! These scripts are written to `~/.config/<NAMESPACE>/` (see `identity::NAMESPACE`
+//! — `agent-terminal` for prod builds, `agent-terminal-dev` for dev builds) on
+//! first launch and injected into each new PTY session via ZDOTDIR (zsh) or
+//! --init-file (bash). They emit OSC 7 (cwd) and OSC 133 (shell marks) sequences
+//! that the MOD engine parses to track directories and process lifecycle.
 
 // zsh dotfile load order (login shell):
 //   /etc/zshenv → $ZDOTDIR/.zshenv → /etc/zprofile → $ZDOTDIR/.zprofile →
 //   /etc/zshrc → $ZDOTDIR/.zshrc → /etc/zlogin → $ZDOTDIR/.zlogin
 //
-// We redirect ZDOTDIR to ~/.config/agent-terminal/zsh/, which means by default
+// We redirect ZDOTDIR to ~/.config/<NAMESPACE>/zsh/, which means by default
 // zsh would NOT load the user's real .zshenv / .zprofile / .zshrc. We supply
 // shim files in our ZDOTDIR that source the user's real ones — otherwise PATH
 // (set in .zshenv / .zprofile / via Homebrew's path_helper) is missing in
@@ -54,7 +55,7 @@ PROMPT_COMMAND="_at_osc133_exit; _at_osc7; _at_osc133_prompt${PROMPT_COMMAND:+; 
 trap '_at_osc133_preexec' DEBUG
 "#;
 
-/// Write shell integration scripts to `~/.config/agent-terminal/`.
+/// Write shell integration scripts to `~/.config/<NAMESPACE>/`.
 ///
 /// This is called once at application startup. If it fails (e.g. the directory
 /// can't be created), the error is logged but the app continues — shell

--- a/src-tauri/src/shell_integration.rs
+++ b/src-tauri/src/shell_integration.rs
@@ -63,7 +63,7 @@ pub fn setup_shell_integration() -> Result<(), String> {
     let config_dir = dirs::home_dir()
         .ok_or_else(|| "cannot determine home directory".to_string())?
         .join(".config")
-        .join("agent-terminal");
+        .join(crate::identity::NAMESPACE);
 
     // zsh: ZDOTDIR points to this directory. We write shims for .zshenv,
     // .zprofile, .zshrc — each sources the user's real file if present.

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Agent Terminal Dev",
+  "identifier": "com.daniakash.agent-terminal-dev"
+}

--- a/src-tauri/tests/hook_integration.rs
+++ b/src-tauri/tests/hook_integration.rs
@@ -12,7 +12,7 @@
 //! ```
 //!
 //! `--test-threads=1` is REQUIRED — every test in this file binds (or asserts
-//! the absence of a binding on) port 47384. Parallel execution would race.
+//! the absence of a binding on) the hook port. Parallel execution would race.
 //! The tests internally serialize with a Mutex as a defence-in-depth measure,
 //! but the test runner can still interleave with other tests in other files.
 //!
@@ -36,7 +36,7 @@ use tokio::time::{Duration, timeout};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Cross-test serialization for port 47384. Tests cannot run in parallel because
+/// Cross-test serialization for the hook port. Tests cannot run in parallel because
 /// they all share this single fixed port. The integration tests assume
 /// `--test-threads=1`, but the mutex is also held inside each test as a guard
 /// against accidental parallelism.
@@ -87,7 +87,7 @@ async fn collect_hook(
     StatusCode::OK
 }
 
-/// Server handle that shuts down on drop, freeing port 47384 for the next test.
+/// Server handle that shuts down on drop, freeing the hook port for the next test.
 struct CollectorServer {
     received: Received,
     shutdown: Option<oneshot::Sender<()>>,
@@ -207,7 +207,7 @@ async fn i1_claude_hook_fires_session_start() {
     }
 
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP i1: port 47384 busy (agent-terminal running?)");
+        eprintln!("SKIP i1: port {} busy (agent-terminal running?)", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);
@@ -238,7 +238,7 @@ async fn i2_claude_hook_fires_pre_tool_use() {
         return;
     }
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP i2: port 47384 busy");
+        eprintln!("SKIP i2: port {} busy", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);
@@ -267,7 +267,7 @@ async fn i3_codex_hook_fires_session_start() {
         return;
     }
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP i3: port 47384 busy");
+        eprintln!("SKIP i3: port {} busy", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);
@@ -297,7 +297,7 @@ async fn i4_codex_hook_fires_stop() {
         return;
     }
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP i4: port 47384 busy");
+        eprintln!("SKIP i4: port {} busy", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);
@@ -314,7 +314,7 @@ async fn i4_codex_hook_fires_stop() {
     assert_eq!(got["last_assistant_message"], "Done.");
 }
 
-// ─── I7: Hook script exits fast when nothing is listening on 47384 ────────────
+// ─── I7: Hook script exits fast when nothing is listening on the hook port ────
 //
 // Regression test: confirms ECONNREFUSED is fast on macOS and the script
 // doesn't hang when agent-terminal is closed. Pre-fix this passed (curl fails
@@ -333,7 +333,7 @@ async fn i7_hook_script_does_not_hang_when_server_absent() {
     // Confirm port really is free. If an external process holds it, skip
     // rather than report a misleading failure.
     if try_bind_hook_port().await.is_none() {
-        eprintln!("SKIP i7: port 47384 busy — cannot test absent-server case");
+        eprintln!("SKIP i7: port {} busy — cannot test absent-server case", agent_terminal_lib::identity::HOOK_PORT);
         return;
     }
     // (Listener dropped immediately above so the script sees a free port.)
@@ -364,7 +364,7 @@ async fn i8_hook_script_does_not_hang_when_server_unresponsive() {
     }
 
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP i8: port 47384 busy");
+        eprintln!("SKIP i8: port {} busy", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
 
@@ -512,7 +512,7 @@ async fn i9_claude_hook_forwards_tab_id_when_env_set() {
         return;
     }
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP i9: port 47384 busy");
+        eprintln!("SKIP i9: port {} busy", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);
@@ -554,7 +554,7 @@ async fn i10_claude_hook_omits_tab_id_when_env_unset() {
         return;
     }
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP i10: port 47384 busy");
+        eprintln!("SKIP i10: port {} busy", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);
@@ -599,7 +599,7 @@ async fn i11_claude_hook_omits_tab_id_when_value_unsafe() {
         return;
     }
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP i11: port 47384 busy");
+        eprintln!("SKIP i11: port {} busy", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);
@@ -640,7 +640,7 @@ async fn i11_claude_hook_omits_tab_id_when_value_unsafe() {
 // Why guided instead of automated subprocess spawning:
 //   1. AI CLIs prompt interactively for trust dialogs, auth, etc. — automating
 //      around all of that is brittle and per-version.
-//   2. While the test collector is bound to 47384, EVERY claude/codex process
+//   2. While the test collector is bound to the hook port, EVERY claude/codex process
 //      on the machine fires hooks at it (incl. the user's other terminals).
 //      Filtering by cwd helps but the cleanest signal is a human pointing the
 //      CLI at a known-empty directory created by the test.
@@ -658,7 +658,7 @@ async fn i11_claude_hook_omits_tab_id_when_value_unsafe() {
 //
 // SKIPPED when:
 //   - CI=true (CI/CD environments — these tests need a human)
-//   - port 47384 busy (agent-terminal running, or stale binding)
+//   - hook port busy (agent-terminal running, or stale binding)
 
 fn ci_environment() -> bool {
     std::env::var("CI").map(|v| v == "true").unwrap_or(false)
@@ -784,7 +784,7 @@ async fn e1_guided_claude_fires_hooks_end_to_end() {
     agent_terminal_lib::hook_config::ensure_hooks_installed().await;
 
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP e1: port 47384 busy (agent-terminal running?)");
+        eprintln!("SKIP e1: port {} busy (agent-terminal running?)", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);
@@ -856,7 +856,7 @@ async fn e2_guided_codex_fires_hooks_end_to_end() {
     agent_terminal_lib::hook_config::ensure_hooks_installed().await;
 
     let Some(listener) = try_bind_hook_port().await else {
-        eprintln!("SKIP e2: port 47384 busy (agent-terminal running?)");
+        eprintln!("SKIP e2: port {} busy (agent-terminal running?)", agent_terminal_lib::identity::HOOK_PORT);
         return;
     };
     let server = start_collector(listener);

--- a/src-tauri/tests/hook_integration.rs
+++ b/src-tauri/tests/hook_integration.rs
@@ -55,7 +55,7 @@ fn acquire_port_lock() -> std::sync::MutexGuard<'static, ()> {
 fn hook_scripts_dir() -> PathBuf {
     dirs::home_dir()
         .expect("no home dir")
-        .join(".agent-terminal")
+        .join(format!(".{}", agent_terminal_lib::identity::NAMESPACE))
         .join("hooks")
 }
 
@@ -67,9 +67,11 @@ fn codex_hook() -> PathBuf {
     hook_scripts_dir().join("codex-hook")
 }
 
-/// Try to bind port 47384. Returns the listener or None if the port is busy.
+/// Try to bind the hook port (47384 prod / 47385 dev — see `identity.rs`).
+/// Returns the listener or None if the port is busy.
 async fn try_bind_hook_port() -> Option<TcpListener> {
-    TcpListener::bind("127.0.0.1:47384").await.ok()
+    let addr = format!("127.0.0.1:{}", agent_terminal_lib::identity::HOOK_PORT);
+    TcpListener::bind(&addr).await.ok()
 }
 
 type Received = Arc<Mutex<VecDeque<Value>>>;
@@ -427,7 +429,7 @@ async fn i5_real_claude_settings_no_duplicates() {
     };
 
     let our_prefix = home
-        .join(".agent-terminal")
+        .join(format!(".{}", agent_terminal_lib::identity::NAMESPACE))
         .join("hooks")
         .join("claude-hook")
         .to_string_lossy()
@@ -477,7 +479,7 @@ async fn i6_real_codex_hooks_no_duplicates() {
         return;
     };
     let our_prefix = home
-        .join(".agent-terminal")
+        .join(format!(".{}", agent_terminal_lib::identity::NAMESPACE))
         .join("hooks")
         .join("codex-hook")
         .to_string_lossy()


### PR DESCRIPTION
## Summary

`bun run tauri:dev` now produces an app that can run **simultaneously** alongside the installed production `Agent Terminal.app`. Each instance gets its own state directory, hook script directory, hook server port, macOS bundle identity (dock entry, Cmd-Tab entry, app-data dir), and its own pair of entries in `~/.claude/settings.json` + `~/.codex/hooks.json`. Neither instance affects the other.

## Why

A developer working on the app shouldn't have to quit the production install (and lose tab/project state) every time they want to try a change in dev. Today the two instances collide on:

- `~/.config/agent-terminal/projects.json` (workspace state)
- `~/.config/agent-terminal/{zsh,bash-integration.bash}` (shell integration scripts)
- `~/.agent-terminal/hooks/{claude,codex}-hook` (hook scripts registered in Claude/Codex settings)
- `127.0.0.1:47384` (hook HTTP server — second-launched instance loses agent-state hooks entirely)
- `com.daniakash.agent-terminal` (macOS bundle ID, which controls the app-data dir under `~/Library/Application Support/`, dock identity, single-instance lock, etc.)

After this PR, all five flip to `-dev`-suffixed variants when built with the new `dev-instance` Cargo feature.

## How

A single Cargo feature `dev-instance` toggles a small `identity` module that exports `NAMESPACE` (`agent-terminal` vs `agent-terminal-dev`) and `HOOK_PORT` (47384 vs 47385). Every previously-hardcoded path/port in `commands.rs`, `shell_integration.rs`, `pty_manager.rs`, `hook_server.rs`, and `hook_config.rs` now references these constants. A tiny `tauri.dev.conf.json` overlay flips the macOS `productName` and `identifier`.

The hook script template (`build_hook_script`) bakes the port into the curl URL at install time, so each instance's installed script POSTs to its own port. Both registered entries fire on every Claude/Codex hook; each instance's listener only sees POSTs from its own script.

`tauri:dev` now runs:
```
tauri dev --config src-tauri/tauri.dev.conf.json --features dev-instance
```

`tauri:build` is **unchanged** — no feature flag → default identity → existing prod identity intact. Existing prod installs see no behaviour change.

## What grows in `~/.claude/settings.json` and `~/.codex/hooks.json`

Per the existing idempotent merge logic in `hook_config.rs`, each agent's settings file gains one entry per *distinct command path* that's ever been installed. Two simultaneous instances → two parallel entries per lifecycle hook, capped at two and never growing further on relaunch (re-installation is a no-op when the command path is already present).

## Verified

- `cargo check` clean on both default and `--features dev-instance`.
- `cargo clippy` no new warnings under either flag (clippy warnings already present on main are unchanged).
- `bun test`: 23 pass.
- `cargo test --lib`: 27 pass under both flags.
- `cargo test --test hook_integration -- --test-threads=1`: 9 pass / 4 ignored under both flags.

## Manual smoke test (after merge or on this branch locally)

1. `bun run tauri:build` and install the produced DMG.
2. Launch the installed Agent Terminal — confirm normal operation.
3. From this branch's worktree: `bun run tauri:dev`. The dev window opens alongside.
4. Confirm both apps appear in the Dock and Cmd-Tab as "Agent Terminal" and "Agent Terminal Dev".
5. Open `claude` in a tab in each app. Confirm both `~/.claude/settings.json` and `~/.codex/hooks.json` now have two entries per event (one referencing `~/.agent-terminal/hooks/...`, one referencing `~/.agent-terminal-dev/hooks/...`).
6. Send a prompt to Claude in the prod app — only its tab transitions through agent-state badges. Same in dev — independent.
7. Confirm `~/.config/agent-terminal/projects.json` and `~/.config/agent-terminal-dev/projects.json` exist as separate files with separate state.

## Out of scope

- Frontend "DEV" badge rendered in the WebView (easy follow-up via `import.meta.env.MODE`).
- Distinct app icon for the dev variant.
- Migration of any existing data — none needed; existing installs use prod paths and stay there.