### PR TITLE
feat(updater): wire tauri-plugin-updater and produce signed update bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,15 @@
 #   4. Wait ~15 min, then publish the draft from the Releases page
 #
 # Required repo secrets (settings → Secrets and variables → Actions):
-#   APPLE_CERTIFICATE           — base64-encoded Developer ID .p12
-#   APPLE_CERTIFICATE_PASSWORD  — password for the .p12
-#   APPLE_SIGNING_IDENTITY      — full Developer ID Application identity string
-#   APPLE_ID                    — Apple ID email
-#   APPLE_PASSWORD              — app-specific password for notarytool
-#   APPLE_TEAM_ID               — Apple Developer team identifier
-#   KEYCHAIN_PASSWORD           — throwaway, unlocks the temp runner keychain
+#   APPLE_CERTIFICATE                    — base64-encoded Developer ID .p12
+#   APPLE_CERTIFICATE_PASSWORD           — password for the .p12
+#   APPLE_SIGNING_IDENTITY               — full Developer ID Application identity string
+#   APPLE_ID                             — Apple ID email
+#   APPLE_PASSWORD                       — app-specific password for notarytool
+#   APPLE_TEAM_ID                        — Apple Developer team identifier
+#   KEYCHAIN_PASSWORD                    — throwaway, unlocks the temp runner keychain
+#   TAURI_SIGNING_PRIVATE_KEY            — minisign private key for updater bundles
+#   TAURI_SIGNING_PRIVATE_KEY_PASSWORD   — password for the minisign key
 #
 # All values stored in repo Settings → Secrets and variables → Actions.
 # Never inline any of them here, even as examples.
@@ -161,19 +163,28 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Updater bundle signing (minisign). Without these set, the
+          # "app" target in tauri.conf.json bundle.targets refuses to
+          # produce .app.tar.gz + .sig — set both secrets before cutting
+          # the first tag after this lands.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           args: --target ${{ matrix.target }}
 
-      - name: Upload .dmg as workflow artifact
-        # Hands the bundle off to the `release` job (which runs on Linux,
-        # so it can't reach into this macOS runner's filesystem directly).
-        # Short retention because the .dmg also lands on the GitHub
-        # Release within minutes — this is a job-to-job carrier, not a
-        # long-term archive.
+      - name: Upload .dmg + updater bundle as workflow artifact
+        # Hands every release artifact for this arch off to the `release`
+        # job (Linux runner, can't reach into this macOS runner's
+        # filesystem directly). Short retention because everything also
+        # lands on the GitHub Release within minutes — workflow artifacts
+        # are a job-to-job carrier, not a long-term archive.
         uses: actions/upload-artifact@v4
         with:
-          name: dmg-${{ matrix.target }}
-          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          name: bundles-${{ matrix.target }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz
+            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz.sig
           if-no-files-found: error
           retention-days: 7
 
@@ -190,13 +201,13 @@ jobs:
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: dmg-*
+          pattern: bundles-*
           path: artifacts
           # `merge-multiple` flattens the per-matrix subdirectories so
           # the final `files:` glob doesn't need a level of indirection.
           merge-multiple: true
 
-      - name: Create draft release with .dmgs attached
+      - name: Create draft release with .dmgs + updater bundles attached
         uses: softprops/action-gh-release@v2
         with:
           # DRAFT — never auto-publish. The user reviews the body, edits
@@ -205,5 +216,13 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body: ${{ needs.changelog.outputs.content }}
-          files: artifacts/*.dmg
+          # Attach .dmg (installs), .app.tar.gz (updater payload), and
+          # .app.tar.gz.sig (minisign signature consumed by the updater
+          # plugin to verify the payload before installing). The manifest
+          # that points at the .app.tar.gz URLs is produced in a follow-up
+          # workflow change.
+          files: |
+            artifacts/*.dmg
+            artifacts/*.app.tar.gz
+            artifacts/*.app.tar.gz.sig
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 # Tag-triggered signed + notarized macOS release.
 #
-# Push a `v*` tag (e.g. `v0.1.0`, `v0.2.0-rc.1`) → this workflow builds a
-# universal (Apple Silicon + Intel) signed + notarized .dmg, creates a
-# DRAFT GitHub Release for that tag, and attaches the .dmg.
+# Push a `v*` tag (e.g. `v0.1.0`, `v0.2.0-rc.1`) → this workflow builds
+# both per-arch signed + notarized .dmgs in parallel, creates a DRAFT
+# GitHub Release for that tag, and attaches both .dmgs.
 #
 # The release stays in DRAFT state. Review it in the GitHub UI and click
 # Publish when ready — never auto-published.
@@ -13,7 +13,7 @@
 #      filtered out by cliff.toml so the version-bump commit doesn't show
 #      up in the next release's changelog.
 #   3. git tag vX.Y.Z && git push origin main --tags
-#   4. Wait ~10 min, then publish the draft from the Releases page
+#   4. Wait ~15 min, then publish the draft from the Releases page
 #
 # Required repo secrets (settings → Secrets and variables → Actions):
 #   APPLE_CERTIFICATE           — base64-encoded Developer ID .p12
@@ -27,7 +27,7 @@
 # All values stored in repo Settings → Secrets and variables → Actions.
 # Never inline any of them here, even as examples.
 
-name: Release (signed + notarized universal macOS build)
+name: Release (signed + notarized per-arch macOS builds)
 
 on:
   push:
@@ -43,13 +43,18 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    name: Build + draft release (universal macOS, signed + notarized)
-    # Pinned runner (not `macos-latest`) so the build environment is stable
-    # across GitHub's runner rollouts. Bump deliberately when needed.
-    runs-on: macos-15
-    timeout-minutes: 90
-
+  # Job 1: figure out the changelog ONCE, on a free Linux runner, and
+  # pass it to the macOS build matrix + final release step via job
+  # outputs. Doing it in each matrix entry would duplicate the work and
+  # risk cliff drift between them.
+  changelog:
+    name: Compute changelog
+    runs-on: ubuntu-latest
+    outputs:
+      first_release: ${{ steps.previous_tag.outputs.first_release }}
+      # Fallback to the literal "first release" string when changelog
+      # step was skipped (very first tag has no ancestor to diff against).
+      content: ${{ steps.changelog.outputs.content || 'first release' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,37 +62,6 @@ jobs:
           # Full history is required so git-cliff (and `git describe`) can
           # walk back to the previous tag and compute the changelog range.
           fetch-depth: 0
-
-      - name: Install Bun
-        # Reads the version from the checked-in `.bun-version` file —
-        # bumping Bun is a one-line change to that file, reviewed like any
-        # other source change.
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install Rust toolchain (universal targets)
-        # Both targets are required so cargo can produce two binaries that
-        # tauri-action then `lipo`s into a single universal binary.
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
-
-      - name: Cache Cargo registry + build artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          # Cache key carries runner.arch + the target triple so caches are
-          # never reused across architectures or build targets. Different
-          # target triple from the manual workflow → first run of this
-          # workflow will cold-build, which is intentional.
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-universal-apple-darwin-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cargo-universal-apple-darwin-
-
-      - name: Install frontend dependencies
-        run: bun install
 
       - name: Determine previous tag (for changelog range)
         id: previous_tag
@@ -122,12 +96,62 @@ jobs:
           config: cliff.toml
           args: --strip header ${{ steps.previous_tag.outputs.previous_tag }}..${{ github.ref_name }}
 
-      - name: Tauri build (universal, signed + notarized)
+  # Job 2: build + sign + notarize each macOS arch in parallel. Each
+  # matrix entry produces ONE per-arch .dmg; the matching .dmg name
+  # contains the arch suffix (Tauri bundler default — `_aarch64` /
+  # `_x64`). `fail-fast: false` so a flake on one arch doesn't cancel
+  # the other; the `release` job's `needs:` will simply not be
+  # satisfied and no draft is created — re-run the failing entry.
+  build:
+    name: Build ${{ matrix.target }}
+    needs: [changelog]
+    runs-on: macos-15
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - x86_64-apple-darwin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        # Reads the version from the checked-in `.bun-version` file —
+        # bumping Bun is a one-line change to that file, reviewed like any
+        # other source change.
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Cargo registry + build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          # Cache key carries the target triple so the two matrix entries
+          # keep separate caches. Different triples = different compiled
+          # artifacts; sharing the cache would just cause misses every time.
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ matrix.target }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-${{ matrix.target }}-
+
+      - name: Install frontend dependencies
+        run: bun install
+
+      - name: Tauri build (signed + notarized)
         # tauri-action handles: cert decode + temp keychain import +
-        # `bun tauri build` + `lipo` of the two arch binaries + signing +
-        # notarization + stapling. Skipping `tagName` means the action does
-        # NOT create a release itself — softprops/action-gh-release does
-        # that in the next step.
+        # `bun tauri build` + signing + notarization + stapling. Skipping
+        # `tagName` means the action does NOT create a release itself —
+        # the dedicated `release` job below does that, once both matrix
+        # entries succeed.
         uses: tauri-apps/tauri-action@v0
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -138,22 +162,48 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          # Universal binary — single .dmg runs on both Apple Silicon and
-          # Intel Macs. Doubles cold-build time vs arm64-only, but ships a
-          # single artifact users can download regardless of hardware.
-          args: --target universal-apple-darwin
+          args: --target ${{ matrix.target }}
 
-      - name: Create draft release with .dmg attached
+      - name: Upload .dmg as workflow artifact
+        # Hands the bundle off to the `release` job (which runs on Linux,
+        # so it can't reach into this macOS runner's filesystem directly).
+        # Short retention because the .dmg also lands on the GitHub
+        # Release within minutes — this is a job-to-job carrier, not a
+        # long-term archive.
+        uses: actions/upload-artifact@v4
+        with:
+          name: dmg-${{ matrix.target }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+          retention-days: 7
+
+  # Job 3: create the draft release with BOTH .dmgs attached. Lives
+  # outside the matrix because softprops/action-gh-release running inside
+  # the matrix would create two separate releases (one per matrix entry)
+  # and the second would 422 because the tag already has a release.
+  # Linux runner — this job just downloads artifacts + POSTs to the API.
+  release:
+    name: Create draft release
+    needs: [changelog, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dmg-*
+          path: artifacts
+          # `merge-multiple` flattens the per-matrix subdirectories so
+          # the final `files:` glob doesn't need a level of indirection.
+          merge-multiple: true
+
+      - name: Create draft release with .dmgs attached
         uses: softprops/action-gh-release@v2
         with:
-          # DRAFT — never auto-publish. The user reviews the body, edits if
-          # needed, and clicks Publish in the GitHub UI.
+          # DRAFT — never auto-publish. The user reviews the body, edits
+          # if needed, and clicks Publish in the GitHub UI.
           draft: true
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          # First release → literal "first release" body. Otherwise → the
-          # git-cliff-rendered changelog. The `||` fallback fires when the
-          # changelog step was skipped (its output is empty in that case).
-          body: ${{ steps.changelog.outputs.content || 'first release' }}
-          files: src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+          body: ${{ needs.changelog.outputs.content }}
+          files: artifacts/*.dmg
           fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   **A terminal workspace built around AI coding agents.**
 
-  [![Download](https://img.shields.io/github/v/release/DaniAkash/agent-terminal?include_prereleases&label=Download%20DMG&color=blue)](https://github.com/DaniAkash/agent-terminal/releases/download/v0.1.3/Agent.Terminal_0.1.3_universal.dmg)
+  [![Latest release](https://img.shields.io/github/v/release/DaniAkash/agent-terminal?include_prereleases&label=latest&color=blue)](https://github.com/DaniAkash/agent-terminal/releases)
   [![Status](https://img.shields.io/badge/status-pre--alpha-orange)](#status)
   [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey)](#download)
 </div>
@@ -32,9 +32,17 @@ Agent Terminal is a terminal that knows the difference between a shell and an ag
 
 ## Download
 
-1. Grab the latest `.dmg` (universal binary — Apple Silicon + Intel) from the [releases page](https://github.com/DaniAkash/agent-terminal/releases).
+Pick the `.dmg` that matches your Mac on the [releases page](https://github.com/DaniAkash/agent-terminal/releases):
+
+| Apple Silicon (M1 / M2 / M3 / M4) | Intel |
+| --- | --- |
+| `agent-terminal_<version>_aarch64.dmg` | `agent-terminal_<version>_x64.dmg` |
+
+Not sure which? Click the Apple menu → About This Mac. "Chip: Apple M…" means Apple Silicon; "Processor: Intel…" means Intel.
+
+1. Download the matching `.dmg`.
 2. Open it, drag **Agent Terminal** to your Applications folder.
-3. First launch: right-click → Open (the app isn't notarised yet, so macOS Gatekeeper will warn — pre-alpha).
+3. Launch.
 
 That's it. No config files, no daemons, no tmux setup.
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-updater": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -365,6 +366,8 @@
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-updater": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,11 @@ tauri-plugin-single-instance = "2"
 # attributes notifications to com.apple.Terminal, which is fine for visibility
 # but means clicks don't route back to us — see the focus-event heuristic.
 tauri-plugin-notification = "2"
+# Self-update via signed Tauri update bundles. Disabled at build time in
+# the `dev-instance` feature (dev builds share the prod manifest endpoint
+# only by accident; letting them auto-update would overlay the prod .app
+# onto the dev bundle id).
+tauri-plugin-updater = "2"
 # Release-mode notifications (debug_assertions = false). Wraps the native
 # UNUserNotificationCenter on macOS so we get real per-notification click
 # callbacks via UNUserNotificationCenterDelegate. Mock mode falls back to

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "core:window:allow-start-dragging",
-    "notification:default"
+    "notification:default",
+    "updater:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,7 +38,7 @@ use std::sync::{Arc, Mutex};
 pub fn run() {
     let pty_map: PtyMap = Arc::new(Mutex::new(HashMap::new()));
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         // Single-instance MUST be the first plugin so duplicate launches
         // (notification clicks routing to a fresh .app, double-clicking the
         // dock icon, etc.) get intercepted before any other plugin tries to
@@ -53,7 +53,17 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_notification::init());
+
+    // Self-update — only the prod-namespaced build registers the plugin.
+    // The dev bundle id (com.daniakash.agent-terminal-dev) cannot be the
+    // legitimate target of a manifest signed for the prod app, so
+    // dev-instance builds skip the plugin entirely rather than risk an
+    // update attempt that overlays a foreign bundle.
+    #[cfg(not(feature = "dev-instance"))]
+    let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+
+    builder
         .setup(|app| {
             // Custom macOS menu — omits the default items whose shortcuts
             // conflict with our keyboard handlers:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
       "endpoints": [
         "https://raw.githubusercontent.com/DaniAkash/agent-terminal/release-manifest/latest.json"
       ],
-      "pubkey": "REPLACE_BEFORE_MERGE_SEE_PR_DESCRIPTION"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDc2NkFGNDczRTQwOTJCOUMKUldTY0t3bmtjL1JxZGxvb3lzVlhRUWQ1TkNxR29JQ0FsaS9qTldzeFRzQzI4TzdLNkUrYWpTREEK"
     }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["dmg", "app"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -39,6 +39,14 @@
       "minimumSystemVersion": "10.15",
       "hardenedRuntime": true,
       "entitlements": "macos/entitlements.plist"
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://raw.githubusercontent.com/DaniAkash/agent-terminal/release-manifest/latest.json"
+      ],
+      "pubkey": "REPLACE_BEFORE_MERGE_SEE_PR_DESCRIPTION"
     }
   }
 }


### PR DESCRIPTION
> Stacked on top of #54. Review that one first.

## Summary

Adds \`tauri-plugin-updater\` end-to-end on the build side: Rust plugin registration, JS plugin package, capability grant, \`bundle.targets\` updated so each release ships the updater payload + minisign signature alongside the installer, and workflow env vars so \`tauri-action\` actually produces them.

This PR does **not** wire any UI — the renderer code that calls \`check()\` / \`downloadAndInstall()\` lands in a later PR. After this PR ships, releases contain three artifacts per arch (\`.dmg\`, \`.app.tar.gz\`, \`.app.tar.gz.sig\`) but installed apps don't yet check for updates.

### 1. Generate the minisign keypair (one-time, local)

\`\`\`sh
bunx tauri signer generate -w ~/keys/agent-terminal-updater.key
\`\`\`

Prompt asks for a password — pick a strong one and save it in 1Password. The command:
- Prints the public key to stdout
- Writes the private key to the path provided

### 2. Paste the public key into \`src-tauri/tauri.conf.json\`

Replace the placeholder in \`plugins.updater.pubkey\` with the printed public key string (it starts with \`untrusted comment: minisign public key...\`).

### 3. Stash the private key for CI

\`\`\`sh
base64 -i ~/keys/agent-terminal-updater.key | pbcopy
\`\`\`

Then in repo Settings → Secrets and variables → Actions, add:
- \`TAURI_SIGNING_PRIVATE_KEY\` — paste from clipboard
- \`TAURI_SIGNING_PRIVATE_KEY_PASSWORD\` — the password from step 1

### 4. Back up for local recovery

- Add both values to Doppler \`agent-terminal/prd\` config (matches the existing Apple-creds backup pattern)
- Save the \`.key\` file itself to 1Password as a secure attachment

## What changed

- \`src-tauri/Cargo.toml\` — adds \`tauri-plugin-updater = "2"\`
- \`src-tauri/src/lib.rs\` — registers the plugin via \`builder.plugin(...)\`. Wrapped in \`#[cfg(not(feature = "dev-instance"))]\` so the dev build doesn't try to update itself with a manifest signed for the prod bundle id
- \`src-tauri/capabilities/default.json\` — adds \`"updater:default"\`
- \`src-tauri/tauri.conf.json\` — \`bundle.targets\` switches from \`"all"\` to \`["dmg", "app"]\`; new \`plugins.updater\` block with the raw.githubusercontent.com endpoint and pubkey placeholder
- \`package.json\` — adds \`@tauri-apps/plugin-updater\` (referenced from the renderer in the follow-up PR)
- \`.github/workflows/release.yml\` — passes \`TAURI_SIGNING_*\` env vars to \`tauri-action\`; upload step captures \`.app.tar.gz\` and \`.sig\` in addition to \`.dmg\`; release step attaches all three patterns

## Why the endpoint is raw.githubusercontent.com and not \`/releases/latest/download/\`

GitHub's \`/releases/latest/download/\` redirect excludes pre-releases. This app ships pre-releases today, so that endpoint would silently never surface them. The manifest is hosted on a dedicated branch served via raw.githubusercontent.com instead — the publish workflow for that branch lands in the next PR.

## Test plan

- [ ] Generate keypair, replace pubkey placeholder, add secrets, push a test tag → workflow produces \`.dmg\` + \`.app.tar.gz\` + \`.sig\` per arch
- [ ] Local prod build (\`bun tauri:build\`) succeeds without the signing env vars (the env vars only matter when bundling \`"app"\` in CI — local dev/prod builds without the env vars will fail at the same step, by design)
- [ ] \`bun tauri:dev\` still works (dev-instance feature skips the plugin)
- [ ] App launches and runs normally with the plugin registered