### PR TITLE
fix(active-state): derive active terminal from navigation, not a stored slot

### DIFF
--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -54,17 +54,9 @@ export const TerminalPane = React.memo(function TerminalPane({
     }
   }, [isActive])
 
-  // Register this pane in the global handle registry while mounted.
-  // Registration is mount-scoped (NOT isActive-scoped) so the registry
-  // contains every live PTY. Which one is "active" is answered separately
-  // by `$activeTabKey`, derived from navigation state — that decoupling
-  // is what makes drag-drop / Cmd+F / Cmd+K target the right pane after
-  // arbitrary project-switching.
-  //
-  // The first run of this effect happens before xterm fires onReady, so
-  // `handleRef.current` is null and we no-op. `handleReady` (below) does
-  // the initial registration; this effect handles re-registration on
-  // tabKey change (rare — tabKey is stable per pane lifetime).
+  // Registry membership is mount-scoped, not isActive-scoped. First mount
+  // runs before xterm's onReady, so handleRef is null and we no-op;
+  // handleReady does the initial register.
   useEffect(() => {
     const handle = handleRef.current
     if (!handle) return
@@ -89,12 +81,6 @@ export const TerminalPane = React.memo(function TerminalPane({
   const handleReady = useCallback(
     (handle: XTermHandle) => {
       handleRef.current = handle
-      // First-paint registration: the mount effect above ran when
-      // handleRef was still null, so register the handle here now that
-      // xterm is ready. The race-safe identity guard inside
-      // unregisterTerminalHandle makes a double-call from StrictMode's
-      // dev double-fire safe — second call replaces the same entry, and
-      // unmount still cleans up the one and only slot.
       registerTerminalHandle(tabKey, handle)
 
       if (pendingOpens.has(tabKey)) return

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -6,7 +6,10 @@ import {
 } from '@/components/XTermTerminal/XTermTerminal'
 import { IPC } from '@/modules/ipc/commands'
 import { onPtyExit, onPtyRespawned } from '@/modules/ipc/events'
-import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
+import {
+  registerTerminalHandle,
+  unregisterTerminalHandle,
+} from '@/modules/stores/$activeTerminal'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
@@ -51,26 +54,25 @@ export const TerminalPane = React.memo(function TerminalPane({
     }
   }, [isActive])
 
-  // Register this terminal as the active one whenever its tab is visible.
-  // Global hotkeys (Cmd+K, Cmd+A, Cmd+F, Cmd+G) read from the registry to
-  // dispatch terminal-scoped actions. Race-safe clear: only nil out the
-  // slot if it still points at us.
+  // Register this pane in the global handle registry while mounted.
+  // Registration is mount-scoped (NOT isActive-scoped) so the registry
+  // contains every live PTY. Which one is "active" is answered separately
+  // by `$activeTabKey`, derived from navigation state — that decoupling
+  // is what makes drag-drop / Cmd+F / Cmd+K target the right pane after
+  // arbitrary project-switching.
   //
-  // The matching set call inside `handleReady` (below) covers the case
-  // where the pane mounts already-active and the handle isn't ready yet
-  // when this effect first runs. Without that, first-launch left the
-  // registry stuck at null until the user switched tabs.
+  // The first run of this effect happens before xterm fires onReady, so
+  // `handleRef.current` is null and we no-op. `handleReady` (below) does
+  // the initial registration; this effect handles re-registration on
+  // tabKey change (rare — tabKey is stable per pane lifetime).
   useEffect(() => {
-    if (!isActive) return
-    if (handleRef.current) {
-      $activeTerminalHandle.set(handleRef.current)
-    }
+    const handle = handleRef.current
+    if (!handle) return
+    registerTerminalHandle(tabKey, handle)
     return () => {
-      if ($activeTerminalHandle.get() === handleRef.current) {
-        $activeTerminalHandle.set(null)
-      }
+      unregisterTerminalHandle(tabKey, handle)
     }
-  }, [isActive])
+  }, [tabKey])
 
   // Called once when the xterm canvas is ready.
   //
@@ -87,12 +89,13 @@ export const TerminalPane = React.memo(function TerminalPane({
   const handleReady = useCallback(
     (handle: XTermHandle) => {
       handleRef.current = handle
-      // If this pane mounted already-active, the registration effect above
-      // ran before the handle existed. Catch up now so global hotkeys
-      // work on first launch without requiring a tab switch.
-      if (isActive) {
-        $activeTerminalHandle.set(handle)
-      }
+      // First-paint registration: the mount effect above ran when
+      // handleRef was still null, so register the handle here now that
+      // xterm is ready. The race-safe identity guard inside
+      // unregisterTerminalHandle makes a double-call from StrictMode's
+      // dev double-fire safe — second call replaces the same entry, and
+      // unmount still cleans up the one and only slot.
+      registerTerminalHandle(tabKey, handle)
 
       if (pendingOpens.has(tabKey)) return
       pendingOpens.add(tabKey)
@@ -110,7 +113,7 @@ export const TerminalPane = React.memo(function TerminalPane({
           pendingOpens.delete(tabKey)
         })
     },
-    [tabKey, cwd, isActive],
+    [tabKey, cwd],
   )
 
   const handleData = useCallback(

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -54,15 +54,18 @@ export const TerminalPane = React.memo(function TerminalPane({
     }
   }, [isActive])
 
-  // Registry membership is mount-scoped, not isActive-scoped. First mount
-  // runs before xterm's onReady, so handleRef is null and we no-op;
-  // handleReady does the initial register.
+  // Registry membership is mount-scoped, not isActive-scoped. The cleanup
+  // reads handleRef.current at teardown time — so an unmount AFTER a
+  // late handleReady registration still unregisters the handle, instead
+  // of leaking it.
   useEffect(() => {
-    const handle = handleRef.current
-    if (!handle) return
-    registerTerminalHandle(tabKey, handle)
+    if (handleRef.current) {
+      registerTerminalHandle(tabKey, handleRef.current)
+    }
     return () => {
-      unregisterTerminalHandle(tabKey, handle)
+      if (handleRef.current) {
+        unregisterTerminalHandle(tabKey, handleRef.current)
+      }
     }
   }, [tabKey])
 

--- a/src/components/TerminalSearchBar/TerminalSearchBar.tsx
+++ b/src/components/TerminalSearchBar/TerminalSearchBar.tsx
@@ -7,7 +7,7 @@ import {
   closeSearch,
   setSearchQuery,
 } from '@/modules/stores/$activeSearch'
-import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
+import { getActiveTerminalHandle } from '@/modules/stores/$activeTerminal'
 
 /**
  * Floating overlay that opens via Cmd+F over the active terminal. Drives
@@ -30,7 +30,7 @@ export function TerminalSearchBar() {
     () => {
       if (!search) return
       closeSearch()
-      $activeTerminalHandle.get()?.focus()
+      getActiveTerminalHandle()?.focus()
     },
     { enableOnFormTags: true, enabled: !!search },
   )
@@ -48,13 +48,13 @@ export function TerminalSearchBar() {
           // existing selection while the growing query still matches it,
           // so the highlight stays anchored to the current match instead
           // of bouncing forward through the buffer on every keystroke.
-          $activeTerminalHandle.get()?.searchNext({ incremental: true })
+          getActiveTerminalHandle()?.searchNext({ incremental: true })
         }}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             e.preventDefault()
-            if (e.shiftKey) $activeTerminalHandle.get()?.searchPrevious()
-            else $activeTerminalHandle.get()?.searchNext()
+            if (e.shiftKey) getActiveTerminalHandle()?.searchPrevious()
+            else getActiveTerminalHandle()?.searchNext()
           }
         }}
         className="w-48 bg-transparent text-sm outline-none"
@@ -62,7 +62,7 @@ export function TerminalSearchBar() {
       />
       <button
         type="button"
-        onClick={() => $activeTerminalHandle.get()?.searchPrevious()}
+        onClick={() => getActiveTerminalHandle()?.searchPrevious()}
         className="rounded px-1 text-xs hover:bg-accent"
         title="Previous (⇧⏎)"
         aria-label="Previous match"
@@ -71,7 +71,7 @@ export function TerminalSearchBar() {
       </button>
       <button
         type="button"
-        onClick={() => $activeTerminalHandle.get()?.searchNext()}
+        onClick={() => getActiveTerminalHandle()?.searchNext()}
         className="rounded px-1 text-xs hover:bg-accent"
         title="Next (⏎)"
         aria-label="Next match"
@@ -82,7 +82,7 @@ export function TerminalSearchBar() {
         type="button"
         onClick={() => {
           closeSearch()
-          $activeTerminalHandle.get()?.focus()
+          getActiveTerminalHandle()?.focus()
         }}
         className="rounded px-1 text-xs hover:bg-accent"
         title="Close (Esc)"

--- a/src/modules/stores/$activeTerminal.test.ts
+++ b/src/modules/stores/$activeTerminal.test.ts
@@ -177,34 +177,20 @@ describe('getActiveTerminalHandle()', () => {
     expect(getActiveTerminalHandle()).toBe(h)
   })
 
-  /**
-   * The headline test for this refactor. The single global atom on `main`
-   * fails this case: pane B's handle stays in the slot after switching
-   * back to project A because the registration effect was keyed on per-
-   * project `isActive`, which never flipped on project navigation.
-   *
-   * The structural fix makes this case correct *without any pane effect
-   * firing*: navigation alone updates `$activeTabKey`, and the lookup
-   * resolves through the registry that already holds both panes' handles.
-   */
   test('17: switching projects switches the active handle without re-registering panes', () => {
     const aHandle = fakeHandle()
     const bHandle = fakeHandle()
-    // Both panes registered once, at their respective mount time.
     registerTerminalHandle('claude-ui:dev', aHandle)
     registerTerminalHandle('api-service:logs', bHandle)
 
-    // Project A active → expect A's handle.
     $activeTabId.set({ 'claude-ui': 'dev', 'api-service': 'logs' })
     $activeProjectId.set('claude-ui')
     expect(getActiveTerminalHandle()).toBe(aHandle)
 
-    // Project B becomes active. Crucially: no register / unregister call
-    // happens here. The active handle must still update.
+    // Project flip alone — no register/unregister call in between.
     $activeProjectId.set('api-service')
     expect(getActiveTerminalHandle()).toBe(bHandle)
 
-    // Back to A. Same registry contents, same outcome — symmetric.
     $activeProjectId.set('claude-ui')
     expect(getActiveTerminalHandle()).toBe(aHandle)
   })

--- a/src/modules/stores/$activeTerminal.test.ts
+++ b/src/modules/stores/$activeTerminal.test.ts
@@ -1,0 +1,253 @@
+import { mock } from 'bun:test'
+
+// Mock IPC before any store imports — $navigation.ts pulls in $projects
+// which in turn touches IPC.saveProjects via persistence side effects.
+mock.module('@/modules/ipc/commands', () => ({
+  IPC: {
+    saveProjects: mock(() => Promise.resolve()),
+    closeTab: mock(() => Promise.resolve()),
+    openTab: mock(() => Promise.resolve(true)),
+    writePty: mock(() => Promise.resolve()),
+    resizePty: mock(() => Promise.resolve()),
+    listProjects: mock(() => Promise.resolve([])),
+  },
+}))
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+import type { XTermHandle } from '@/components/XTermTerminal/XTermTerminal'
+import {
+  $activeTabKey,
+  $terminalHandles,
+  getActiveTerminalHandle,
+  registerTerminalHandle,
+  unregisterTerminalHandle,
+} from '@/modules/stores/$activeTerminal'
+import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
+import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+
+// A handle is identified by reference, never by its method shape — the
+// registry uses object identity for race-safe unregistration. Factory
+// returns distinct objects with no behaviour; the registry never calls
+// any method during these unit tests.
+function fakeHandle(): XTermHandle {
+  return {
+    write: () => {},
+    focus: () => {},
+    clear: () => {},
+    selectAll: () => {},
+    searchNext: () => {},
+    searchPrevious: () => {},
+    sendToPty: () => {},
+    pasteToPty: () => {},
+  } as XTermHandle
+}
+
+beforeEach(() => {
+  $terminalHandles.set(new Map())
+  $activeProjectId.set('')
+  $activeTabId.set({})
+})
+
+/* ---------------------------------------------------------------------------
+ * $activeTabKey — derived, can't drift from navigation
+ * -------------------------------------------------------------------------*/
+describe('$activeTabKey', () => {
+  test('1: returns null when no project is selected', () => {
+    expect($activeTabKey.get()).toBeNull()
+  })
+
+  test('2: returns null when project has no active tab in the map', () => {
+    $activeProjectId.set('claude-ui')
+    expect($activeTabKey.get()).toBeNull()
+  })
+
+  test('3: returns null when project key is the empty string', () => {
+    // Defensive: $activeProjectId is typed as string and initialises to "".
+    // The derived store must treat that as "no selection," not as a real key.
+    $activeProjectId.set('')
+    $activeTabId.set({ '': 'something' })
+    expect($activeTabKey.get()).toBeNull()
+  })
+
+  test('4: returns the composite key when both nav stores are set', () => {
+    $activeProjectId.set('claude-ui')
+    $activeTabId.set({ 'claude-ui': 'dev' })
+    expect($activeTabKey.get()).toBe(makeTabKey('claude-ui', 'dev'))
+  })
+
+  test('5: re-derives when active project switches without touching the tab map', () => {
+    $activeTabId.set({ 'claude-ui': 'dev', 'api-service': 'logs' })
+    $activeProjectId.set('claude-ui')
+    expect($activeTabKey.get()).toBe('claude-ui:dev')
+    $activeProjectId.set('api-service')
+    expect($activeTabKey.get()).toBe('api-service:logs')
+  })
+
+  test('6: re-derives when active tab switches within the same project', () => {
+    $activeProjectId.set('claude-ui')
+    $activeTabId.set({ 'claude-ui': 'dev' })
+    expect($activeTabKey.get()).toBe('claude-ui:dev')
+    $activeTabId.set({ 'claude-ui': 'server' })
+    expect($activeTabKey.get()).toBe('claude-ui:server')
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * registerTerminalHandle / unregisterTerminalHandle
+ * -------------------------------------------------------------------------*/
+describe('register / unregister', () => {
+  test('7: register adds the handle under its tabKey', () => {
+    const h = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', h)
+    expect($terminalHandles.get().get('claude-ui:dev')).toBe(h)
+  })
+
+  test('8: register replaces an existing handle for the same key (idempotent on re-register)', () => {
+    const h1 = fakeHandle()
+    const h2 = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', h1)
+    registerTerminalHandle('claude-ui:dev', h2)
+    expect($terminalHandles.get().get('claude-ui:dev')).toBe(h2)
+  })
+
+  test('9: unregister removes the handle when identity matches', () => {
+    const h = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', h)
+    unregisterTerminalHandle('claude-ui:dev', h)
+    expect($terminalHandles.get().has('claude-ui:dev')).toBe(false)
+  })
+
+  test('10: unregister is a no-op when the slot holds a different handle (race-safe)', () => {
+    // Scenario: pane A registers, pane B remounts with the same key and
+    // registers BEFORE A's effect cleanup runs. When A's cleanup finally
+    // fires, it must NOT wipe B's handle.
+    const a = fakeHandle()
+    const b = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', a)
+    registerTerminalHandle('claude-ui:dev', b)
+    unregisterTerminalHandle('claude-ui:dev', a) // late cleanup from A
+    expect($terminalHandles.get().get('claude-ui:dev')).toBe(b)
+  })
+
+  test('11: unregister is a no-op when the key is not in the registry', () => {
+    const h = fakeHandle()
+    unregisterTerminalHandle('claude-ui:dev', h)
+    expect($terminalHandles.get().size).toBe(0)
+  })
+
+  test('12: multiple panes can be registered side-by-side', () => {
+    const a = fakeHandle()
+    const b = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', a)
+    registerTerminalHandle('api-service:logs', b)
+    expect($terminalHandles.get().size).toBe(2)
+    expect($terminalHandles.get().get('claude-ui:dev')).toBe(a)
+    expect($terminalHandles.get().get('api-service:logs')).toBe(b)
+  })
+
+  test('13: register / unregister swap the map identity so nanostores subscribers fire', () => {
+    // Mutating the existing Map in place would not flip the store's
+    // shallow-equality check. Each write must produce a new Map.
+    const before = $terminalHandles.get()
+    registerTerminalHandle('claude-ui:dev', fakeHandle())
+    const after = $terminalHandles.get()
+    expect(after).not.toBe(before)
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * getActiveTerminalHandle — composition of navigation + registry
+ * -------------------------------------------------------------------------*/
+describe('getActiveTerminalHandle()', () => {
+  test('14: returns null when no project is selected', () => {
+    expect(getActiveTerminalHandle()).toBeNull()
+  })
+
+  test('15: returns null when the active tab key has no entry in the registry', () => {
+    $activeProjectId.set('claude-ui')
+    $activeTabId.set({ 'claude-ui': 'dev' })
+    expect(getActiveTerminalHandle()).toBeNull()
+  })
+
+  test('16: returns the handle for the active tab key', () => {
+    const h = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', h)
+    $activeProjectId.set('claude-ui')
+    $activeTabId.set({ 'claude-ui': 'dev' })
+    expect(getActiveTerminalHandle()).toBe(h)
+  })
+
+  /**
+   * The headline test for this refactor. The single global atom on `main`
+   * fails this case: pane B's handle stays in the slot after switching
+   * back to project A because the registration effect was keyed on per-
+   * project `isActive`, which never flipped on project navigation.
+   *
+   * The structural fix makes this case correct *without any pane effect
+   * firing*: navigation alone updates `$activeTabKey`, and the lookup
+   * resolves through the registry that already holds both panes' handles.
+   */
+  test('17: switching projects switches the active handle without re-registering panes', () => {
+    const aHandle = fakeHandle()
+    const bHandle = fakeHandle()
+    // Both panes registered once, at their respective mount time.
+    registerTerminalHandle('claude-ui:dev', aHandle)
+    registerTerminalHandle('api-service:logs', bHandle)
+
+    // Project A active → expect A's handle.
+    $activeTabId.set({ 'claude-ui': 'dev', 'api-service': 'logs' })
+    $activeProjectId.set('claude-ui')
+    expect(getActiveTerminalHandle()).toBe(aHandle)
+
+    // Project B becomes active. Crucially: no register / unregister call
+    // happens here. The active handle must still update.
+    $activeProjectId.set('api-service')
+    expect(getActiveTerminalHandle()).toBe(bHandle)
+
+    // Back to A. Same registry contents, same outcome — symmetric.
+    $activeProjectId.set('claude-ui')
+    expect(getActiveTerminalHandle()).toBe(aHandle)
+  })
+
+  test('18: switching tabs within the same project switches the active handle without re-registering', () => {
+    const devHandle = fakeHandle()
+    const serverHandle = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', devHandle)
+    registerTerminalHandle('claude-ui:server', serverHandle)
+    $activeProjectId.set('claude-ui')
+
+    $activeTabId.set({ 'claude-ui': 'dev' })
+    expect(getActiveTerminalHandle()).toBe(devHandle)
+
+    $activeTabId.set({ 'claude-ui': 'server' })
+    expect(getActiveTerminalHandle()).toBe(serverHandle)
+  })
+
+  test('19: returns null after the active pane unregisters, even if the registry still has other handles', () => {
+    const aHandle = fakeHandle()
+    const bHandle = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', aHandle)
+    registerTerminalHandle('api-service:logs', bHandle)
+    $activeProjectId.set('claude-ui')
+    $activeTabId.set({ 'claude-ui': 'dev' })
+
+    unregisterTerminalHandle('claude-ui:dev', aHandle)
+    expect(getActiveTerminalHandle()).toBeNull()
+    // Sanity: B is still in the registry, just not the active one.
+    expect($terminalHandles.get().get('api-service:logs')).toBe(bHandle)
+  })
+
+  test('20: returns the new handle after a remount (register → unregister-stale → register again)', () => {
+    // Simulates StrictMode dev double-fire: handleReady runs twice, the
+    // intervening unregister carries the stale identity, and the final
+    // state must be the latest handle.
+    const stale = fakeHandle()
+    const fresh = fakeHandle()
+    registerTerminalHandle('claude-ui:dev', stale)
+    registerTerminalHandle('claude-ui:dev', fresh)
+    unregisterTerminalHandle('claude-ui:dev', stale) // stale cleanup runs late
+    $activeProjectId.set('claude-ui')
+    $activeTabId.set({ 'claude-ui': 'dev' })
+    expect(getActiveTerminalHandle()).toBe(fresh)
+  })
+})

--- a/src/modules/stores/$activeTerminal.test.ts
+++ b/src/modules/stores/$activeTerminal.test.ts
@@ -145,7 +145,35 @@ describe('register / unregister', () => {
     expect($terminalHandles.get().get('api-service:logs')).toBe(b)
   })
 
-  test('13: register / unregister swap the map identity so nanostores subscribers fire', () => {
+  test('13: TerminalPane lifecycle — deferred register followed by unmount cleanup clears the slot', () => {
+    // Mirrors TerminalPane: the mount effect runs before xterm fires
+    // onReady, so the handle ref is still null and the effect cannot
+    // register anything itself. handleReady registers later. The cleanup,
+    // captured at mount, must still unregister whatever was registered
+    // when it eventually runs at unmount — or the handle leaks.
+    const handleRef: { current: XTermHandle | null } = { current: null }
+
+    // 1. "Mount effect" runs — ref is null, nothing to do, but the
+    //    closure captures handleRef for the cleanup.
+    const cleanup = () => {
+      if (handleRef.current) {
+        unregisterTerminalHandle('claude-ui:dev', handleRef.current)
+      }
+    }
+
+    // 2. "handleReady" arrives — pane installs its handle and registers.
+    const h = fakeHandle()
+    handleRef.current = h
+    registerTerminalHandle('claude-ui:dev', h)
+    expect($terminalHandles.get().get('claude-ui:dev')).toBe(h)
+
+    // 3. "Unmount" — cleanup runs, reads the ref's CURRENT value (which
+    //    is now `h`), and unregisters.
+    cleanup()
+    expect($terminalHandles.get().has('claude-ui:dev')).toBe(false)
+  })
+
+  test('14: register / unregister swap the map identity so nanostores subscribers fire', () => {
     // Mutating the existing Map in place would not flip the store's
     // shallow-equality check. Each write must produce a new Map.
     const before = $terminalHandles.get()
@@ -159,17 +187,17 @@ describe('register / unregister', () => {
  * getActiveTerminalHandle — composition of navigation + registry
  * -------------------------------------------------------------------------*/
 describe('getActiveTerminalHandle()', () => {
-  test('14: returns null when no project is selected', () => {
+  test('15: returns null when no project is selected', () => {
     expect(getActiveTerminalHandle()).toBeNull()
   })
 
-  test('15: returns null when the active tab key has no entry in the registry', () => {
+  test('16: returns null when the active tab key has no entry in the registry', () => {
     $activeProjectId.set('claude-ui')
     $activeTabId.set({ 'claude-ui': 'dev' })
     expect(getActiveTerminalHandle()).toBeNull()
   })
 
-  test('16: returns the handle for the active tab key', () => {
+  test('17: returns the handle for the active tab key', () => {
     const h = fakeHandle()
     registerTerminalHandle('claude-ui:dev', h)
     $activeProjectId.set('claude-ui')
@@ -177,7 +205,7 @@ describe('getActiveTerminalHandle()', () => {
     expect(getActiveTerminalHandle()).toBe(h)
   })
 
-  test('17: switching projects switches the active handle without re-registering panes', () => {
+  test('18: switching projects switches the active handle without re-registering panes', () => {
     const aHandle = fakeHandle()
     const bHandle = fakeHandle()
     registerTerminalHandle('claude-ui:dev', aHandle)
@@ -195,7 +223,7 @@ describe('getActiveTerminalHandle()', () => {
     expect(getActiveTerminalHandle()).toBe(aHandle)
   })
 
-  test('18: switching tabs within the same project switches the active handle without re-registering', () => {
+  test('19: switching tabs within the same project switches the active handle without re-registering', () => {
     const devHandle = fakeHandle()
     const serverHandle = fakeHandle()
     registerTerminalHandle('claude-ui:dev', devHandle)
@@ -209,7 +237,7 @@ describe('getActiveTerminalHandle()', () => {
     expect(getActiveTerminalHandle()).toBe(serverHandle)
   })
 
-  test('19: returns null after the active pane unregisters, even if the registry still has other handles', () => {
+  test('20: returns null after the active pane unregisters, even if the registry still has other handles', () => {
     const aHandle = fakeHandle()
     const bHandle = fakeHandle()
     registerTerminalHandle('claude-ui:dev', aHandle)
@@ -223,7 +251,7 @@ describe('getActiveTerminalHandle()', () => {
     expect($terminalHandles.get().get('api-service:logs')).toBe(bHandle)
   })
 
-  test('20: returns the new handle after a remount (register → unregister-stale → register again)', () => {
+  test('21: returns the new handle after a remount (register → unregister-stale → register again)', () => {
     // Simulates StrictMode dev double-fire: handleReady runs twice, the
     // intervening unregister carries the stale identity, and the final
     // state must be the latest handle.

--- a/src/modules/stores/$activeTerminal.ts
+++ b/src/modules/stores/$activeTerminal.ts
@@ -3,22 +3,10 @@ import type { XTermHandle } from '@/components/XTermTerminal/XTermTerminal'
 import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
 import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
-/**
- * Registry of every mounted terminal pane's xterm handle, keyed by
- * `${projectId}:${tabId}`. Populated on TerminalPane mount, cleared on
- * unmount. NOT a record of which pane is "active" — that question is
- * answered by `$activeTabKey` below, which composes the navigation
- * stores. Keeping registration mount-scoped means the registry contains
- * every live PTY, which is the correct surface for addressing a specific
- * tab by id (e.g. notification-driven focus, cross-tab snippet send).
- */
+/** Every mounted pane's handle, keyed by `${projectId}:${tabId}`. */
 export const $terminalHandles = atom<Map<string, XTermHandle>>(new Map())
 
-/**
- * Authoritative `${projectId}:${tabId}` of the currently active terminal,
- * derived from navigation state. Cannot be written; cannot drift from
- * the navigation stores. Returns null when no project / tab is selected.
- */
+/** Active tab key derived from navigation; null when nothing is selected. */
 export const $activeTabKey = computed(
   [$activeProjectId, $activeTabId],
   (projectId, activeTabsByProject) => {
@@ -28,7 +16,6 @@ export const $activeTabKey = computed(
   },
 )
 
-/** Add or replace a handle in the registry, keyed by tab. */
 export function registerTerminalHandle(
   tabKey: string,
   handle: XTermHandle,
@@ -38,16 +25,12 @@ export function registerTerminalHandle(
   $terminalHandles.set(next)
 }
 
-/**
- * Remove a handle from the registry. Race-safe: only deletes the slot if
- * the recorded handle still matches the one being unregistered. Without
- * the identity guard a remount could overwrite the slot before the old
- * pane's cleanup runs, and the cleanup would wipe the new pane's handle.
- */
 export function unregisterTerminalHandle(
   tabKey: string,
   handle: XTermHandle,
 ): void {
+  // Identity guard: a same-key re-register can land before this cleanup
+  // runs; without the guard we'd wipe the newer handle.
   const current = $terminalHandles.get().get(tabKey)
   if (current !== handle) return
   const next = new Map($terminalHandles.get())
@@ -55,11 +38,6 @@ export function unregisterTerminalHandle(
   $terminalHandles.set(next)
 }
 
-/**
- * Snapshot lookup of the active terminal's handle. Composes the derived
- * `$activeTabKey` with the registry. Use from event handlers (hotkeys,
- * drag-drop) that need the value at the moment the event fires.
- */
 export function getActiveTerminalHandle(): XTermHandle | null {
   const key = $activeTabKey.get()
   if (!key) return null

--- a/src/modules/stores/$activeTerminal.ts
+++ b/src/modules/stores/$activeTerminal.ts
@@ -1,10 +1,67 @@
-import { atom } from 'nanostores'
+import { atom, computed } from 'nanostores'
 import type { XTermHandle } from '@/components/XTermTerminal/XTermTerminal'
+import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
+import { makeTabKey } from '@/screens/workspace/workspace.helpers'
 
 /**
- * Handle of the terminal whose tab is currently active and visible.
- * Set by TerminalPane when its `isActive` prop is true; cleared on unmount or
- * deactivation. Global hotkey handlers (Cmd+K, Cmd+A, Cmd+F) call into this
- * handle to dispatch terminal-scoped actions without threading refs.
+ * Registry of every mounted terminal pane's xterm handle, keyed by
+ * `${projectId}:${tabId}`. Populated on TerminalPane mount, cleared on
+ * unmount. NOT a record of which pane is "active" — that question is
+ * answered by `$activeTabKey` below, which composes the navigation
+ * stores. Keeping registration mount-scoped means the registry contains
+ * every live PTY, which is the correct surface for addressing a specific
+ * tab by id (e.g. notification-driven focus, cross-tab snippet send).
  */
-export const $activeTerminalHandle = atom<XTermHandle | null>(null)
+export const $terminalHandles = atom<Map<string, XTermHandle>>(new Map())
+
+/**
+ * Authoritative `${projectId}:${tabId}` of the currently active terminal,
+ * derived from navigation state. Cannot be written; cannot drift from
+ * the navigation stores. Returns null when no project / tab is selected.
+ */
+export const $activeTabKey = computed(
+  [$activeProjectId, $activeTabId],
+  (projectId, activeTabsByProject) => {
+    const tabId = activeTabsByProject[projectId]
+    if (!projectId || !tabId) return null
+    return makeTabKey(projectId, tabId)
+  },
+)
+
+/** Add or replace a handle in the registry, keyed by tab. */
+export function registerTerminalHandle(
+  tabKey: string,
+  handle: XTermHandle,
+): void {
+  const next = new Map($terminalHandles.get())
+  next.set(tabKey, handle)
+  $terminalHandles.set(next)
+}
+
+/**
+ * Remove a handle from the registry. Race-safe: only deletes the slot if
+ * the recorded handle still matches the one being unregistered. Without
+ * the identity guard a remount could overwrite the slot before the old
+ * pane's cleanup runs, and the cleanup would wipe the new pane's handle.
+ */
+export function unregisterTerminalHandle(
+  tabKey: string,
+  handle: XTermHandle,
+): void {
+  const current = $terminalHandles.get().get(tabKey)
+  if (current !== handle) return
+  const next = new Map($terminalHandles.get())
+  next.delete(tabKey)
+  $terminalHandles.set(next)
+}
+
+/**
+ * Snapshot lookup of the active terminal's handle. Composes the derived
+ * `$activeTabKey` with the registry. Use from event handlers (hotkeys,
+ * drag-drop) that need the value at the moment the event fires.
+ */
+export function getActiveTerminalHandle(): XTermHandle | null {
+  const key = $activeTabKey.get()
+  if (!key) return null
+  return $terminalHandles.get().get(key) ?? null
+}

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -8,7 +8,7 @@ import { TerminalSearchBar } from '@/components/TerminalSearchBar/TerminalSearch
 import { formatDropPayload } from '@/modules/dragDrop/dropPayload'
 import { Keys, Mod } from '@/modules/keymap/keys'
 import { $activeSearch, openSearch } from '@/modules/stores/$activeSearch'
-import { $activeTerminalHandle } from '@/modules/stores/$activeTerminal'
+import { getActiveTerminalHandle } from '@/modules/stores/$activeTerminal'
 import { popClosedTab } from '@/modules/stores/$closedTabs'
 import {
   decreaseFontSize,
@@ -102,7 +102,7 @@ export function WorkspaceLayout() {
       if (!payload) return
       // No active terminal (e.g. no projects open yet) — drop silently.
       // Same posture as the other global handlers.
-      $activeTerminalHandle.get()?.pasteToPty(payload)
+      getActiveTerminalHandle()?.pasteToPty(payload)
     })
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {})
@@ -225,14 +225,14 @@ export function WorkspaceLayout() {
   // ⌘K — clear screen + scrollback in the active terminal
   useHotkeys(
     `${Mod.Meta}+${Keys.K}`,
-    () => $activeTerminalHandle.get()?.clear(),
+    () => getActiveTerminalHandle()?.clear(),
     hotkeyOpts,
   )
 
   // ⌘A — select all in the active terminal
   useHotkeys(
     `${Mod.Meta}+${Keys.A}`,
-    () => $activeTerminalHandle.get()?.selectAll(),
+    () => getActiveTerminalHandle()?.selectAll(),
     hotkeyOpts,
   )
 
@@ -272,14 +272,14 @@ export function WorkspaceLayout() {
   useHotkeys(
     `${Mod.Meta}+${Keys.G}`,
     () => {
-      if ($activeSearch.get()) $activeTerminalHandle.get()?.searchNext()
+      if ($activeSearch.get()) getActiveTerminalHandle()?.searchNext()
     },
     hotkeyOpts,
   )
   useHotkeys(
     `${Mod.Meta}+${Mod.Shift}+${Keys.G}`,
     () => {
-      if ($activeSearch.get()) $activeTerminalHandle.get()?.searchPrevious()
+      if ($activeSearch.get()) getActiveTerminalHandle()?.searchPrevious()
     },
     hotkeyOpts,
   )

--- a/src/screens/workspace/WorkspaceView.tsx
+++ b/src/screens/workspace/WorkspaceView.tsx
@@ -37,10 +37,6 @@ export function WorkspaceView({ project }: Props) {
       <div className="relative min-h-0 flex-1 bg-terminal">
         {project.tabs.map((tab) => {
           if (!mounted.has(tab.id)) return null
-          // App-scoped: a pane is only "active" when ITS project is the active
-          // project AND it's that project's active tab. Without the project
-          // gate, panes in CSS-hidden projects keep claiming activity, which
-          // would mis-route auto-focus and any future isActive-keyed feature.
           const isActive =
             project.id === activeProjectId && tab.id === activeTabId
           return (

--- a/src/screens/workspace/WorkspaceView.tsx
+++ b/src/screens/workspace/WorkspaceView.tsx
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useEffect, useState } from 'react'
 import { TabBar } from '@/components/TabBar/TabBar'
 import { TerminalPane } from '@/components/TerminalPane/TerminalPane'
-import { $activeTabId } from '@/modules/stores/$navigation'
+import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
 import type { Project } from '@/screens/workspace/workspace.types'
 
 type Props = {
@@ -11,6 +11,7 @@ type Props = {
 
 export function WorkspaceView({ project }: Props) {
   const activeTabsByProject = useStore($activeTabId)
+  const activeProjectId = useStore($activeProjectId)
   // No fallback to project.tabs[0] here — tab selection is driven by
   // initNavigation() / navigateToProject() so the store is always authoritative.
   const activeTabId = activeTabsByProject[project.id] ?? ''
@@ -36,7 +37,12 @@ export function WorkspaceView({ project }: Props) {
       <div className="relative min-h-0 flex-1 bg-terminal">
         {project.tabs.map((tab) => {
           if (!mounted.has(tab.id)) return null
-          const isActive = tab.id === activeTabId
+          // App-scoped: a pane is only "active" when ITS project is the active
+          // project AND it's that project's active tab. Without the project
+          // gate, panes in CSS-hidden projects keep claiming activity, which
+          // would mis-route auto-focus and any future isActive-keyed feature.
+          const isActive =
+            project.id === activeProjectId && tab.id === activeTabId
           return (
             <div
               key={tab.id}


### PR DESCRIPTION
## Summary

Make the active-terminal answer **derived from navigation state**, not stored in a mutable slot that panes write to. Fixes drag-drop, ⌘F, ⌘K, ⌘A landing on the wrong terminal after switching between projects.

## Root cause

`$activeTerminalHandle` was a single mutable atom written by `TerminalPane` whenever its `isActive` prop was true. But `isActive` in `WorkspaceView` is computed **per-project** (`tab.id === activeTabId` for that project's own active tab map entry), with no awareness of `$activeProjectId`. Reproduction:

1. Open project A → pane A1's `isActive=true` → A1's handle written to the atom.
2. Open project B → B1's `isActive=true` → B1 overwrites the atom. A1 is still mounted (CSS-hidden) and its `isActive` is still `true`; cleanup does not run.
3. Switch back to A. `$activeProjectId` flips. **Neither pane's `isActive` changes.** Registration effect (deps `[isActive]`) does not re-fire. Atom still points to B1.
4. ⌘F / drag-drop → goes to B1, the hidden pane. ❌

The single mutable slot makes this a class of bug, not a one-off — every future global hotkey or terminal-targeted action would inherit it.

## Structural fix

- **Registry**, not slot — `$terminalHandles: Map<tabKey, XTermHandle>`, populated on `TerminalPane` mount, cleared on unmount. Holds every live PTY.
- **Derived active key** — `$activeTabKey` is `computed` from `$activeProjectId` + `$activeTabId`. Cannot be written; cannot drift.
- **Composition lookup** — `getActiveTerminalHandle()` resolves the active handle by looking up the derived key in the registry. Twelve call sites migrated.
- **App-scoped `isActive`** — `WorkspaceView` ANDs in `$activeProjectId` so auto-focus and any future `isActive`-keyed feature stop lying for hidden-project panes.

After the change, switching projects does not require any pane effect to re-fire — navigation alone updates `$activeTabKey`, and the lookup resolves through the registry that already holds both panes' handles.

## Files

- `src/modules/stores/$activeTerminal.ts` — rewrite
- `src/modules/stores/\$activeTerminal.test.ts` — 20 new tests
- `src/components/TerminalPane/TerminalPane.tsx` — register on mount, not on `isActive`
- `src/screens/workspace/WorkspaceView.tsx` — app-scope `isActive`
- `src/screens/workspace/WorkspaceLayout.tsx`, `src/components/TerminalSearchBar/TerminalSearchBar.tsx` — migrate read sites

## Test plan

- [x] \`bun test src/modules/stores/\$activeTerminal.test.ts\` — 20/20 pass, including the headline case "switching projects switches the active handle without re-registering panes"
- [x] \`bun test src/modules/stores/\$navigation.test.ts\` etc. — adjacent suites still green
- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` on changed files clean
- [ ] Manual QA — open project A tab → drop a file (lands in A). Open project B → drop (lands in B). Switch back to A → drop (lands in A, **broken on main**).
- [ ] Manual QA — same matrix for ⌘F search target, ⌘K clear, ⌘A select-all.
- [ ] Manual QA — open a never-visited project; first action against its tab targets that tab (validates first-paint registration via \`handleReady\`).
- [ ] Manual QA — close active tab, next ⌘F targets the new active tab, not stale state.
- [ ] Manual QA — auto-focus: switching to a tab puts cursor in its xterm canvas; switching to a previously-active project re-focuses its remembered tab (this is a new improvement enabled by the app-scoped \`isActive\`).