### PR TITLE
feat(drop): drag files into the active terminal

### DIFF
--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -26,6 +26,14 @@ export type XTermHandle = {
   searchNext: (opts?: { incremental?: boolean }) => void
   /** Jumps to the previous match for the current `$activeSearch` query. */
   searchPrevious: () => void
+  /**
+   * Writes data into the PTY as if the user typed it. Goes through the
+   * same `onData` channel xterm uses for keypresses, so it ends up at
+   * `IPC.writePty(tabKey, data)` via TerminalPane's `handleData`. Used
+   * by the file-drop flow and any future flow that injects text on
+   * the user's behalf.
+   */
+  sendToPty: (data: string) => void
 }
 
 type Props = {
@@ -199,6 +207,7 @@ export const XTermTerminal = React.memo(function XTermTerminal({
           regex: s.regex,
         })
       },
+      sendToPty: (data) => onDataRef.current(data),
     })
 
     return () => {

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -29,11 +29,24 @@ export type XTermHandle = {
   /**
    * Writes data into the PTY as if the user typed it. Goes through the
    * same `onData` channel xterm uses for keypresses, so it ends up at
-   * `IPC.writePty(tabKey, data)` via TerminalPane's `handleData`. Used
-   * by the file-drop flow and any future flow that injects text on
-   * the user's behalf.
+   * `IPC.writePty(tabKey, data)` via TerminalPane's `handleData`. Raw
+   * — no transformation. Use for flows that genuinely simulate typing
+   * (snippet expand, character-by-character autocomplete).
    */
   sendToPty: (data: string) => void
+  /**
+   * Writes data as a paste. If the running app has enabled bracketed
+   * paste mode (DECSET 2004 — Claude Code, Codex, modern shells all
+   * do), wraps the payload with `\x1b[200~` ... `\x1b[201~` so the
+   * app can distinguish paste from typed input. Without that, agents
+   * like Claude Code render dropped file paths as plain text instead
+   * of attaching them as `[image]`.
+   *
+   * If bracketed paste is off (e.g., raw `cat` waiting for input),
+   * sends unwrapped — otherwise the markers would appear as visible
+   * escape garbage.
+   */
+  pasteToPty: (data: string) => void
 }
 
 type Props = {
@@ -208,6 +221,13 @@ export const XTermTerminal = React.memo(function XTermTerminal({
         })
       },
       sendToPty: (data) => onDataRef.current(data),
+      pasteToPty: (data) => {
+        const term = termRef.current
+        if (!term) return
+        const wrap = term.modes.bracketedPasteMode
+        const payload = wrap ? `\x1b[200~${data}\x1b[201~` : data
+        onDataRef.current(payload)
+      },
     })
 
     return () => {

--- a/src/modules/dragDrop/dropPayload.ts
+++ b/src/modules/dragDrop/dropPayload.ts
@@ -1,0 +1,23 @@
+/**
+ * POSIX-shell-quotes a single path. Wraps in single quotes and escapes
+ * any single quotes inside as `'\''` (close, escape, reopen). Handles
+ * spaces, dollar signs, backticks, parentheses, glob characters —
+ * everything readline / a shell parser would otherwise interpret.
+ */
+export function shellQuote(path: string): string {
+  return `'${path.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * Formats one or more dropped file paths into a single string ready to
+ * write to the PTY. Each path is shell-quoted, multiple paths are
+ * space-separated, and a trailing space is appended so the user can
+ * keep typing afterward without manually adding the separator.
+ *
+ * Returns an empty string for an empty path list (caller can no-op
+ * cleanly without checking length).
+ */
+export function formatDropPayload(paths: readonly string[]): string {
+  if (paths.length === 0) return ''
+  return `${paths.map(shellQuote).join(' ')} `
+}

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -1,9 +1,11 @@
 import { useStore } from '@nanostores/react'
+import { getCurrentWebview } from '@tauri-apps/api/webview'
 import { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { Sidebar } from '@/components/Sidebar/Sidebar'
 import { StatusBar } from '@/components/StatusBar/StatusBar'
 import { TerminalSearchBar } from '@/components/TerminalSearchBar/TerminalSearchBar'
+import { formatDropPayload } from '@/modules/dragDrop/dropPayload'
 import { Keys, Mod } from '@/modules/keymap/keys'
 import { $activeSearch, openSearch } from '@/modules/stores/$activeSearch'
 import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
@@ -82,6 +84,26 @@ export function WorkspaceLayout() {
       window.removeEventListener('keydown', onKeyDown)
       window.removeEventListener('keyup', onKeyUp)
       window.removeEventListener('blur', onBlur)
+    }
+  }, [])
+
+  // File drag-drop — Tauri 2 captures the OS drop at the window level
+  // (default `dragDropEnabled: true`) and emits a JS event. On `drop` we
+  // shell-quote the paths and write them into the active terminal's PTY,
+  // which makes the experience identical to Apple Terminal / iTerm2 /
+  // Ghostty: the agent (Claude / Codex) or shell sees the path text and
+  // decides what to do with it.
+  useEffect(() => {
+    const unlistenPromise = getCurrentWebview().onDragDropEvent((event) => {
+      if (event.payload.type !== 'drop') return
+      const payload = formatDropPayload(event.payload.paths)
+      if (!payload) return
+      // No active terminal (e.g. no projects open yet) — drop silently.
+      // Same posture as the other global handlers.
+      $activeTerminalHandle.get()?.sendToPty(payload)
+    })
+    return () => {
+      unlistenPromise.then((fn) => fn()).catch(() => {})
     }
   }, [])
 

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -89,10 +89,12 @@ export function WorkspaceLayout() {
 
   // File drag-drop — Tauri 2 captures the OS drop at the window level
   // (default `dragDropEnabled: true`) and emits a JS event. On `drop` we
-  // shell-quote the paths and write them into the active terminal's PTY,
-  // which makes the experience identical to Apple Terminal / iTerm2 /
-  // Ghostty: the agent (Claude / Codex) or shell sees the path text and
-  // decides what to do with it.
+  // shell-quote the paths and paste them into the active terminal's PTY.
+  //
+  // `pasteToPty` (not `sendToPty`) wraps the payload in bracketed paste
+  // markers if the running app enabled them — Claude Code / Codex use
+  // that signal to distinguish paste from typed input and auto-attach
+  // image paths as [image] instead of inserting them as raw text.
   useEffect(() => {
     const unlistenPromise = getCurrentWebview().onDragDropEvent((event) => {
       if (event.payload.type !== 'drop') return
@@ -100,7 +102,7 @@ export function WorkspaceLayout() {
       if (!payload) return
       // No active terminal (e.g. no projects open yet) — drop silently.
       // Same posture as the other global handlers.
-      $activeTerminalHandle.get()?.sendToPty(payload)
+      $activeTerminalHandle.get()?.pasteToPty(payload)
     })
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {})


### PR DESCRIPTION
## Summary

Drag a file (or several) from Finder onto the agent-terminal window — the file paths get written into the active terminal's PTY as shell-quoted text, exactly as if you'd typed them. Claude Code / Codex auto-attach the path; the shell treats it as plain input.

Standard macOS-terminal UX (Apple Terminal, iTerm2, Ghostty, Warp all do this); silently broken in agent-terminal until now.

## How it works

1. Tauri 2 captures the OS file drop at the window level (default \`dragDropEnabled: true\`) and emits a JS event with the actual filesystem paths. The browser-level DOM drop event can't access paths on macOS due to webview sandboxing — so the Tauri event is the only way to get the real path text.
2. The handler reads \`\$activeTerminalHandle\`, formats the paths via a new POSIX shell-quoter, and calls \`handle.sendToPty(payload)\`.
3. \`sendToPty\` is a new method on \`XTermHandle\` that routes through the existing \`onData\` channel into \`IPC.writePty\` — same path xterm uses for keypresses.

## Files

- **New** \`src/modules/dragDrop/dropPayload.ts\` — pure helpers \`shellQuote\` + \`formatDropPayload\`. POSIX single-quote wrapping with the standard \`'\\''\` escape; handles spaces, quotes, globs, dollar signs.
- **Modified** \`src/components/XTermTerminal/XTermTerminal.tsx\` — \`XTermHandle\` gains \`sendToPty: (data) => onDataRef.current(data)\` (5 lines).
- **Modified** \`src/screens/workspace/WorkspaceLayout.tsx\` — one \`useEffect\` that subscribes to \`getCurrentWebview().onDragDropEvent\` (~15 lines).

No new dependencies, no Rust changes, no Tauri config changes.

## Why not as an xterm.js addon

Briefly considered. xterm.js addons are designed for terminal-scoped concerns (rendering, parsing, output). Our drop event is window-scoped — Tauri fires it once per window, but we have N panes and need to route to whichever is active. An addon would mean N subscriptions to the same global event, each instance asking "am I the active one?" — strictly more coordination than the current single-effect-in-WorkspaceLayout shape. The xterm.js community has discussed this in [issue #4956](https://github.com/xtermjs/xterm.js/issues/4956) and [discussion #4958](https://github.com/xtermjs/xterm.js/discussions/4958); both confirm there's no built-in addon for it and it has to live at the host-app layer.

## Test plan

- [ ] Open a project, focus a tab, drag one file from Finder onto the window — path appears in the terminal, properly quoted, with a trailing space.
- [ ] Drag a file with spaces in the name (e.g. \`My Doc.pdf\`) — appears as \`'/path/to/My Doc.pdf'\`.
- [ ] Drag a file with a single quote in the name — appears with \`'\\''\` escapes in the right places.
- [ ] Select multiple files in Finder, drag them all — space-separated quoted paths, single trailing space.
- [ ] Run \`claude\` in a tab. Drag an image file. Claude detects the path and offers to attach.
- [ ] Run \`codex\` in a tab. Same.
- [ ] In a plain shell (no agent), drag a file — path lands at the cursor; user can prefix with \`cat \` and hit Enter.
- [ ] Switch to another tab via \`⌘1..9\` / \`⌘⇧]\` and drag — lands in the now-active tab.
- [ ] No projects open — drop silently no-ops, no console errors.
- [ ] Drag across the window without dropping — no spurious writes.

## Notes

- **Active-tab routing**: drops go to whichever terminal is currently registered as active. Drop position is ignored for v1; when splits ship later, we can map \`event.payload.position\` to per-pane targets.
- **Shell quoting**: POSIX-only (single-quote wrapping). Works on bash/zsh/fish. When/if Windows ships, we'd add a platform branch.
- **Future**: drop-indicator overlay (highlight the active terminal's border while dragging) and per-pane targeting (when splits exist) — easy follow-ups, intentionally out of scope here.