### PR TITLE
feat(keyboard): macOS line-editing + AI-agent newline translations

### DIFF
--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import React, { useCallback, useEffect, useRef } from 'react'
 import {
   type XTermHandle,
@@ -6,6 +7,7 @@ import {
 import { IPC } from '@/modules/ipc/commands'
 import { onPtyExit, onPtyRespawned } from '@/modules/ipc/events'
 import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
 // Tracks in-flight openTab calls per tabKey. Prevents concurrent calls
@@ -31,6 +33,11 @@ export const TerminalPane = React.memo(function TerminalPane({
 }: Props) {
   const tabKey = makeTabKey(projectId, tabId)
   const handleRef = useRef<XTermHandle | null>(null)
+  // Reactive read — flips on the next render whenever ClaudeCodeMod /
+  // CodexMod sets or clears `type === 'agent'` for this tab. xterm's
+  // key handler reads it (via ref) on the next keypress.
+  const allTabMeta = useStore($tabMeta)
+  const isAgent = allTabMeta[tabKey]?.type === 'agent'
 
   // Auto-focus the xterm canvas when this tab becomes active.
   //
@@ -160,6 +167,7 @@ export const TerminalPane = React.memo(function TerminalPane({
       onReady={handleReady}
       onData={handleData}
       onResize={handleResize}
+      isAgent={isAgent}
       className="h-full min-h-0 w-full"
     />
   )

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -33,6 +33,13 @@ type Props = {
   onReady: (handle: XTermHandle) => void
   onData: (data: string) => void
   onResize: (cols: number, rows: number) => void
+  /**
+   * True when the pane's tab is currently running an AI agent
+   * (`$tabMeta[tabKey].type === 'agent'`). Drives the Shift+Enter /
+   * Option+Enter newline translation in the key handler — outside agent
+   * tabs those chords pass through unchanged.
+   */
+  isAgent: boolean
   className?: string
 }
 
@@ -108,32 +115,13 @@ const LIGHT_THEME: ITheme = {
   brightWhite: '#a5a5a5',
 }
 
-// Returns true when the key combo is claimed by the app's hotkey layer
-// (react-hotkeys-hook at document level). Returning false from xterm's
-// attachCustomKeyEventHandler skips xterm's own handler so the event bubbles.
-//
-// Cmd-based: every primary app shortcut uses Cmd, and Cmd+anything has no
-// meaningful translation to a PTY control byte on macOS — so suppressing
-// xterm's handler for any meta-key combo is safe and removes the
-// per-shortcut allowlist that grew with the keymap.
-//
-// Ctrl+Tab / Ctrl+Shift+Tab are the only Ctrl-based aliases: they back
-// the Cmd+Shift+] / Cmd+Shift+[ tab-nav muscle memory from Apple Terminal,
-// VS Code, Chrome. Safe on Ctrl because Ctrl+Tab has no readline binding
-// (Tab itself is shell-bound but Ctrl+Tab isn't).
-//
-// Browser-level shortcuts (Cmd+C/V copy/paste) are handled above xterm
-// in the contenteditable layer and are unaffected by this filter.
-function isAppShortcut(e: KeyboardEvent): boolean {
-  if (e.metaKey) return true
-  if (e.ctrlKey && e.key === 'Tab') return true
-  return false
-}
+import { handleKeyEvent } from '@/components/XTermTerminal/xterm-terminal.keys'
 
 export const XTermTerminal = React.memo(function XTermTerminal({
   onReady,
   onData,
   onResize,
+  isAgent,
   className,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -142,16 +130,20 @@ export const XTermTerminal = React.memo(function XTermTerminal({
   const searchAddonRef = useRef<SearchAddon | null>(null)
   const fontSize = useStore($fontSize)
 
-  // Keep callbacks in refs so the mount-once effect always calls the latest
-  // versions without needing to re-run when they change reference.
+  // Keep callbacks (and the agent flag) in refs so the mount-once effect
+  // always sees the latest versions without needing to re-run when they
+  // change reference. The custom key handler reads `isAgentRef.current`
+  // so toggling agent state mid-session reflects on the next keypress.
   const onReadyRef = useRef(onReady)
   const onDataRef = useRef(onData)
   const onResizeRef = useRef(onResize)
+  const isAgentRef = useRef(isAgent)
   useEffect(() => {
     onReadyRef.current = onReady
     onDataRef.current = onData
     onResizeRef.current = onResize
-  }, [onReady, onData, onResize])
+    isAgentRef.current = isAgent
+  }, [onReady, onData, onResize, isAgent])
 
   useEffect(() => {
     const container = containerRef.current
@@ -197,7 +189,15 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     // Pass app-level shortcuts through to document-level hotkey handlers.
     // xterm calls preventDefault on keys it processes; returning false here
     // short-circuits that so the events bubble up to react-hotkeys-hook.
-    term.attachCustomKeyEventHandler((e) => !isAppShortcut(e))
+    // Single dispatch — see `xterm-terminal.keys.ts` for the precedence
+    // rules between agent-newline / line-edit translation / app shortcut
+    // bubbling / xterm default.
+    term.attachCustomKeyEventHandler((e) =>
+      handleKeyEvent(e, {
+        isAgent: isAgentRef.current,
+        onData: onDataRef.current,
+      }),
+    )
 
     // WebGL renderer — falls back to xterm's built-in DOM renderer on context
     // loss. The canvas addon is not used: it is v5-only and was removed in v6.

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -3,7 +3,6 @@ import { FitAddon } from '@xterm/addon-fit'
 import { SearchAddon } from '@xterm/addon-search'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { WebglAddon } from '@xterm/addon-webgl'
-import type { ITheme } from '@xterm/xterm'
 import { Terminal } from '@xterm/xterm'
 import React, { useEffect, useRef } from 'react'
 import { $activeSearch } from '@/modules/stores/$activeSearch'
@@ -43,79 +42,11 @@ type Props = {
   className?: string
 }
 
-// VS Code Dark+ palette, sourced from VS Code's terminal defaults
-// (src/vs/workbench/contrib/terminal/browser/terminalConfiguration.ts, MIT).
-//
-// Deviations from upstream:
-//   - `background` is set to `#0e0f10` (upstream `#1e1e1e`) so the terminal
-//     pane matches the app's --terminal-background CSS variable and blends
-//     with the surrounding chrome.
-//   - `cursorAccent` follows the overridden background. cursorAccent is
-//     drawn behind a block-style cursor and must equal the terminal bg for
-//     the cursor character to invert cleanly; it's a derived value, not an
-//     independent palette choice.
-//
-// Every other slot (foreground, cursor, ANSI 16, selection) is upstream-faithful.
-//
-// `selectionForeground` is the load-bearing addition vs. the previous
-// hand-rolled palette: without it, xterm.js leaves the glyph colour
-// unchanged when a cell is selected, causing the WebGL renderer to
-// re-rasterise glyphs with shifted contrast and producing a visible
-// "font wobble" during selection.
-const DARK_THEME: ITheme = {
-  background: '#0e0f10', // matches --terminal-background (dark)
-  foreground: '#cccccc',
-  cursor: '#aeafad',
-  cursorAccent: '#0e0f10',
-  selectionBackground: '#264f78',
-  selectionForeground: '#ffffff',
-  selectionInactiveBackground: '#3a3d41',
-  black: '#000000',
-  red: '#cd3131',
-  green: '#0dbc79',
-  yellow: '#e5e510',
-  blue: '#2472c8',
-  magenta: '#bc3fbc',
-  cyan: '#11a8cd',
-  white: '#e5e5e5',
-  brightBlack: '#666666',
-  brightRed: '#f14c4c',
-  brightGreen: '#23d18b',
-  brightYellow: '#f5f543',
-  brightBlue: '#3b8eea',
-  brightMagenta: '#d670d6',
-  brightCyan: '#29b8db',
-  brightWhite: '#e5e5e5',
-}
-
-// VS Code Light+ palette, same source as Dark+ above.
-const LIGHT_THEME: ITheme = {
-  background: '#ffffff', // matches --terminal-background (light)
-  foreground: '#333333',
-  cursor: '#333333',
-  cursorAccent: '#ffffff',
-  selectionBackground: '#add6ff',
-  selectionForeground: '#000000',
-  selectionInactiveBackground: '#e5ebf1',
-  black: '#000000',
-  red: '#cd3131',
-  green: '#00bc00',
-  yellow: '#949800',
-  blue: '#0451a5',
-  magenta: '#bc05bc',
-  cyan: '#0598bc',
-  white: '#555555',
-  brightBlack: '#666666',
-  brightRed: '#cd3131',
-  brightGreen: '#14ce14',
-  brightYellow: '#b5ba00',
-  brightBlue: '#0451a5',
-  brightMagenta: '#bc05bc',
-  brightCyan: '#0598bc',
-  brightWhite: '#a5a5a5',
-}
-
 import { handleKeyEvent } from '@/components/XTermTerminal/xterm-terminal.keys'
+import {
+  DARK_THEME,
+  LIGHT_THEME,
+} from '@/components/XTermTerminal/xterm-terminal.themes'
 
 export const XTermTerminal = React.memo(function XTermTerminal({
   onReady,

--- a/src/components/XTermTerminal/xterm-terminal.keys.ts
+++ b/src/components/XTermTerminal/xterm-terminal.keys.ts
@@ -1,0 +1,122 @@
+// Keyboard helpers for `XTermTerminal`. Split out of the component file so
+// the mount-once effect stays simple and the file lengths stay sane.
+
+/**
+ * Returns true when the key combo is claimed by the app's hotkey layer
+ * (react-hotkeys-hook at document level). Returning false from xterm's
+ * `attachCustomKeyEventHandler` skips xterm's own handler so the event
+ * bubbles up to the document.
+ *
+ * Cmd-based: every primary app shortcut uses Cmd, and Cmd+anything has
+ * no meaningful translation to a PTY control byte on macOS — so
+ * suppressing xterm's handler for any meta-key combo is safe and
+ * removes the per-shortcut allowlist that grew with the keymap.
+ *
+ * Ctrl+Tab / Ctrl+Shift+Tab are the only Ctrl-based aliases: they back
+ * the Cmd+Shift+] / Cmd+Shift+[ tab-nav muscle memory from Apple
+ * Terminal, VS Code, Chrome. Safe on Ctrl because Ctrl+Tab has no
+ * readline binding (Tab itself is shell-bound but Ctrl+Tab isn't).
+ *
+ * Browser-level shortcuts (Cmd+C/V copy/paste) are handled above xterm
+ * in the contenteditable layer and are unaffected by this filter.
+ */
+function isAppShortcut(e: KeyboardEvent): boolean {
+  if (e.metaKey) return true
+  if (e.ctrlKey && e.key === 'Tab') return true
+  return false
+}
+
+/**
+ * Translates macOS line-editing chords (⌥←, ⌘←, ⌥⌫, etc.) into the
+ * readline byte sequences the shell already understands. Mirrors what
+ * Apple Terminal / iTerm2 / Ghostty / Warp do at the terminal layer.
+ *
+ * Returns the bytes to write to the PTY, or `null` if the event isn't
+ * a translatable chord. The caller writes the bytes via `onData` and
+ * suppresses xterm.js's default — its "modified arrow" CSI sequence
+ * (`\x1b[1;3D` and friends) reaches readline as gibberish.
+ *
+ * Byte mappings (keyed by `<modifier>:<key>`):
+ *   alt:ArrowLeft   `\x1bb` = ESC + 'b' = Meta-B = `backward-word`
+ *   alt:ArrowRight  `\x1bf` = ESC + 'f' = Meta-F = `forward-word`
+ *   alt:Backspace   `\x17`  = Ctrl+W           = `backward-kill-word`
+ *   meta:ArrowLeft  `\x01`  = Ctrl+A           = `beginning-of-line`
+ *   meta:ArrowRight `\x05`  = Ctrl+E           = `end-of-line`
+ *   meta:Backspace  `\x15`  = Ctrl+U           = `unix-line-discard`
+ */
+const LINE_EDIT_MAP: Record<string, string> = {
+  'alt:ArrowLeft': '\x1bb',
+  'alt:ArrowRight': '\x1bf',
+  'alt:Backspace': '\x17',
+  'meta:ArrowLeft': '\x01',
+  'meta:ArrowRight': '\x05',
+  'meta:Backspace': '\x15',
+}
+
+function translateLineEdit(e: KeyboardEvent): string | null {
+  // Strict modifier match — exactly one of alt/meta and none of the
+  // others. Broader chords (Cmd+Shift+Left, etc.) stay free for future
+  // bindings rather than getting silently translated.
+  const onlyAlt = e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey
+  const onlyMeta = e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey
+  const mod = onlyAlt ? 'alt' : onlyMeta ? 'meta' : null
+  if (mod === null) return null
+  return LINE_EDIT_MAP[`${mod}:${e.key}`] ?? null
+}
+
+/**
+ * Translates Shift+Enter / Option+Enter into the Meta-Enter byte
+ * sequence (`\x1b\r`) that Ink-based AI-agent input boxes (Claude
+ * Code, Codex) recognize as "insert newline, don't submit". Only fires
+ * when the pane is running an agent — outside agent tabs the same
+ * keypresses pass through unchanged so a plain shell still treats
+ * Shift+Enter as Enter.
+ *
+ * Cmd+Enter is intentionally NOT bound — Slack/Linear/ChatGPT all
+ * reserve it for "submit"; reusing it for newline would surprise users
+ * coming from those apps.
+ */
+function translateAgentNewline(
+  e: KeyboardEvent,
+  isAgent: boolean,
+): string | null {
+  if (!isAgent) return null
+  if (e.key !== 'Enter') return null
+  const onlyShift = e.shiftKey && !e.metaKey && !e.altKey && !e.ctrlKey
+  const onlyAlt = e.altKey && !e.metaKey && !e.shiftKey && !e.ctrlKey
+  if (onlyShift || onlyAlt) return '\x1b\r'
+  return null
+}
+
+export type HandleKeyEventOpts = {
+  isAgent: boolean
+  onData: (data: string) => void
+}
+
+/**
+ * Single dispatch point for `attachCustomKeyEventHandler`. Returns
+ * `true` to let xterm process the event normally, `false` to suppress
+ * it (either because we wrote translated bytes ourselves or because
+ * the event is an app shortcut that should bubble to react-hotkeys).
+ *
+ * Order matters — translations win over app-shortcut bubbling because
+ * some translations (Cmd+arrow) would otherwise be eaten by
+ * `isAppShortcut` returning true for any meta-key combo.
+ */
+export function handleKeyEvent(
+  e: KeyboardEvent,
+  opts: HandleKeyEventOpts,
+): boolean {
+  const newline = translateAgentNewline(e, opts.isAgent)
+  if (newline !== null) {
+    opts.onData(newline)
+    return false
+  }
+  const lineEdit = translateLineEdit(e)
+  if (lineEdit !== null) {
+    opts.onData(lineEdit)
+    return false
+  }
+  if (isAppShortcut(e)) return false
+  return true
+}

--- a/src/components/XTermTerminal/xterm-terminal.keys.ts
+++ b/src/components/XTermTerminal/xterm-terminal.keys.ts
@@ -94,6 +94,14 @@ export type HandleKeyEventOpts = {
 }
 
 /**
+ * Returns the byte sequence this event translates to, if any. Pure —
+ * safe to call multiple times for the same event without side effects.
+ */
+function matchTranslation(e: KeyboardEvent, isAgent: boolean): string | null {
+  return translateAgentNewline(e, isAgent) ?? translateLineEdit(e)
+}
+
+/**
  * Single dispatch point for `attachCustomKeyEventHandler`. Returns
  * `true` to let xterm process the event normally, `false` to suppress
  * it (either because we wrote translated bytes ourselves or because
@@ -102,19 +110,23 @@ export type HandleKeyEventOpts = {
  * Order matters — translations win over app-shortcut bubbling because
  * some translations (Cmd+arrow) would otherwise be eaten by
  * `isAppShortcut` returning true for any meta-key combo.
+ *
+ * Important: xterm's `attachCustomKeyEventHandler` fires for `keydown`,
+ * `keypress`, AND `keyup` (three call sites in `CoreBrowserTerminal`).
+ * The match check runs on every flavor so xterm's default stays
+ * suppressed across the whole event lifecycle (otherwise xterm would
+ * still emit the original byte from its keypress handler, leaking
+ * through our translation). The side-effecting write only fires on
+ * keydown, so each physical keypress sends the translated bytes
+ * exactly once.
  */
 export function handleKeyEvent(
   e: KeyboardEvent,
   opts: HandleKeyEventOpts,
 ): boolean {
-  const newline = translateAgentNewline(e, opts.isAgent)
-  if (newline !== null) {
-    opts.onData(newline)
-    return false
-  }
-  const lineEdit = translateLineEdit(e)
-  if (lineEdit !== null) {
-    opts.onData(lineEdit)
+  const translation = matchTranslation(e, opts.isAgent)
+  if (translation !== null) {
+    if (e.type === 'keydown') opts.onData(translation)
     return false
   }
   if (isAppShortcut(e)) return false

--- a/src/components/XTermTerminal/xterm-terminal.keys.ts
+++ b/src/components/XTermTerminal/xterm-terminal.keys.ts
@@ -7,10 +7,13 @@
  * `attachCustomKeyEventHandler` skips xterm's own handler so the event
  * bubbles up to the document.
  *
- * Cmd-based: every primary app shortcut uses Cmd, and Cmd+anything has
- * no meaningful translation to a PTY control byte on macOS — so
- * suppressing xterm's handler for any meta-key combo is safe and
- * removes the per-shortcut allowlist that grew with the keymap.
+ * Order in `handleKeyEvent` is load-bearing: line-edit and agent-newline
+ * translations are checked BEFORE this. So by the time we get here,
+ * the meta-key combos with PTY translations (`⌘←`, `⌘→`, `⌘⌫`) have
+ * already been handled — anything Cmd-based reaching this filter is
+ * an app shortcut bound at the react-hotkeys-hook layer (`⌘T`, `⌘W`,
+ * `⌘K`, `⌘F`, `⌘1..9`, …). Bubbling all remaining meta-key combos is
+ * safe and removes the per-shortcut allowlist that grew with the keymap.
  *
  * Ctrl+Tab / Ctrl+Shift+Tab are the only Ctrl-based aliases: they back
  * the Cmd+Shift+] / Cmd+Shift+[ tab-nav muscle memory from Apple

--- a/src/components/XTermTerminal/xterm-terminal.themes.ts
+++ b/src/components/XTermTerminal/xterm-terminal.themes.ts
@@ -1,0 +1,78 @@
+// xterm.js color palettes for `XTermTerminal`. Split out of the component
+// file so the .tsx stays focused on React/lifecycle code and the file
+// length lint cap has headroom.
+//
+// Palettes sourced from VS Code's terminal defaults
+// (src/vs/workbench/contrib/terminal/browser/terminalConfiguration.ts, MIT).
+//
+// Deviations from upstream:
+//   - `background` is set to `#0e0f10` / `#ffffff` so the terminal pane
+//     matches the app's `--terminal-background` CSS variable and blends
+//     with the surrounding chrome.
+//   - `cursorAccent` follows the overridden background. cursorAccent is
+//     drawn behind a block-style cursor and must equal the terminal bg
+//     for the cursor character to invert cleanly; it's a derived value,
+//     not an independent palette choice.
+//
+// Every other slot (foreground, cursor, ANSI 16, selection) is
+// upstream-faithful.
+//
+// `selectionForeground` is load-bearing vs. the previous hand-rolled
+// palette: without it, xterm.js leaves the glyph colour unchanged when
+// a cell is selected, causing the WebGL renderer to re-rasterise glyphs
+// with shifted contrast and producing a visible "font wobble" during
+// selection.
+
+import type { ITheme } from '@xterm/xterm'
+
+export const DARK_THEME: ITheme = {
+  background: '#0e0f10', // matches --terminal-background (dark)
+  foreground: '#cccccc',
+  cursor: '#aeafad',
+  cursorAccent: '#0e0f10',
+  selectionBackground: '#264f78',
+  selectionForeground: '#ffffff',
+  selectionInactiveBackground: '#3a3d41',
+  black: '#000000',
+  red: '#cd3131',
+  green: '#0dbc79',
+  yellow: '#e5e510',
+  blue: '#2472c8',
+  magenta: '#bc3fbc',
+  cyan: '#11a8cd',
+  white: '#e5e5e5',
+  brightBlack: '#666666',
+  brightRed: '#f14c4c',
+  brightGreen: '#23d18b',
+  brightYellow: '#f5f543',
+  brightBlue: '#3b8eea',
+  brightMagenta: '#d670d6',
+  brightCyan: '#29b8db',
+  brightWhite: '#e5e5e5',
+}
+
+export const LIGHT_THEME: ITheme = {
+  background: '#ffffff', // matches --terminal-background (light)
+  foreground: '#333333',
+  cursor: '#333333',
+  cursorAccent: '#ffffff',
+  selectionBackground: '#add6ff',
+  selectionForeground: '#000000',
+  selectionInactiveBackground: '#e5ebf1',
+  black: '#000000',
+  red: '#cd3131',
+  green: '#00bc00',
+  yellow: '#949800',
+  blue: '#0451a5',
+  magenta: '#bc05bc',
+  cyan: '#0598bc',
+  white: '#555555',
+  brightBlack: '#666666',
+  brightRed: '#cd3131',
+  brightGreen: '#14ce14',
+  brightYellow: '#b5ba00',
+  brightBlue: '#0451a5',
+  brightMagenta: '#bc05bc',
+  brightCyan: '#0598bc',
+  brightWhite: '#a5a5a5',
+}


### PR DESCRIPTION
## Summary

Two PTY-write translations added to xterm.js's custom key handler so common chords work the way native macOS terminals (Apple Terminal, iTerm2, Ghostty, Warp) handle them.

### macOS line-editing — always on

| Chord | Sends to PTY | readline action |
|---|---|---|
| `⌥←` | `\x1bb` | `backward-word` |
| `⌥→` | `\x1bf` | `forward-word` |
| `⌥⌫` | `\x17` (Ctrl+W) | `backward-kill-word` |
| `⌘←` | `\x01` (Ctrl+A) | `beginning-of-line` |
| `⌘→` | `\x05` (Ctrl+E) | `end-of-line` |
| `⌘⌫` | `\x15` (Ctrl+U) | `unix-line-discard` |

xterm.js's default for these chords is the W3C "modified arrow" CSI sequence (`\x1b[1;3D` and friends), which readline doesn't bind. Native terminals translate at the terminal layer; we now do too.

### AI-agent newline — only when the active tab is detected as an agent

| Chord | Sends to PTY | Agent action |
|---|---|---|
| `Shift+Enter` | `\x1b\r` (Meta-Enter) | insert newline (don't submit) |
| `⌥+Enter` | `\x1b\r` | same |
| Plain `Enter` | `\r` | submit (unchanged) |
| `Cmd+Enter` | `\r` | submit — intentionally NOT bound (Slack/Linear/ChatGPT all reserve Cmd+Enter for submit) |

Ink-based input boxes (Claude Code, Codex) recognize `\x1b\r` as "insert newline, don't submit". Outside agent tabs, the same chords pass through unchanged so a plain shell still treats `Shift+Enter` as plain Enter.

`isAgent` is driven reactively by `\$tabMeta[tabKey].type === 'agent'`, which `ClaudeCodeMod` / `CodexMod` flip based on actual process detection. Start `claude` → translation on. `/exit` → translation off. Switch tabs → only the agent tab translates. Zero coordination.

## Files

- **New:** `src/components/XTermTerminal/xterm-terminal.keys.ts` — `isAppShortcut`, `translateLineEdit`, `translateAgentNewline`, `handleKeyEvent` dispatcher. Splitting these out of the component file keeps the .tsx under the 300-line lint cap and centralizes the translation precedence rules in one place.
- **Modified:** `src/components/XTermTerminal/XTermTerminal.tsx` — adds \`isAgent\` prop + ref, removes the in-file helpers, replaces the 1-line key handler with a single dispatcher call.
- **Modified:** `src/components/TerminalPane/TerminalPane.tsx` — reads \`\$tabMeta\` for its own \`tabKey\`, derives \`isAgent\`, passes the prop.

No new dependencies, no Rust changes, no new stores.

## Test plan

### macOS line-editing (in any tab — shell or agent)
- [x] Type \`echo hello world\`. Press \`⌥←\` once → cursor jumps to start of \`world\`. Again → start of \`hello\`. \`⌥→\` walks back forward.
- [x] Press \`⌘←\` → cursor at line start. \`⌘→\` → cursor at line end.
- [x] Type \`echo abc def ghi\`. \`⌥⌫\` deletes \`ghi\`. Again deletes \`def\`.
- [x] Type a long line, press \`⌘⌫\` → entire line cleared.
- [x] Plain \`←\` / \`→\` still move one character.
- [x] \`⇧←\` / \`⇧→\` still extend the visual selection.

### AI-agent newline (when tab is detected as running an agent)
- [x] Plain shell tab: type a half-line, \`Shift+Enter\` → submits as line (current behavior).
- [x] Run \`claude\`. Type a message, press \`Shift+Enter\` → cursor moves to second line, no submit. Add more text. Press plain \`Enter\` → multi-line message goes to Claude.
- [x] Same flow with \`⌥+Enter\` — also inserts newline.
- [x] Same with \`codex\`.
- [x] Mid-session flip: in a tab, run \`claude\` (Shift+Enter → newline), \`/exit\` (Shift+Enter → submits as plain line), run \`claude\` again (back to newline). Validates reactive \`\$tabMeta\` flow.
- [x] Two tabs: A running \`claude\`, B running shell. Shift+Enter inserts newline in A only, submits in B. Validates per-pane state.
- [x] \`Cmd+Enter\` does nothing special anywhere (no app hotkey, no translation).
- [x] Plain \`Enter\` in agent tab still submits the message.

### Existing behavior preserved
- [x] All app hotkeys (\`⌘T\`, \`⌘W\`, \`⌘K\`, \`⌘F\`, \`⌘1..9\`, \`⌘+/-/0\`, \`⌘⇧]/[\`, etc.) work as before.
- [x] \`⌃C\` still sends SIGINT, \`⌃R\` still does reverse-history-search, \`⌃W\` still deletes a word.
- [x] In \`vim\` / \`htop\` / \`less\`, the chords behave however those apps decide — we're sending standard meta-letter / Meta-Enter sequences, not hijacking them.

## Notes

- **Why \`\\x1b\\r\` and not \`\\n\` for newline?** Ink reads stdin char-by-char and treats \`\\n\` as end-of-line for paste handling, but treats \`\\x1b\\r\` (Meta-Enter) as the explicit "user typed multi-line break" signal. The Meta-Enter sequence is the documented unambiguous way.
- **Why active-tab gating for newline (not always-on)?** In a plain shell, \`Shift+Enter\` should be Enter (submit). Translating unconditionally would send \`\\x1b\\r\` (Meta-Enter) to bash/zsh, which readline interprets as a no-op by default but some users have remapped.
- **Why is line-editing always-on (not gated)?** \`⌥←\` etc. are universally expected on macOS regardless of whether you're in a shell or an agent. Apple Terminal / iTerm2 / Ghostty all do this unconditionally.
- **Cross-platform:** the line-edit chords are macOS-specific (\`⌘\` doesn't exist on Win/Linux). When the cross-platform path lands, \`Ctrl+←/→\` and \`Home/End\` map directly to readline via xterm.js's native CSI sequences, so this code only needs platform-gating then. Shift+Enter / Alt+Enter behave identically across browsers — agent newline is portable as-is.