### PR TITLE
feat(status-bar): rich PR display with state icon, checks dot, tooltip

### DIFF
--- a/src-tauri/src/mod_engine/mods/git_monitor.rs
+++ b/src-tauri/src/mod_engine/mods/git_monitor.rs
@@ -54,24 +54,27 @@ impl GitMonitorMod {
     pub fn new() -> Self {
         Self { tabs: HashMap::new() }
     }
+}
 
-    /// Spawn a git query and, after it returns, update the per-tab refresh
-    /// cadence based on whether the PR has pending checks.
-    fn spawn_git_query(
-        &self,
-        cwd: String,
-        emitter: AsyncEmitter,
-        interval_tx: watch::Sender<u64>,
-    ) {
-        tokio::spawn(async move {
-            let data = query_git_info(&cwd).await;
-            let desired = desired_interval_secs(&data);
-            if *interval_tx.borrow() != desired {
-                let _ = interval_tx.send(desired);
-            }
-            emitter.emit("git_monitor", "git_info", data);
-        });
-    }
+/// Spawn a git query and, after it returns, update the per-tab refresh
+/// cadence based on whether the PR has pending checks.
+///
+/// Lives as a free function (not a `&self` method) so callers holding a
+/// `&mut GitTabState` from `self.tabs.get_mut(...)` can call it without
+/// triggering a `self` re-borrow conflict.
+fn spawn_git_query(
+    cwd: String,
+    emitter: AsyncEmitter,
+    interval_tx: watch::Sender<u64>,
+) {
+    tokio::spawn(async move {
+        let data = query_git_info(&cwd).await;
+        let desired = desired_interval_secs(&data);
+        if *interval_tx.borrow() != desired {
+            let _ = interval_tx.send(desired);
+        }
+        emitter.emit("git_monitor", "git_info", data);
+    });
 }
 
 impl Mod for GitMonitorMod {
@@ -223,7 +226,7 @@ impl Mod for GitMonitorMod {
 
         // Fire an immediate git query for the new directory.
         state.last_query_at = Some(Instant::now());
-        self.spawn_git_query(cwd.to_string(), ctx.async_emitter(), state.interval_tx.clone());
+        spawn_git_query(cwd.to_string(), ctx.async_emitter(), state.interval_tx.clone());
     }
 
     fn on_close(&mut self, ctx: &ModContext) {

--- a/src-tauri/src/mod_engine/mods/git_monitor.rs
+++ b/src-tauri/src/mod_engine/mods/git_monitor.rs
@@ -97,7 +97,12 @@ impl Mod for GitMonitorMod {
         //   - Reads the latest CWD from the watch receiver each tick.
         let timer = tokio::spawn(async move {
             loop {
-                let secs = *interval_rx.borrow();
+                // borrow_and_update advances the watch's seen pointer, so a
+                // `send` from the in-loop query below doesn't immediately
+                // resolve the `.changed()` future on the next iteration (which
+                // would trigger one redundant wake + `continue` per cadence
+                // change).
+                let secs = *interval_rx.borrow_and_update();
                 let sleep = tokio::time::sleep(tokio::time::Duration::from_secs(secs));
                 tokio::select! {
                     _ = sleep => {}
@@ -332,7 +337,7 @@ async fn run_gh_pr(root: &str) -> Option<serde_json::Value> {
 
     if output.status.success() {
         let raw: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
-        Some(transform_pr(raw))
+        transform_pr(raw)
     } else {
         None
     }
@@ -345,7 +350,16 @@ async fn run_gh_pr(root: &str) -> Option<serde_json::Value> {
 ///
 /// `mergedAt` disambiguates older `gh` versions that return `state: "CLOSED"`
 /// for merged PRs — when `mergedAt` is populated we treat the PR as merged.
-fn transform_pr(raw: serde_json::Value) -> serde_json::Value {
+///
+/// Returns `None` when `number`, `title`, or `url` are missing or the wrong
+/// JSON shape — the frontend's `PrInfo` type asserts those are non-null and
+/// we'd rather drop the pill than emit a misshapen payload that the UI then
+/// has to defensively guard against.
+fn transform_pr(raw: serde_json::Value) -> Option<serde_json::Value> {
+    let number = raw.get("number").and_then(|v| v.as_u64())?;
+    let title = raw.get("title").and_then(|v| v.as_str())?;
+    let url = raw.get("url").and_then(|v| v.as_str())?;
+
     let state = raw.get("state").and_then(|v| v.as_str()).unwrap_or("OPEN");
     let merged_at = raw.get("mergedAt").and_then(|v| v.as_str());
     let normalised_state = match (state, merged_at) {
@@ -360,14 +374,14 @@ fn transform_pr(raw: serde_json::Value) -> serde_json::Value {
         .and_then(|v| v.as_array())
         .map(|arr| summarise_checks(arr));
 
-    serde_json::json!({
-        "number": raw.get("number"),
-        "title": raw.get("title"),
+    Some(serde_json::json!({
+        "number": number,
+        "title": title,
         "state": normalised_state,
         "isDraft": raw.get("isDraft").and_then(|v| v.as_bool()).unwrap_or(false),
-        "url": raw.get("url"),
+        "url": url,
         "checks": checks,
-    })
+    }))
 }
 
 #[derive(Default)]
@@ -381,6 +395,12 @@ struct CheckCounts {
 /// Collapse a `statusCheckRollup` array into a 4-bucket counter. Handles both
 /// GitHub Actions check runs (state lives on `conclusion`/`status`) and
 /// external status contexts (state lives on `state`).
+///
+/// Failing-side coverage is exhaustive on purpose: `STARTUP_FAILURE` and
+/// `STALE` are real CheckRun conclusions that mean "the check broke" — if we
+/// dropped them, a broken CI would render a green dot. `EXPECTED` is a
+/// StatusContext sentinel for "a future check will be reported" and counts as
+/// pending.
 fn summarise_checks(items: &[serde_json::Value]) -> serde_json::Value {
     let mut c = CheckCounts::default();
     for item in items {
@@ -392,10 +412,16 @@ fn summarise_checks(items: &[serde_json::Value]) -> serde_json::Value {
             .unwrap_or("");
         match s {
             "SUCCESS" => c.passing += 1,
-            "FAILURE" | "ERROR" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" => {
-                c.failing += 1
+            "FAILURE"
+            | "ERROR"
+            | "CANCELLED"
+            | "TIMED_OUT"
+            | "ACTION_REQUIRED"
+            | "STARTUP_FAILURE"
+            | "STALE" => c.failing += 1,
+            "PENDING" | "IN_PROGRESS" | "QUEUED" | "WAITING" | "EXPECTED" => {
+                c.pending += 1
             }
-            "PENDING" | "IN_PROGRESS" | "QUEUED" | "WAITING" => c.pending += 1,
             "SKIPPED" | "NEUTRAL" => c.skipped += 1,
             _ => {}
         }
@@ -467,7 +493,7 @@ mod tests {
                 {"status": "IN_PROGRESS"},
             ],
         });
-        let out = transform_pr(raw);
+        let out = transform_pr(raw).expect("required fields present");
         assert_eq!(out["state"], "OPEN");
         assert_eq!(out["isDraft"], false);
         assert_eq!(out["number"], 42);
@@ -487,7 +513,7 @@ mod tests {
             "url": "u", "isDraft": false, "mergedAt": "2026-01-01T00:00:00Z",
             "statusCheckRollup": [],
         });
-        assert_eq!(transform_pr(raw)["state"], "MERGED");
+        assert_eq!(transform_pr(raw).unwrap()["state"], "MERGED");
     }
 
     #[test]
@@ -497,7 +523,7 @@ mod tests {
             "url": "u", "isDraft": false, "mergedAt": null,
             "statusCheckRollup": [],
         });
-        assert_eq!(transform_pr(raw)["state"], "CLOSED");
+        assert_eq!(transform_pr(raw).unwrap()["state"], "CLOSED");
     }
 
     #[test]
@@ -507,7 +533,7 @@ mod tests {
             "url": "u", "isDraft": false, "mergedAt": "2026-01-01T00:00:00Z",
             "statusCheckRollup": [],
         });
-        assert_eq!(transform_pr(raw)["state"], "MERGED");
+        assert_eq!(transform_pr(raw).unwrap()["state"], "MERGED");
     }
 
     #[test]
@@ -517,7 +543,7 @@ mod tests {
             "url": "u", "isDraft": false, "mergedAt": null,
             "statusCheckRollup": [],
         });
-        let out = transform_pr(raw);
+        let out = transform_pr(raw).expect("required fields present");
         assert_eq!(out["checks"]["total"], 0);
         assert_eq!(out["checks"]["passing"], 0);
     }
@@ -535,7 +561,7 @@ mod tests {
                 {"state": "FAILURE"},
             ],
         });
-        let out = transform_pr(raw);
+        let out = transform_pr(raw).expect("required fields present");
         assert_eq!(out["checks"]["passing"], 1);
         assert_eq!(out["checks"]["pending"], 1);
         assert_eq!(out["checks"]["failing"], 1);
@@ -549,7 +575,7 @@ mod tests {
             "url": "u", "isDraft": true, "mergedAt": null,
             "statusCheckRollup": [],
         });
-        let out = transform_pr(raw);
+        let out = transform_pr(raw).expect("required fields present");
         assert_eq!(out["state"], "OPEN");
         assert_eq!(out["isDraft"], true);
     }
@@ -561,7 +587,66 @@ mod tests {
             "url": "u", "mergedAt": null,
             "statusCheckRollup": [],
         });
-        assert_eq!(transform_pr(raw)["isDraft"], false);
+        assert_eq!(transform_pr(raw).unwrap()["isDraft"], false);
+    }
+
+    #[test]
+    fn missing_required_fields_returns_none() {
+        // Defence against future `gh` payload shape changes — frontend
+        // PrInfo asserts these are non-null, so drop the pill rather than
+        // emit a malformed payload.
+        let no_number = serde_json::json!({
+            "title": "t", "url": "u", "state": "OPEN", "isDraft": false,
+        });
+        let no_title = serde_json::json!({
+            "number": 1, "url": "u", "state": "OPEN", "isDraft": false,
+        });
+        let no_url = serde_json::json!({
+            "number": 1, "title": "t", "state": "OPEN", "isDraft": false,
+        });
+        let null_title = serde_json::json!({
+            "number": 1, "title": null, "url": "u", "state": "OPEN", "isDraft": false,
+        });
+        assert!(transform_pr(no_number).is_none());
+        assert!(transform_pr(no_title).is_none());
+        assert!(transform_pr(no_url).is_none());
+        assert!(transform_pr(null_title).is_none());
+    }
+
+    #[test]
+    fn startup_failure_and_stale_count_as_failing() {
+        // Defence against the silent-green-dot bug — if these fell through
+        // the match they'd disappear from the counter and a broken CI would
+        // show green.
+        let raw = serde_json::json!({
+            "number": 1, "title": "t", "state": "OPEN",
+            "url": "u", "isDraft": false, "mergedAt": null,
+            "statusCheckRollup": [
+                {"conclusion": "STARTUP_FAILURE"},
+                {"conclusion": "STALE"},
+            ],
+        });
+        let out = transform_pr(raw).expect("required fields present");
+        assert_eq!(out["checks"]["failing"], 2);
+        assert_eq!(out["checks"]["passing"], 0);
+        assert_eq!(out["checks"]["total"], 2);
+    }
+
+    #[test]
+    fn expected_status_counts_as_pending() {
+        // `EXPECTED` is the StatusContext sentinel for "a future check will
+        // be reported"; it should keep the dot yellow, not green.
+        let raw = serde_json::json!({
+            "number": 1, "title": "t", "state": "OPEN",
+            "url": "u", "isDraft": false, "mergedAt": null,
+            "statusCheckRollup": [
+                {"state": "SUCCESS"},
+                {"state": "EXPECTED"},
+            ],
+        });
+        let out = transform_pr(raw).expect("required fields present");
+        assert_eq!(out["checks"]["passing"], 1);
+        assert_eq!(out["checks"]["pending"], 1);
     }
 
     #[test]
@@ -576,7 +661,7 @@ mod tests {
                 {"conclusion": "BRAND_NEW_STATE_FROM_FUTURE_GH"},
             ],
         });
-        let out = transform_pr(raw);
+        let out = transform_pr(raw).expect("required fields present");
         assert_eq!(out["checks"]["passing"], 1);
         assert_eq!(out["checks"]["total"], 1);
     }

--- a/src-tauri/src/mod_engine/mods/git_monitor.rs
+++ b/src-tauri/src/mod_engine/mods/git_monitor.rs
@@ -5,10 +5,21 @@ use crate::mod_engine::{AsyncEmitter, Mod, ModContext};
 use crate::mod_engine::osc_parser::OscParser;
 use tokio::sync::watch;
 
+/// Baseline refresh interval when no PR checks are pending.
+const REFRESH_BASELINE_SECS: u64 = 60;
+
+/// Faster refresh interval used while a PR has pending checks. Keeps the
+/// status bar responsive during active CI runs without spawning a separate
+/// polling task.
+const REFRESH_PENDING_CHECKS_SECS: u64 = 15;
+
 struct GitTabState {
     last_queried_cwd: Option<String>,
-    /// Watch sender: updated on each on_cwd_changed; the 60s timer reads the receiver.
+    /// Watch sender: updated on each on_cwd_changed; the refresh timer reads the receiver.
     cwd_tx: watch::Sender<Option<String>>,
+    /// Watch sender for the desired refresh cadence. Flips between the
+    /// baseline and the pending-checks interval as PR state evolves.
+    interval_tx: watch::Sender<u64>,
     timer: Option<tokio::task::JoinHandle<()>>,
     /// OSC 133 parser — detects command-done sequences to trigger immediate git refresh.
     osc_parser: OscParser,
@@ -21,11 +32,18 @@ struct GitTabState {
 /// Triggers:
 /// 1. CWD change (received via `on_cwd_changed` push from the engine)
 /// 2. Command done — OSC 133;D fired by the shell after any command exits
-/// 3. 60-second periodic refresh timer (fallback for shells without OSC 133)
+/// 3. Adaptive periodic refresh timer: 60s baseline, 15s while a PR has
+///    pending CI checks (fallback for shells without OSC 133, and what
+///    drives status bar updates while the user isn't typing)
 ///
 /// Trigger 2 fixes the common case where a command like `git push` or `git pull`
-/// changes remote tracking state without changing the CWD. The 60-second timer
+/// changes remote tracking state without changing the CWD. The periodic timer
 /// remains as a safety net but should rarely be the first to catch an update.
+///
+/// Trigger 3's cadence is dynamic so that PR check transitions
+/// (queued → running → pass/fail) surface within ~15s during CI, instead of
+/// waiting up to 60s. Once `checks.pending` reaches zero the timer collapses
+/// back to the baseline — no extra `gh` calls while CI is idle.
 ///
 /// Emits `git_info` events with branch, ahead/behind, dirty, worktree, and PR.
 pub struct GitMonitorMod {
@@ -37,9 +55,20 @@ impl GitMonitorMod {
         Self { tabs: HashMap::new() }
     }
 
-    fn spawn_git_query(&self, cwd: String, emitter: AsyncEmitter) {
+    /// Spawn a git query and, after it returns, update the per-tab refresh
+    /// cadence based on whether the PR has pending checks.
+    fn spawn_git_query(
+        &self,
+        cwd: String,
+        emitter: AsyncEmitter,
+        interval_tx: watch::Sender<u64>,
+    ) {
         tokio::spawn(async move {
             let data = query_git_info(&cwd).await;
+            let desired = desired_interval_secs(&data);
+            if *interval_tx.borrow() != desired {
+                let _ = interval_tx.send(desired);
+            }
             emitter.emit("git_monitor", "git_info", data);
         });
     }
@@ -52,17 +81,40 @@ impl Mod for GitMonitorMod {
 
     fn on_open(&mut self, ctx: &ModContext) {
         let (cwd_tx, cwd_rx) = watch::channel::<Option<String>>(None);
+        let (interval_tx, mut interval_rx) = watch::channel::<u64>(REFRESH_BASELINE_SECS);
         let emitter = ctx.async_emitter();
+        let interval_tx_for_timer = interval_tx.clone();
 
-        // 60-second periodic refresh: reads the latest CWD from the watch receiver.
+        // Adaptive periodic refresh:
+        //   - Sleeps for the current desired interval (baseline 60s, or 15s
+        //     while PR checks are pending). The interval is re-read on every
+        //     loop iteration AND we wake early on `interval_rx.changed()` so
+        //     transitioning from idle → pending checks doesn't wait out a
+        //     full 60s before catching up.
+        //   - Reads the latest CWD from the watch receiver each tick.
         let timer = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
-            interval.tick().await; // skip immediate tick
             loop {
-                interval.tick().await;
+                let secs = *interval_rx.borrow();
+                let sleep = tokio::time::sleep(tokio::time::Duration::from_secs(secs));
+                tokio::select! {
+                    _ = sleep => {}
+                    // Cadence changed — re-loop without firing a query so we
+                    // pick up the new interval on the next iteration. Without
+                    // this, going from 60s to 15s would still wait 60s once.
+                    res = interval_rx.changed() => {
+                        if res.is_err() {
+                            return; // sender dropped — module closed
+                        }
+                        continue;
+                    }
+                }
                 let cwd = cwd_rx.borrow().clone();
                 if let Some(cwd) = cwd {
                     let data = query_git_info(&cwd).await;
+                    let desired = desired_interval_secs(&data);
+                    if *interval_tx_for_timer.borrow() != desired {
+                        let _ = interval_tx_for_timer.send(desired);
+                    }
                     emitter.emit("git_monitor", "git_info", data);
                 }
             }
@@ -73,6 +125,7 @@ impl Mod for GitMonitorMod {
             GitTabState {
                 last_queried_cwd: None,
                 cwd_tx,
+                interval_tx,
                 timer: Some(timer),
                 osc_parser: OscParser::new(),
                 last_query_at: None,
@@ -133,6 +186,7 @@ impl Mod for GitMonitorMod {
         // output chunk updating the watch via on_cwd_changed).
         let mut cwd_rx = state.cwd_tx.subscribe();
         let emitter = ctx.async_emitter();
+        let interval_tx = state.interval_tx.clone();
         tokio::spawn(async move {
             // Yield briefly so the engine can process any OSC 7 that arrived
             // in the same PTY chunk as the OSC 133;D. After this sleep the
@@ -144,6 +198,10 @@ impl Mod for GitMonitorMod {
             let cwd = cwd_rx.borrow_and_update().clone();
             if let Some(cwd) = cwd {
                 let data = query_git_info(&cwd).await;
+                let desired = desired_interval_secs(&data);
+                if *interval_tx.borrow() != desired {
+                    let _ = interval_tx.send(desired);
+                }
                 emitter.emit("git_monitor", "git_info", data);
             }
         });
@@ -160,12 +218,12 @@ impl Mod for GitMonitorMod {
         }
         state.last_queried_cwd = Some(cwd.to_string());
 
-        // Update the watch sender so the 60s timer picks up the new CWD.
+        // Update the watch sender so the periodic timer picks up the new CWD.
         let _ = state.cwd_tx.send(Some(cwd.to_string()));
 
         // Fire an immediate git query for the new directory.
         state.last_query_at = Some(Instant::now());
-        self.spawn_git_query(cwd.to_string(), ctx.async_emitter());
+        self.spawn_git_query(cwd.to_string(), ctx.async_emitter(), state.interval_tx.clone());
     }
 
     fn on_close(&mut self, ctx: &ModContext) {
@@ -174,6 +232,23 @@ impl Mod for GitMonitorMod {
                 handle.abort();
             }
         }
+    }
+}
+
+/// Decide the next refresh interval based on the just-emitted git payload.
+/// Pending PR checks earn the faster cadence; everything else uses the
+/// baseline.
+fn desired_interval_secs(payload: &serde_json::Value) -> u64 {
+    let pending = payload
+        .get("pr")
+        .and_then(|pr| pr.get("checks"))
+        .and_then(|c| c.get("pending"))
+        .and_then(|p| p.as_u64())
+        .unwrap_or(0);
+    if pending > 0 {
+        REFRESH_PENDING_CHECKS_SECS
+    } else {
+        REFRESH_BASELINE_SECS
     }
 }
 
@@ -234,9 +309,17 @@ async fn run_git(args: &[&str], cwd: &str) -> Option<String> {
 
 async fn run_gh_pr(root: &str) -> Option<serde_json::Value> {
     let output = tokio::time::timeout(
+        // statusCheckRollup adds ~100-200ms over the bare 4-field query but
+        // stays well within the 5s timeout. The extra fields keep the PR
+        // pill's checks dot + tooltip breakdown coming through the same call.
         tokio::time::Duration::from_secs(5),
         tokio::process::Command::new("gh")
-            .args(["pr", "view", "--json", "number,title,state,url"])
+            .args([
+                "pr",
+                "view",
+                "--json",
+                "number,title,state,url,isDraft,mergedAt,statusCheckRollup",
+            ])
             .current_dir(root)
             .output(),
     )
@@ -245,10 +328,83 @@ async fn run_gh_pr(root: &str) -> Option<serde_json::Value> {
     .and_then(|r| r.ok())?;
 
     if output.status.success() {
-        serde_json::from_slice(&output.stdout).ok()
+        let raw: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+        Some(transform_pr(raw))
     } else {
         None
     }
+}
+
+/// Reduce the verbose `gh pr view` payload to the compact shape the frontend
+/// consumes. Collapses `statusCheckRollup` (variable-length array) into a
+/// 4-bucket counter, normalises state to `OPEN | MERGED | CLOSED`, and drops
+/// every field the UI doesn't use so the IPC payload stays small.
+///
+/// `mergedAt` disambiguates older `gh` versions that return `state: "CLOSED"`
+/// for merged PRs — when `mergedAt` is populated we treat the PR as merged.
+fn transform_pr(raw: serde_json::Value) -> serde_json::Value {
+    let state = raw.get("state").and_then(|v| v.as_str()).unwrap_or("OPEN");
+    let merged_at = raw.get("mergedAt").and_then(|v| v.as_str());
+    let normalised_state = match (state, merged_at) {
+        ("MERGED", _) => "MERGED",
+        ("CLOSED", Some(_)) => "MERGED",
+        ("CLOSED", _) => "CLOSED",
+        _ => "OPEN",
+    };
+
+    let checks = raw
+        .get("statusCheckRollup")
+        .and_then(|v| v.as_array())
+        .map(|arr| summarise_checks(arr));
+
+    serde_json::json!({
+        "number": raw.get("number"),
+        "title": raw.get("title"),
+        "state": normalised_state,
+        "isDraft": raw.get("isDraft").and_then(|v| v.as_bool()).unwrap_or(false),
+        "url": raw.get("url"),
+        "checks": checks,
+    })
+}
+
+#[derive(Default)]
+struct CheckCounts {
+    passing: u32,
+    failing: u32,
+    pending: u32,
+    skipped: u32,
+}
+
+/// Collapse a `statusCheckRollup` array into a 4-bucket counter. Handles both
+/// GitHub Actions check runs (state lives on `conclusion`/`status`) and
+/// external status contexts (state lives on `state`).
+fn summarise_checks(items: &[serde_json::Value]) -> serde_json::Value {
+    let mut c = CheckCounts::default();
+    for item in items {
+        let s = item
+            .get("conclusion")
+            .and_then(|v| v.as_str())
+            .or_else(|| item.get("status").and_then(|v| v.as_str()))
+            .or_else(|| item.get("state").and_then(|v| v.as_str()))
+            .unwrap_or("");
+        match s {
+            "SUCCESS" => c.passing += 1,
+            "FAILURE" | "ERROR" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" => {
+                c.failing += 1
+            }
+            "PENDING" | "IN_PROGRESS" | "QUEUED" | "WAITING" => c.pending += 1,
+            "SKIPPED" | "NEUTRAL" => c.skipped += 1,
+            _ => {}
+        }
+    }
+    let total = c.passing + c.failing + c.pending + c.skipped;
+    serde_json::json!({
+        "passing": c.passing,
+        "failing": c.failing,
+        "pending": c.pending,
+        "skipped": c.skipped,
+        "total": total,
+    })
 }
 
 /// Parse `git rev-list --count --left-right` output format: `"ahead\tbehind"`.
@@ -286,4 +442,170 @@ fn parse_worktree_name(output: &str, root: &str) -> Option<String> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transforms_open_pr_with_mixed_checks() {
+        let raw = serde_json::json!({
+            "number": 42,
+            "title": "Fix login",
+            "state": "OPEN",
+            "url": "https://github.com/o/r/pull/42",
+            "isDraft": false,
+            "mergedAt": null,
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS"},
+                {"conclusion": "FAILURE"},
+                {"conclusion": "SKIPPED"},
+                {"status": "IN_PROGRESS"},
+            ],
+        });
+        let out = transform_pr(raw);
+        assert_eq!(out["state"], "OPEN");
+        assert_eq!(out["isDraft"], false);
+        assert_eq!(out["number"], 42);
+        assert_eq!(out["title"], "Fix login");
+        assert_eq!(out["url"], "https://github.com/o/r/pull/42");
+        assert_eq!(out["checks"]["passing"], 1);
+        assert_eq!(out["checks"]["failing"], 1);
+        assert_eq!(out["checks"]["pending"], 1);
+        assert_eq!(out["checks"]["skipped"], 1);
+        assert_eq!(out["checks"]["total"], 4);
+    }
+
+    #[test]
+    fn collapses_closed_with_merged_at_to_merged() {
+        let raw = serde_json::json!({
+            "number": 1, "title": "t", "state": "CLOSED",
+            "url": "u", "isDraft": false, "mergedAt": "2026-01-01T00:00:00Z",
+            "statusCheckRollup": [],
+        });
+        assert_eq!(transform_pr(raw)["state"], "MERGED");
+    }
+
+    #[test]
+    fn closed_without_merged_at_stays_closed() {
+        let raw = serde_json::json!({
+            "number": 1, "title": "t", "state": "CLOSED",
+            "url": "u", "isDraft": false, "mergedAt": null,
+            "statusCheckRollup": [],
+        });
+        assert_eq!(transform_pr(raw)["state"], "CLOSED");
+    }
+
+    #[test]
+    fn merged_state_passes_through() {
+        let raw = serde_json::json!({
+            "number": 1, "title": "t", "state": "MERGED",
+            "url": "u", "isDraft": false, "mergedAt": "2026-01-01T00:00:00Z",
+            "statusCheckRollup": [],
+        });
+        assert_eq!(transform_pr(raw)["state"], "MERGED");
+    }
+
+    #[test]
+    fn empty_rollup_returns_zero_counts() {
+        let raw = serde_json::json!({
+            "number": 1, "title": "t", "state": "OPEN",
+            "url": "u", "isDraft": false, "mergedAt": null,
+            "statusCheckRollup": [],
+        });
+        let out = transform_pr(raw);
+        assert_eq!(out["checks"]["total"], 0);
+        assert_eq!(out["checks"]["passing"], 0);
+    }
+
+    #[test]
+    fn external_status_state_field_classified() {
+        // External status contexts (e.g. Vercel deployment) report via the
+        // `state` field, not `conclusion`.
+        let raw = serde_json::json!({
+            "number": 1, "title": "t", "state": "OPEN",
+            "url": "u", "isDraft": false, "mergedAt": null,
+            "statusCheckRollup": [
+                {"state": "SUCCESS"},
+                {"state": "PENDING"},
+                {"state": "FAILURE"},
+            ],
+        });
+        let out = transform_pr(raw);
+        assert_eq!(out["checks"]["passing"], 1);
+        assert_eq!(out["checks"]["pending"], 1);
+        assert_eq!(out["checks"]["failing"], 1);
+        assert_eq!(out["checks"]["total"], 3);
+    }
+
+    #[test]
+    fn draft_flag_preserved() {
+        let raw = serde_json::json!({
+            "number": 7, "title": "wip", "state": "OPEN",
+            "url": "u", "isDraft": true, "mergedAt": null,
+            "statusCheckRollup": [],
+        });
+        let out = transform_pr(raw);
+        assert_eq!(out["state"], "OPEN");
+        assert_eq!(out["isDraft"], true);
+    }
+
+    #[test]
+    fn missing_isdraft_defaults_to_false() {
+        let raw = serde_json::json!({
+            "number": 7, "title": "t", "state": "OPEN",
+            "url": "u", "mergedAt": null,
+            "statusCheckRollup": [],
+        });
+        assert_eq!(transform_pr(raw)["isDraft"], false);
+    }
+
+    #[test]
+    fn unknown_check_state_dropped_from_buckets() {
+        // A future `gh` adding a new conclusion enum should not crash or
+        // miscategorise — unrecognised values are simply skipped.
+        let raw = serde_json::json!({
+            "number": 1, "title": "t", "state": "OPEN",
+            "url": "u", "isDraft": false, "mergedAt": null,
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS"},
+                {"conclusion": "BRAND_NEW_STATE_FROM_FUTURE_GH"},
+            ],
+        });
+        let out = transform_pr(raw);
+        assert_eq!(out["checks"]["passing"], 1);
+        assert_eq!(out["checks"]["total"], 1);
+    }
+
+    #[test]
+    fn desired_interval_uses_baseline_when_no_pr() {
+        let payload = serde_json::json!({"branch": "main"});
+        assert_eq!(desired_interval_secs(&payload), REFRESH_BASELINE_SECS);
+    }
+
+    #[test]
+    fn desired_interval_uses_baseline_when_no_checks() {
+        let payload = serde_json::json!({
+            "pr": {
+                "number": 1, "title": "t", "state": "OPEN", "isDraft": false, "url": "u",
+                "checks": {
+                    "passing": 5, "failing": 0, "pending": 0, "skipped": 0, "total": 5,
+                },
+            },
+        });
+        assert_eq!(desired_interval_secs(&payload), REFRESH_BASELINE_SECS);
+    }
+
+    #[test]
+    fn desired_interval_switches_to_pending_cadence() {
+        let payload = serde_json::json!({"pr": {"checks": {"pending": 2}}});
+        assert_eq!(desired_interval_secs(&payload), REFRESH_PENDING_CHECKS_SECS);
+    }
+
+    #[test]
+    fn desired_interval_handles_null_pr() {
+        let payload = serde_json::json!({"pr": null});
+        assert_eq!(desired_interval_secs(&payload), REFRESH_BASELINE_SECS);
+    }
 }

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -1,7 +1,6 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { Pin } from 'lucide-react'
 import type React from 'react'
 import { useEffect, useRef, useState } from 'react'
@@ -43,7 +42,6 @@ export function SidebarTabItem({
   const isActive =
     activeProjectId === projectId && activeTabsByProject[projectId] === tab.id
   const tabMeta = allTabMeta[makeTabKey(projectId, tab.id)]
-  const prUrl = tabMeta?.git?.pr?.url
   const [renaming, setRenaming] = useState(false)
 
   const {
@@ -142,27 +140,13 @@ export function SidebarTabItem({
 
             {/*
              * Right-side indicators, left to right:
-             *   PR link → DangerBadge → StatusIcon
+             *   DangerBadge → StatusIcon
              *
              * DangerBadge sits immediately left of the status icon so it reads
              * as "this agent is running hot" rather than a separate entity.
-             * PR link comes before danger so it groups with the label content.
+             * PR info now lives in the status bar (StatusBarRight → PrItem)
+             * where there's room for a state icon, checks dot, and tooltip.
              */}
-            {!renaming && tabMeta?.git?.pr && prUrl && (
-              <a
-                href={prUrl}
-                className="shrink-0 rounded px-1 text-[9.5px] text-accent opacity-70 hover:opacity-100"
-                style={{ fontFamily: MONO_FONT }}
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => {
-                  e.preventDefault()
-                  e.stopPropagation()
-                  openUrl(prUrl).catch(() => {})
-                }}
-              >
-                #{tabMeta.git.pr.number}
-              </a>
-            )}
             {!renaming &&
               tabMeta?.type === 'agent' &&
               hasDangerFlag(tabMeta.agentCmd) && <DangerBadge size={11} />}

--- a/src/components/StatusBar/PrItem.test.ts
+++ b/src/components/StatusBar/PrItem.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   checksColor,
+  stateColor,
   stateLabel,
   truncate,
 } from '@/components/StatusBar/PrItem'
@@ -66,6 +67,34 @@ describe('stateLabel', () => {
 
   test('closed reads as "closed"', () => {
     expect(stateLabel(pr({ state: 'CLOSED' }))).toBe('closed')
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * stateColor — maps to the github.com Primer palette for familiarity
+ * -------------------------------------------------------------------------*/
+
+describe('stateColor', () => {
+  test('open non-draft → pr-open (green)', () => {
+    expect(stateColor(pr())).toBe('var(--pr-open)')
+  })
+
+  test('open + isDraft → pr-draft (grey)', () => {
+    expect(stateColor(pr({ isDraft: true }))).toBe('var(--pr-draft)')
+  })
+
+  test('merged → pr-merged (purple); wins over isDraft', () => {
+    expect(stateColor(pr({ state: 'MERGED' }))).toBe('var(--pr-merged)')
+    expect(stateColor(pr({ state: 'MERGED', isDraft: true }))).toBe(
+      'var(--pr-merged)',
+    )
+  })
+
+  test('closed → pr-closed (red); wins over isDraft', () => {
+    expect(stateColor(pr({ state: 'CLOSED' }))).toBe('var(--pr-closed)')
+    expect(stateColor(pr({ state: 'CLOSED', isDraft: true }))).toBe(
+      'var(--pr-closed)',
+    )
   })
 })
 

--- a/src/components/StatusBar/PrItem.test.ts
+++ b/src/components/StatusBar/PrItem.test.ts
@@ -32,6 +32,24 @@ describe('truncate', () => {
     expect(truncated.length).toBe(40)
     expect(truncated.endsWith('…')).toBe(true)
   })
+
+  test('does not split surrogate pairs at the truncation boundary', () => {
+    // 🚀 is U+1F680 — a single code point made of two UTF-16 code units.
+    // Pre-fix: slicing by .length would cut between the high and low
+    // surrogate and produce a stray replacement character before the
+    // ellipsis. Post-fix: code-point-based slicing keeps the emoji intact.
+    const titleWithEmoji = `${'a'.repeat(5)}🚀${'b'.repeat(10)}`
+    const truncated = truncate(titleWithEmoji, 7)
+    // First 6 code points (5 'a's + 🚀) then ellipsis = 7 code points total.
+    expect(truncated).toBe(`${'a'.repeat(5)}🚀…`)
+    expect(Array.from(truncated).length).toBe(7)
+    // Crucially: no replacement character (U+FFFD) introduced.
+    expect(truncated.includes('�')).toBe(false)
+  })
+
+  test('short emoji-laden titles pass through unchanged', () => {
+    expect(truncate('🚀🎉✨', 10)).toBe('🚀🎉✨')
+  })
 })
 
 /* ---------------------------------------------------------------------------

--- a/src/components/StatusBar/PrItem.test.ts
+++ b/src/components/StatusBar/PrItem.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  checksColor,
+  stateLabel,
+  truncate,
+} from '@/components/StatusBar/PrItem'
+import type { PrInfo } from '@/modules/stores/$tabMeta'
+
+/* ---------------------------------------------------------------------------
+ * truncate
+ * -------------------------------------------------------------------------*/
+
+describe('truncate', () => {
+  test('passes through strings shorter than the limit', () => {
+    expect(truncate('hi', 10)).toBe('hi')
+  })
+
+  test('passes through strings exactly at the limit', () => {
+    expect(truncate('hello', 5)).toBe('hello')
+  })
+
+  test('truncates and appends an ellipsis when over the limit', () => {
+    expect(truncate('hello world', 8)).toBe('hello w…')
+    expect(truncate('hello world', 8).length).toBe(8)
+  })
+
+  test('keeps the trailing character count exact (ellipsis counts as one)', () => {
+    // 40-char cap is the real-world value; the cap is inclusive.
+    const long = 'a'.repeat(80)
+    const truncated = truncate(long, 40)
+    expect(truncated.length).toBe(40)
+    expect(truncated.endsWith('…')).toBe(true)
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * stateLabel
+ * -------------------------------------------------------------------------*/
+
+function pr(overrides: Partial<PrInfo> = {}): PrInfo {
+  return {
+    number: 1,
+    title: 't',
+    state: 'OPEN',
+    isDraft: false,
+    url: 'https://example.com/pr/1',
+    ...overrides,
+  }
+}
+
+describe('stateLabel', () => {
+  test('open non-draft reads as "open"', () => {
+    expect(stateLabel(pr())).toBe('open')
+  })
+
+  test('open + isDraft reads as "draft"', () => {
+    expect(stateLabel(pr({ isDraft: true }))).toBe('draft')
+  })
+
+  test('merged overrides isDraft', () => {
+    // Defence in depth — if backend ever sends MERGED + isDraft (it
+    // shouldn't, but…), we want the user-visible label to reflect the
+    // terminal state, not a stale draft flag.
+    expect(stateLabel(pr({ state: 'MERGED', isDraft: true }))).toBe('merged')
+  })
+
+  test('closed reads as "closed"', () => {
+    expect(stateLabel(pr({ state: 'CLOSED' }))).toBe('closed')
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * checksColor
+ * -------------------------------------------------------------------------*/
+
+describe('checksColor', () => {
+  test("returns null when checks are undefined (CI hasn't reported yet)", () => {
+    expect(checksColor(undefined)).toBeNull()
+  })
+
+  test('returns null when total is zero (no CI configured)', () => {
+    expect(
+      checksColor({ passing: 0, failing: 0, pending: 0, skipped: 0, total: 0 }),
+    ).toBeNull()
+  })
+
+  test('red when any check is failing', () => {
+    // Failing dominates — even alongside passing + pending.
+    expect(
+      checksColor({ passing: 5, failing: 1, pending: 2, skipped: 0, total: 8 }),
+    ).toBe('var(--terminal-red)')
+  })
+
+  test('yellow when none failing but some pending', () => {
+    expect(
+      checksColor({ passing: 3, failing: 0, pending: 2, skipped: 0, total: 5 }),
+    ).toBe('var(--terminal-yellow)')
+  })
+
+  test('green when all passing', () => {
+    expect(
+      checksColor({ passing: 5, failing: 0, pending: 0, skipped: 0, total: 5 }),
+    ).toBe('var(--terminal-green)')
+  })
+
+  test('green when all passing + skipped (skipped treated as success)', () => {
+    // Skipped checks are intentional (matrix gating, path filters). Showing
+    // red because half the matrix was filtered out would mislead.
+    expect(
+      checksColor({ passing: 2, failing: 0, pending: 0, skipped: 3, total: 5 }),
+    ).toBe('var(--terminal-green)')
+  })
+
+  test('green when all skipped (no passes, no failures)', () => {
+    // Edge case: every check filtered out by a path matcher. Read as
+    // "nothing is broken" — green, not yellow.
+    expect(
+      checksColor({ passing: 0, failing: 0, pending: 0, skipped: 4, total: 4 }),
+    ).toBe('var(--terminal-green)')
+  })
+
+  test('red precedence: 1 failing + 99 pending still red', () => {
+    expect(
+      checksColor({
+        passing: 0,
+        failing: 1,
+        pending: 99,
+        skipped: 0,
+        total: 100,
+      }),
+    ).toBe('var(--terminal-red)')
+  })
+})

--- a/src/components/StatusBar/PrItem.tsx
+++ b/src/components/StatusBar/PrItem.tsx
@@ -46,18 +46,31 @@ export function stateLabel(pr: PrInfo): string {
 }
 
 /**
+ * The colour for the PR icon and number, matching github.com's familiar
+ * palette: green open, red closed, purple merged, grey draft. Sourced from
+ * Primer tokens via CSS variables in index.css (light + dark variants).
+ */
+export function stateColor(pr: PrInfo): string {
+  if (pr.state === 'MERGED') return 'var(--pr-merged)'
+  if (pr.state === 'CLOSED') return 'var(--pr-closed)'
+  if (pr.isDraft) return 'var(--pr-draft)'
+  return 'var(--pr-open)'
+}
+
+/**
  * Picks the state icon. Order matters: MERGED and CLOSED take precedence
  * over isDraft because a draft that gets merged still reads as "merged."
  */
 function StateIcon({ pr }: { pr: PrInfo }) {
   const sz = { size: 10, strokeWidth: 1.5 } as const
+  const color = stateColor(pr)
   if (pr.state === 'MERGED') {
     return (
       <GitMerge
         aria-hidden="true"
         {...sz}
         className="shrink-0"
-        style={{ color: 'var(--terminal-magenta)' }}
+        style={{ color }}
         data-testid="pr-icon-merged"
       />
     )
@@ -68,7 +81,7 @@ function StateIcon({ pr }: { pr: PrInfo }) {
         aria-hidden="true"
         {...sz}
         className="shrink-0"
-        style={{ color: 'var(--terminal-red)' }}
+        style={{ color }}
         data-testid="pr-icon-closed"
       />
     )
@@ -78,7 +91,8 @@ function StateIcon({ pr }: { pr: PrInfo }) {
       <GitPullRequestDraft
         aria-hidden="true"
         {...sz}
-        className="shrink-0 opacity-60"
+        className="shrink-0"
+        style={{ color }}
         data-testid="pr-icon-draft"
       />
     )
@@ -88,6 +102,7 @@ function StateIcon({ pr }: { pr: PrInfo }) {
       aria-hidden="true"
       {...sz}
       className="shrink-0"
+      style={{ color }}
       data-testid="pr-icon-open"
     />
   )
@@ -206,7 +221,7 @@ export function PrItem({ git }: { git: GitInfo }) {
             />
           )}
           <StateIcon pr={pr} />
-          <span>#{pr.number}</span>
+          <span style={{ color: stateColor(pr) }}>#{pr.number}</span>
           <span className="truncate opacity-80">
             {truncate(pr.title, TITLE_MAX)}
           </span>

--- a/src/components/StatusBar/PrItem.tsx
+++ b/src/components/StatusBar/PrItem.tsx
@@ -35,8 +35,16 @@ import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
 /** Max chars for the inline title before truncating with an ellipsis. */
 export const TITLE_MAX = 40
 
+/**
+ * Truncate by Unicode code points (not UTF-16 code units) so a title ending
+ * with an emoji or other astral character at the boundary doesn't get cut
+ * mid surrogate-pair and render as a replacement glyph. Realistic for PR
+ * titles that follow gitmoji or similar conventions.
+ */
 export function truncate(s: string, n: number): string {
-  return s.length > n ? `${s.slice(0, n - 1)}…` : s
+  const codePoints = Array.from(s)
+  if (codePoints.length <= n) return s
+  return `${codePoints.slice(0, n - 1).join('')}…`
 }
 
 export function stateLabel(pr: PrInfo): string {

--- a/src/components/StatusBar/PrItem.tsx
+++ b/src/components/StatusBar/PrItem.tsx
@@ -1,7 +1,7 @@
 import { openUrl } from '@tauri-apps/plugin-opener'
 import {
   GitMerge,
-  GitPullRequest,
+  GitPullRequestArrow,
   GitPullRequestClosed,
   GitPullRequestDraft,
 } from 'lucide-react'
@@ -98,7 +98,7 @@ function StateIcon({ pr }: { pr: PrInfo }) {
     )
   }
   return (
-    <GitPullRequest
+    <GitPullRequestArrow
       aria-hidden="true"
       {...sz}
       className="shrink-0"

--- a/src/components/StatusBar/PrItem.tsx
+++ b/src/components/StatusBar/PrItem.tsx
@@ -1,0 +1,235 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+import {
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+} from 'lucide-react'
+import { Fragment } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import type { GitInfo, PrChecks, PrInfo } from '@/modules/stores/$tabMeta'
+import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
+
+/* ---------------------------------------------------------------------------
+ * PrItem — status bar pill for the PR linked to the active tab's branch.
+ *
+ * Layout (left to right inside the pill):
+ *   [checks dot]  [state icon]  #<num>  <truncated title>
+ *
+ * The whole pill is a single button — click opens the PR in the OS default
+ * browser. Hover surfaces a tooltip with the full title, state label,
+ * ahead/behind echo, and a 4-bucket check breakdown.
+ *
+ * Refresh cadence is driven by GitMonitorMod on the Rust side: 60s baseline,
+ * 15s while `checks.pending > 0` so active CI runs surface quickly without
+ * adding a separate polling task. The OSC 133;D trigger keeps things
+ * sub-second after any shell command that could change PR state (push,
+ * commit, force-push, gh pr ready, etc.).
+ * -------------------------------------------------------------------------*/
+
+/** Max chars for the inline title before truncating with an ellipsis. */
+export const TITLE_MAX = 40
+
+export function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s
+}
+
+export function stateLabel(pr: PrInfo): string {
+  if (pr.state === 'MERGED') return 'merged'
+  if (pr.state === 'CLOSED') return 'closed'
+  return pr.isDraft ? 'draft' : 'open'
+}
+
+/**
+ * Picks the state icon. Order matters: MERGED and CLOSED take precedence
+ * over isDraft because a draft that gets merged still reads as "merged."
+ */
+function StateIcon({ pr }: { pr: PrInfo }) {
+  const sz = { size: 10, strokeWidth: 1.5 } as const
+  if (pr.state === 'MERGED') {
+    return (
+      <GitMerge
+        aria-hidden="true"
+        {...sz}
+        className="shrink-0"
+        style={{ color: 'var(--terminal-magenta)' }}
+        data-testid="pr-icon-merged"
+      />
+    )
+  }
+  if (pr.state === 'CLOSED') {
+    return (
+      <GitPullRequestClosed
+        aria-hidden="true"
+        {...sz}
+        className="shrink-0"
+        style={{ color: 'var(--terminal-red)' }}
+        data-testid="pr-icon-closed"
+      />
+    )
+  }
+  if (pr.isDraft) {
+    return (
+      <GitPullRequestDraft
+        aria-hidden="true"
+        {...sz}
+        className="shrink-0 opacity-60"
+        data-testid="pr-icon-draft"
+      />
+    )
+  }
+  return (
+    <GitPullRequest
+      aria-hidden="true"
+      {...sz}
+      className="shrink-0"
+      data-testid="pr-icon-open"
+    />
+  )
+}
+
+/**
+ * Returns the colour of the build-health dot, or `null` to hide it.
+ * Hidden when:
+ *   - no checks data yet (`checks` undefined — first poll hasn't returned a rollup)
+ *   - rollup reports zero items (repo has no CI configured for this PR)
+ *
+ * SKIPPED is treated as success — skipped checks are intentional (matrix
+ * gating, path filters), and showing red because half the runners were
+ * filtered out would be wrong.
+ */
+export function checksColor(checks: PrChecks | undefined): string | null {
+  if (!checks || checks.total === 0) return null
+  if (checks.failing > 0) return 'var(--terminal-red)'
+  if (checks.pending > 0) return 'var(--terminal-yellow)'
+  return 'var(--terminal-green)'
+}
+
+/** Single-row check breakdown for the tooltip body. */
+function ChecksBreakdown({ checks }: { checks: PrChecks | undefined }) {
+  if (!checks || checks.total === 0) {
+    return (
+      <span className="opacity-60" data-testid="pr-checks-empty">
+        no checks reported
+      </span>
+    )
+  }
+  // Dim zero-count categories rather than dropping them entirely — keeps
+  // the layout stable so the eye doesn't have to re-parse on each refresh.
+  const parts: Array<{ key: string; node: React.ReactNode }> = [
+    {
+      key: 'p',
+      node: (
+        <span className={checks.passing > 0 ? '' : 'opacity-40'}>
+          ✓ {checks.passing} passing
+        </span>
+      ),
+    },
+    {
+      key: 'f',
+      node: (
+        <span
+          className={
+            checks.failing > 0 ? 'text-[var(--terminal-red)]' : 'opacity-40'
+          }
+        >
+          ✗ {checks.failing} failing
+        </span>
+      ),
+    },
+    {
+      key: 'i',
+      node: (
+        <span
+          className={
+            checks.pending > 0 ? 'text-[var(--terminal-yellow)]' : 'opacity-40'
+          }
+        >
+          ◐ {checks.pending} pending
+        </span>
+      ),
+    },
+  ]
+  if (checks.skipped > 0) {
+    parts.push({
+      key: 's',
+      node: <span className="opacity-60">⊘ {checks.skipped} skipped</span>,
+    })
+  }
+  return (
+    <span
+      className="flex flex-wrap items-center gap-2"
+      data-testid="pr-checks-breakdown"
+    >
+      {parts.map((p, i) => (
+        <Fragment key={p.key}>
+          {i > 0 && <span className="opacity-30">·</span>}
+          {p.node}
+        </Fragment>
+      ))}
+      <span className="opacity-30">·</span>
+      <span className="opacity-60">{checks.total} total</span>
+    </span>
+  )
+}
+
+export function PrItem({ git }: { git: GitInfo }) {
+  const pr = git.pr
+  if (!pr) return null
+
+  const dotColor = checksColor(pr.checks)
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger
+          onClick={(e) => {
+            e.preventDefault()
+            openUrl(pr.url).catch(() => {})
+          }}
+          className="flex cursor-pointer appearance-none items-center gap-1 border-0 bg-transparent p-0 text-[11px] text-inherit hover:opacity-100"
+          style={{ fontFamily: MONO_FONT, opacity: 0.85 }}
+          aria-label={`Pull request #${pr.number}: ${pr.title}`}
+          data-testid="pr-pill"
+        >
+          {dotColor && (
+            <span
+              aria-hidden="true"
+              className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+              style={{ background: dotColor }}
+              data-testid="pr-checks-dot"
+            />
+          )}
+          <StateIcon pr={pr} />
+          <span>#{pr.number}</span>
+          <span className="truncate opacity-80">
+            {truncate(pr.title, TITLE_MAX)}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[28rem]">
+          <div
+            className="flex flex-col gap-1 text-[11px]"
+            style={{ fontFamily: MONO_FONT }}
+          >
+            <div className="font-medium">{pr.title}</div>
+            <div className="opacity-70">
+              #{pr.number} · {stateLabel(pr)}
+              {(git.aheadBy > 0 || git.behindBy > 0) && (
+                <>
+                  {' · '}
+                  {git.aheadBy} ahead, {git.behindBy} behind
+                </>
+              )}
+            </div>
+            <ChecksBreakdown checks={pr.checks} />
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/components/StatusBar/StatusBarRight.tsx
+++ b/src/components/StatusBar/StatusBarRight.tsx
@@ -57,7 +57,9 @@ import {
  *
  * Tab with no process data (shell tabs, or agent tabs before first poll):
  *
- *   status · ⎇ branch [●] [↑N] [↓N] · [●] ⊟ #123 title · 📂 /cwd   (status hidden when idle)
+ *   status · ⎇ branch [●] [↑N] [↓N] · [●] ⊟ #123 title · 📂 /cwd
+ *   (status hidden when idle; PR pill omitted when the branch has no PR;
+ *    checks dot hidden when no checks have reported yet)
  *
  * Icon sizing: size=10, strokeWidth=1.5 — visually balanced against 11px mono text.
  * Icon opacity: matches the opacity of the adjacent text item.

--- a/src/components/StatusBar/StatusBarRight.tsx
+++ b/src/components/StatusBar/StatusBarRight.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react'
 import type React from 'react'
 import { parseModelFlag } from '@/components/agent.helpers'
+import { PrItem } from '@/components/StatusBar/PrItem'
 import {
   Tooltip,
   TooltipContent,
@@ -42,16 +43,21 @@ import {
  *
  * Tab with live process data (currently agent tabs only):
  *
- *   name · pid · ⏱ elapsed · 🧮 memory · 🔌 :port1 :port2 · ✨ model · ⎇ branch [●] [↑N] [↓N] · 📂 /cwd
- *   │      │                                                              │                              │
- *   │      │                                                              │                              └── FolderOpen + CWD basename (tooltip = full path)
- *   │      │                                                              └─────────────────────────────── GitBranch + name; ● if dirty; Upload N if ahead; Download N if behind
- *   │      └──────────────────────────────────────────────────────────────────────────────────────────── process PID (no icon — self-describing number)
- *   └─────────────────────────────────────────────────────────────────────────────────────────────────── process name (no icon — agent name is already a label)
+ *   name · pid · ⏱ elapsed · 🧮 mem · 🔌 :p1 · ✨ model · ⎇ branch [●] [↑N] [↓N] · [●] ⊟ #123 title · 📂 /cwd
+ *   │      │                                                                       │   │              │
+ *   │      │                                                                       │   │              └── FolderOpen + CWD basename (tooltip = full path)
+ *   │      │                                                                       │   └────────────── PrItem: state icon + #num + truncated title (tooltip: full title + state + ahead/behind + checks)
+ *   │      │                                                                       └────────────────── checks dot (red/yellow/green; hidden when no checks)
+ *   │      └──────────────────────────────────────────────────────────────────────────────────────── process PID
+ *   └─────────────────────────────────────────────────────────────────────────────────────────────── process name
+ *
+ * The PR pill sits between git and cwd so the eye reads "branch → its PR →
+ * where I am on disk" — matches the existing left-to-right grouping logic.
+ * Pill is omitted when no PR is associated with the branch.
  *
  * Tab with no process data (shell tabs, or agent tabs before first poll):
  *
- *   status · ⎇ branch [●] [↑N] [↓N] · 📂 /cwd   (status hidden when idle)
+ *   status · ⎇ branch [●] [↑N] [↓N] · [●] ⊟ #123 title · 📂 /cwd   (status hidden when idle)
  *
  * Icon sizing: size=10, strokeWidth=1.5 — visually balanced against 11px mono text.
  * Icon opacity: matches the opacity of the adjacent text item.
@@ -277,9 +283,16 @@ export function StatusBarRight() {
     }
   }
 
-  // ── Git branch — always shown when available (second from right) ─────────
+  // ── Git branch — always shown when available ─────────────────────────────
   if (git?.branch) {
     items.push(<GitItem key="git" git={git} />)
+  }
+
+  // ── PR — between git and cwd when the branch has an associated PR ────────
+  // PrItem handles its own "no pr" guard, but we gate here too to avoid
+  // adding an empty item that would render a stray dot separator.
+  if (git?.pr) {
+    items.push(<PrItem key="pr" git={git} />)
   }
 
   // ── CWD — always shown when available (rightmost), full path on hover ────

--- a/src/index.css
+++ b/src/index.css
@@ -132,6 +132,13 @@
   --terminal-magenta: #7a4dbf;
   --terminal-cyan: #1e7a9e;
 
+  /* GitHub PR state — Primer tokens so the PR pill matches the colours
+     users already associate with these states on github.com. */
+  --pr-open: #1a7f37;
+  --pr-closed: #cf222e;
+  --pr-merged: #8250df;
+  --pr-draft: #59636e;
+
   /* Status bar */
   --status-bar-background: #fafafa;
   --status-bar-border: rgba(0, 0, 0, 0.06);
@@ -222,6 +229,12 @@
     --terminal-red: #f7768e;
     --terminal-magenta: #bb9af7;
     --terminal-cyan: #7dcfff;
+
+    /* GitHub PR state — Primer dark-mode tokens. */
+    --pr-open: #3fb950;
+    --pr-closed: #f85149;
+    --pr-merged: #a371f7;
+    --pr-draft: #9198a1;
 
     /* Status bar */
     --status-bar-background: #141517;

--- a/src/modules/stores/$tabMeta.ts
+++ b/src/modules/stores/$tabMeta.ts
@@ -10,13 +10,39 @@ export type TabType = 'shell' | 'task' | 'agent'
  */
 export type AgentTurnState = 'idle' | 'in-progress' | 'awaiting' | 'completed'
 
+export type PrState = 'OPEN' | 'MERGED' | 'CLOSED'
+
+/**
+ * Compact CI rollup populated by GitMonitorMod from `gh pr view`'s
+ * `statusCheckRollup`. Rust does the bucketing so the frontend treats this
+ * as a closed 4-bucket counter — unknown check states are dropped on the
+ * way out, never producing an "unclassified" bucket here.
+ */
+export type PrChecks = {
+  passing: number
+  failing: number
+  pending: number
+  skipped: number
+  total: number
+}
+
+export type PrInfo = {
+  number: number
+  title: string
+  state: PrState
+  isDraft: boolean
+  url: string
+  /** Undefined when no checks have reported yet (or repo has no CI). */
+  checks?: PrChecks
+}
+
 export type GitInfo = {
   branch: string
   aheadBy: number
   behindBy: number
   isDirty: boolean
   worktree?: string
-  pr?: { number: number; title: string; state: string; url: string }
+  pr?: PrInfo
 }
 
 /**


### PR DESCRIPTION
## Summary

- Removes the bare \`#<num>\` chip from the sidebar tab row and replaces it with a rich PR pill in the status bar (between the git segment and the cwd segment).
- Pill renders: state icon (open / draft / merged / closed), \`#<num> + truncated title\`, a CI checks dot (green / yellow / red), and a tooltip with full title, state label, ahead/behind echo, and a 4-bucket check breakdown.
- Click on the pill opens the PR in the OS default browser (\`plugin-opener\`).

## How PR state stays fresh

\`GitMonitorMod\` gains an adaptive refresh cadence:

- **60s baseline** when no PR checks are pending (or when there's no PR).
- **15s** while \`checks.pending > 0\` so CI transitions surface quickly during active runs.
- The mod re-derives the desired interval after every query and the periodic timer wakes early on cadence changes via \`tokio::watch\` — no new polling task per tab, no extra \`gh\` calls when CI is idle.
- The existing OSC 133;D trigger keeps things sub-second after any shell command that could change PR state (push, commit, \`gh pr ready\`, etc.).

\`gh pr view --json\` now also requests \`isDraft\`, \`mergedAt\`, and \`statusCheckRollup\`. The rollup is collapsed on the Rust side into a fixed 4-bucket counter so the frontend treats it as a closed type — unknown check states from future \`gh\` versions are dropped, never miscategorised. \`mergedAt\` disambiguates older \`gh\` versions that return \`state: \"CLOSED\"\` for merged PRs.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bunx biome check\` clean on changed files
- [x] \`bun test src/components/StatusBar/PrItem.test.ts\` — 16/16 pass (truncate / stateLabel / checksColor coverage including skipped-as-success, MERGED-overrides-isDraft, dot precedence)
- [ ] \`cargo test --manifest-path src-tauri/Cargo.toml --lib git_monitor\` — covers \`transform_pr\` / \`summarise_checks\` / \`desired_interval_secs\` (open + checks bucketing, CLOSED+mergedAt → MERGED, CLOSED without mergedAt stays CLOSED, MERGED passthrough, empty rollup, external \`state\` field, draft flag, missing isDraft default, unknown future state dropped, cadence selection)
- [ ] Manual QA: tab on a branch with open PR shows pill; click opens browser; hover shows tooltip; \`gh pr ready\` on a draft flips icon within ~60s (or immediately after any shell command); pushing a failing commit turns dot red within 15s; merging on github.com flips icon to \`GitMerge\`; tab on branch without PR hides the pill; tab on PR-but-no-CI shows pill with no dot and \"no checks reported\" in the tooltip
- [ ] Window-resize sanity — long titles clip via existing \`overflow-hidden\`