### PR TITLE
fix(tabs): inherit cwd when opening a new tab (live or persisted)

### DIFF
--- a/src/components/Sidebar/SidebarProjectRow.tsx
+++ b/src/components/Sidebar/SidebarProjectRow.tsx
@@ -29,13 +29,11 @@ import { cn } from '@/lib/utils'
 import { $metaHeld } from '@/modules/stores/$keyboard'
 import {
   $activeProjectId,
-  $activeTabId,
   navigateToProject,
-  navigateToTab,
+  openNewTabInProject,
 } from '@/modules/stores/$navigation'
 import {
   $projects,
-  addTab,
   removeProject,
   renameProject,
   reorderTabs,
@@ -104,15 +102,7 @@ export function SidebarProjectRow({ project }: { project: Project }) {
   }
 
   function handleAddTab() {
-    const tabId = $activeTabId.get()[project.id]
-    const cwd = tabId
-      ? ($tabMeta.get()[makeTabKey(project.id, tabId)]?.cwd ?? '')
-      : ''
-    const newTab = addTab(project.id, cwd || undefined)
-    if (newTab) {
-      navigateToProject(project.id)
-      navigateToTab(project.id, newTab.id)
-    }
+    openNewTabInProject(project.id)
   }
 
   return (

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -23,13 +23,12 @@ import {
 } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
 import {
-  $activeProjectId,
   $activeTabId,
   navigateToTab,
   onTabRemoved,
+  openNewTabInProject,
 } from '@/modules/stores/$navigation'
 import {
-  addTab,
   removeTab,
   reorderTabs,
   toggleTabPin,
@@ -185,15 +184,7 @@ export function TabBar({ project }: { project: Project }) {
   }
 
   function handleAddTab() {
-    const projectId = $activeProjectId.get()
-    const tabId = $activeTabId.get()[projectId]
-    const cwd = tabId
-      ? ($tabMeta.get()[makeTabKey(projectId, tabId)]?.cwd ?? '')
-      : ''
-    const newTab = addTab(project.id, cwd || undefined)
-    if (newTab) {
-      navigateToTab(project.id, newTab.id)
-    }
+    openNewTabInProject(project.id)
   }
 
   return (

--- a/src/modules/stores/$navigation.openNewTab.test.ts
+++ b/src/modules/stores/$navigation.openNewTab.test.ts
@@ -1,0 +1,76 @@
+import { mock } from 'bun:test'
+
+// Mock IPC before any store imports so Tauri invoke() is never called.
+mock.module('@/modules/ipc/commands', () => ({
+  IPC: {
+    saveProjects: mock(() => Promise.resolve()),
+    closeTab: mock(() => Promise.resolve()),
+    openTab: mock(() => Promise.resolve(true)),
+    writePty: mock(() => Promise.resolve()),
+    resizePty: mock(() => Promise.resolve()),
+    listProjects: mock(() => Promise.resolve([])),
+  },
+}))
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+import {
+  $activeProjectId,
+  $activeTabId,
+  navigateToTab,
+  openNewTabInProject,
+} from '@/modules/stores/$navigation'
+import { $projects } from '@/modules/stores/$projects'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
+import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+import type { Project } from '@/screens/workspace/workspace.types'
+
+function singleTabProject(lastCwd?: string): Project[] {
+  return [
+    {
+      id: 'p',
+      name: 'p',
+      path: '~/start',
+      pinned: false,
+      tabs: [{ id: 'a', label: 'a', cmd: '', pinned: false, lastCwd }],
+    },
+  ]
+}
+
+beforeEach(() => {
+  $projects.set([])
+  $activeProjectId.set('')
+  $activeTabId.set({})
+  $tabMeta.set({})
+})
+
+describe('openNewTabInProject() — cwd inheritance', () => {
+  test('1: live $tabMeta cwd wins over persisted lastCwd on the source tab', () => {
+    $projects.set(singleTabProject('/persisted'))
+    navigateToTab('p', 'a')
+    $tabMeta.set({
+      [makeTabKey('p', 'a')]: { status: 'idle', type: 'shell', cwd: '/live' },
+    })
+    expect(openNewTabInProject('p')?.lastCwd).toBe('/live')
+  })
+
+  test('2: persisted lastCwd used when $tabMeta has no entry for the source tab', () => {
+    $projects.set(singleTabProject('/persisted'))
+    navigateToTab('p', 'a')
+    expect(openNewTabInProject('p')?.lastCwd).toBe('/persisted')
+  })
+
+  test('3: stale $activeTabId (id not in project.tabs) falls back to tabs[0]', () => {
+    $projects.set(singleTabProject('/from-a'))
+    $activeTabId.set({ p: 'ghost' })
+    expect(openNewTabInProject('p')?.lastCwd).toBe('/from-a')
+  })
+
+  test('4: no cwd anywhere → new tab has undefined lastCwd', () => {
+    $projects.set(singleTabProject(undefined))
+    expect(openNewTabInProject('p')?.lastCwd).toBeUndefined()
+  })
+
+  test('5: returns null for unknown projectId', () => {
+    expect(openNewTabInProject('nonexistent')).toBeNull()
+  })
+})

--- a/src/modules/stores/$navigation.ts
+++ b/src/modules/stores/$navigation.ts
@@ -92,10 +92,14 @@ export function onTabRemoved(projectId: string, removedTabId: string): void {
 export function openNewTabInProject(projectId: string): Tab | null {
   const project = $projects.get().find((p) => p.id === projectId)
   if (!project) return null
-  const sourceTabId = $activeTabId.get()[projectId] ?? project.tabs[0]?.id
-  const sourceTab = sourceTabId
-    ? project.tabs.find((t) => t.id === sourceTabId)
-    : undefined
+  // `?? project.tabs[0]` covers BOTH "no entry recorded" AND "recorded id no
+  // longer exists in project.tabs" (stale state from a removal that didn't
+  // route through onTabRemoved, persistence drift, etc.) — find() returning
+  // undefined is treated identically to no entry.
+  const activeTabId = $activeTabId.get()[projectId]
+  const sourceTab =
+    (activeTabId && project.tabs.find((t) => t.id === activeTabId)) ??
+    project.tabs[0]
   const inheritCwd = sourceTab
     ? ($tabMeta.get()[makeTabKey(projectId, sourceTab.id)]?.cwd ??
       sourceTab.lastCwd)

--- a/src/modules/stores/$navigation.ts
+++ b/src/modules/stores/$navigation.ts
@@ -69,18 +69,36 @@ export function onTabRemoved(projectId: string, removedTabId: string): void {
 }
 
 /**
- * Open a fresh tab in `projectId`, inheriting the live cwd from that
- * project's currently-active tab, and switch to the new tab.
+ * Open a fresh tab in `projectId`, inheriting cwd from a sensible source
+ * tab in the same project, and switch to the new tab. Cwd is resolved as:
  *
- * Reads from `$tabMeta` (synchronous OSC 7 cwd) rather than `Tab.lastCwd`
- * because `Tab.lastCwd` is debounced (cwd-persist.ts) — it lags the live
- * cwd by up to 2s, so a quick `cd` followed by ⌘T would otherwise inherit
- * the pre-`cd` directory.
+ *   1. Live OSC 7 cwd from `$tabMeta` (this session's `cd`s)
+ *   2. Persisted `Tab.lastCwd` (debounced into `$projects` last session)
+ *   3. Otherwise `undefined` → caller falls through to `project.path`
+ *
+ * Source tab is `$activeTabId` for the project if set, otherwise
+ * `project.tabs[0]` — covers the case where the user clicks a non-active
+ * project's "+" button, in which case `$activeTabId` has no entry for
+ * that project yet (it's lazy-populated on `navigateToProject`, and not
+ * persisted across sessions).
+ *
+ * Why two cwd layers: `$tabMeta` only has entries for tabs whose PTYs
+ * have spawned this session. For a project never visited in this session
+ * but with persisted state from disk, `$tabMeta` is empty and we need to
+ * fall back to the persisted `Tab.lastCwd`. `Tab.lastCwd` itself lags
+ * live cwd by up to 2s (cwd-persist.ts debounce), which is why we prefer
+ * `$tabMeta` first when both are available.
  */
 export function openNewTabInProject(projectId: string): Tab | null {
-  const activeTabId = $activeTabId.get()[projectId]
-  const inheritCwd = activeTabId
-    ? $tabMeta.get()[makeTabKey(projectId, activeTabId)]?.cwd
+  const project = $projects.get().find((p) => p.id === projectId)
+  if (!project) return null
+  const sourceTabId = $activeTabId.get()[projectId] ?? project.tabs[0]?.id
+  const sourceTab = sourceTabId
+    ? project.tabs.find((t) => t.id === sourceTabId)
+    : undefined
+  const inheritCwd = sourceTab
+    ? ($tabMeta.get()[makeTabKey(projectId, sourceTab.id)]?.cwd ??
+      sourceTab.lastCwd)
     : undefined
   const newTab = addTab(projectId, inheritCwd || undefined)
   if (!newTab) return null

--- a/src/modules/stores/$navigation.ts
+++ b/src/modules/stores/$navigation.ts
@@ -1,7 +1,9 @@
 import { invoke } from '@tauri-apps/api/core'
 import { atom } from 'nanostores'
-import { $projects } from '@/modules/stores/$projects'
+import { $projects, addTab } from '@/modules/stores/$projects'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+import type { Tab } from '@/screens/workspace/workspace.types'
 
 /**
  * Best-effort: clear any pending OS notification for the navigated tab.
@@ -64,6 +66,27 @@ export function onTabRemoved(projectId: string, removedTabId: string): void {
   const newActive =
     remaining[Math.max(0, idx - 1)]?.id ?? remaining[0]?.id ?? ''
   $activeTabId.set({ ...$activeTabId.get(), [projectId]: newActive })
+}
+
+/**
+ * Open a fresh tab in `projectId`, inheriting the live cwd from that
+ * project's currently-active tab, and switch to the new tab.
+ *
+ * Reads from `$tabMeta` (synchronous OSC 7 cwd) rather than `Tab.lastCwd`
+ * because `Tab.lastCwd` is debounced (cwd-persist.ts) — it lags the live
+ * cwd by up to 2s, so a quick `cd` followed by ⌘T would otherwise inherit
+ * the pre-`cd` directory.
+ */
+export function openNewTabInProject(projectId: string): Tab | null {
+  const activeTabId = $activeTabId.get()[projectId]
+  const inheritCwd = activeTabId
+    ? $tabMeta.get()[makeTabKey(projectId, activeTabId)]?.cwd
+    : undefined
+  const newTab = addTab(projectId, inheritCwd || undefined)
+  if (!newTab) return null
+  navigateToProject(projectId)
+  navigateToTab(projectId, newTab.id)
+  return newTab
 }
 
 /** Initialize navigation from loaded projects (called on app start). */

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -20,6 +20,7 @@ import {
   navigateToProject,
   navigateToTab,
   onTabRemoved,
+  openNewTabInProject,
 } from '@/modules/stores/$navigation'
 import {
   $projects,
@@ -93,9 +94,7 @@ export function WorkspaceLayout() {
   useHotkeys(
     `${Mod.Meta}+${Keys.T}`,
     () => {
-      const projectId = $activeProjectId.get()
-      const newTab = addTab(projectId)
-      if (newTab) navigateToTab(projectId, newTab.id)
+      openNewTabInProject($activeProjectId.get())
     },
     hotkeyOpts,
   )


### PR DESCRIPTION
## Summary

Two related bugs in "open new tab", both surfaced via the same code-duplication problem:

1. **⌘T started new tabs at `project.path`** instead of the active tab's current cwd.
2. **Clicking "+" on a project not visited this session** started new tabs at `\$HOME` instead of inheriting the project's last-known cwd.

Both fixed by a single high-level action `openNewTabInProject(projectId)` in `\$navigation.ts` that resolves cwd through a layered fallback. The three duplicate "open new tab" call sites (⌘T hotkey, sidebar "+", tab-bar "+") each collapse to one function call.

## Cwd resolution

For a given project, the action picks a **source tab** and a **cwd**, both with fallbacks:

**Source tab:**
1. `\$activeTabId[projectId]` (the project's active tab, if user has navigated to this project this session)
2. `project.tabs[0]` (first tab — used when project hasn't been visited this session, since `\$activeTabId` is lazy-populated and not persisted across sessions)

**Cwd from source tab:**
1. `\$tabMeta[makeTabKey(...)].cwd` (live OSC 7 cwd from this session)
2. `sourceTab.lastCwd` (persisted to disk by `cwd-persist.ts`, debounced 2s after every `cd`)
3. `undefined` → caller falls through to `project.path` (existing WorkspaceView fallback) → empty string → `\$HOME`

| Scenario | Source tab | Cwd source |
|---|---|---|
| Project visited this session, you `cd`'d somewhere | `\$activeTabId` entry | live `\$tabMeta.cwd` |
| Project visited last session, not yet this session, has persisted cwd | `tabs[0]` (fallback) | persisted `Tab.lastCwd` |
| Brand-new project, no tabs ever opened | `tabs[0]` (auto-created shell) | falls through to `project.path` |
| Project with no persisted state anywhere | `tabs[0]` | falls through to `\$HOME` |

**Cwd is always scoped to the same project — never bleeds across project boundaries.**

## Three call sites collapse to one each

| File | Before | After |
|---|---|---|
| `WorkspaceLayout.tsx` (⌘T) | 4-line handler with no cwd lookup at all | `openNewTabInProject(\$activeProjectId.get())` |
| `SidebarProjectRow.tsx` | 8-line handler reading `\$tabMeta` | `openNewTabInProject(project.id)` |
| `TabBar.tsx` | 8-line handler reading `\$tabMeta` | `openNewTabInProject(project.id)` |

Future "open new tab" triggers (command palette, right-click menu, etc.) inherit the correct behaviour for free.

## What stays untouched

- `addTab` in `\$projects.ts` — still the low-level primitive. `\$projects` deliberately doesn't depend on `\$navigation` or `\$tabMeta`; the composition lives one layer up.
- Restore-closed-tab path in `WorkspaceLayout.tsx` — different action ("restore at the cwd captured at close time", not "inherit live or persisted cwd"). Kept separate.
- `Tab.lastCwd` debounce in `cwd-persist.ts` — left as-is. The debounce is intentional for persistence; the fix sidesteps it by reading `\$tabMeta` first.

## Known limitation (out of scope here, follow-up worth tracking)

`\$activeTabId` is not persisted across sessions. So for a project loaded from disk that hasn't been visited yet this session, we can't tell which of its tabs was active in the previous session — we deterministically pick `tabs[0]`. If your main working tab in a project was `tabs[1]`, the new tab inherits `tabs[0]`'s cwd instead.

Predictable but not perfect. The clean fix is persisting active-tab-per-project (one nanostore + persistence wiring change) — a separate PR if cross-session continuity becomes painful.

## Verified

- `bunx tsc --noEmit` clean
- `bunx biome check` on touched files: clean
- `bun test`: 23 pass

## Manual test plan

- [x] Project 1 / tab 1 (`~`), `cd ~/Docs`, ⌘T → new tab in `~/Docs`
- [x] Same with sidebar "+" on project 1 → new tab in `~/Docs`
- [x] Same with tab-bar "+" → new tab in `~/Docs`
- [x] Restart app. Without visiting project 2, click "+" on project 2 → new tab opens at `project2.tabs[0].lastCwd` (NOT `\$HOME`)
- [x] In a brand-new project with no persisted cwd anywhere, ⌘T → falls back to `\$HOME` (no bleeding from another project)
- [x] Reopen a closed tab via the close-and-restore path → restores at the cwd captured at close (separate action, unaffected)