### PR TITLE
feat(terminal): clickable links in terminal output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
+        "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
@@ -394,6 +395,8 @@
     "@xterm/addon-search": ["@xterm/addon-search@0.16.0", "", {}, "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA=="],
 
     "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.9.0", "", {}, "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="],
+
+    "@xterm/addon-web-links": ["@xterm/addon-web-links@0.11.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q=="],
 
     "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",
+    "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -1,7 +1,9 @@
 import { useStore } from '@nanostores/react'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { FitAddon } from '@xterm/addon-fit'
 import { SearchAddon } from '@xterm/addon-search'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
+import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { Terminal } from '@xterm/xterm'
 import React, { useEffect, useRef } from 'react'
@@ -104,10 +106,17 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     const fitAddon = new FitAddon()
     const unicode11Addon = new Unicode11Addon()
     const searchAddon = new SearchAddon()
+    // Custom click handler — the addon's default calls window.open(), which
+    // inside Tauri's webview either no-ops or hijacks the app window. Route
+    // through plugin-opener so URLs land in the OS default browser.
+    const webLinksAddon = new WebLinksAddon((_event, uri) => {
+      openUrl(uri).catch(() => {})
+    })
 
     term.loadAddon(fitAddon)
     term.loadAddon(unicode11Addon)
     term.loadAddon(searchAddon)
+    term.loadAddon(webLinksAddon)
     term.open(container)
 
     // Activate Unicode 11 after open() per addon docs.
@@ -212,6 +221,7 @@ export const XTermTerminal = React.memo(function XTermTerminal({
       searchAddon.dispose()
       fitAddon.dispose()
       unicode11Addon.dispose()
+      webLinksAddon.dispose()
       term.dispose()
       termRef.current = null
       fitAddonRef.current = null


### PR DESCRIPTION
## Summary
- Adds `@xterm/addon-web-links` to `XTermTerminal`, making URLs in terminal output underlined on hover and Cmd-clickable
- Routes the click through `@tauri-apps/plugin-opener` so links open in the OS default browser, not the Tauri webview (the addon's default `window.open` would otherwise hijack the app window inside Tauri)
- Disposes the addon alongside the existing addons on unmount

Matches the link-handling pattern already used by the PR badge in `SidebarTabItem.tsx`.

## Test plan
- [ ] `bun tauri dev` and run `echo "https://github.com/DaniAkash/agent-terminal"` — URL underlines on hover; Cmd-click opens it in the OS default browser, not the Tauri window
- [ ] Surrounding text isn't part of the link (`echo "Visit https://example.com for details"`)
- [ ] Real-world tool output works the same (`curl -sI https://example.com | head -1`, `npm install` registry URLs, etc.)
- [ ] Links printed by an agent tab (Claude Code / Codex) are clickable
- [ ] Drag-selecting across a URL still selects text rather than triggering the click
- [ ] Cmd+= / Cmd+- font-size changes — link decoration stays aligned after fit() recomputes glyph metrics