### PR TITLE
docs: explain per-arch downloads, in-app updates, and the release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,15 @@
 #   4. Wait ~15 min, then publish the draft from the Releases page
 #
 # Required repo secrets (settings → Secrets and variables → Actions):
-#   APPLE_CERTIFICATE           — base64-encoded Developer ID .p12
-#   APPLE_CERTIFICATE_PASSWORD  — password for the .p12
-#   APPLE_SIGNING_IDENTITY      — full Developer ID Application identity string
-#   APPLE_ID                    — Apple ID email
-#   APPLE_PASSWORD              — app-specific password for notarytool
-#   APPLE_TEAM_ID               — Apple Developer team identifier
-#   KEYCHAIN_PASSWORD           — throwaway, unlocks the temp runner keychain
+#   APPLE_CERTIFICATE                    — base64-encoded Developer ID .p12
+#   APPLE_CERTIFICATE_PASSWORD           — password for the .p12
+#   APPLE_SIGNING_IDENTITY               — full Developer ID Application identity string
+#   APPLE_ID                             — Apple ID email
+#   APPLE_PASSWORD                       — app-specific password for notarytool
+#   APPLE_TEAM_ID                        — Apple Developer team identifier
+#   KEYCHAIN_PASSWORD                    — throwaway, unlocks the temp runner keychain
+#   TAURI_SIGNING_PRIVATE_KEY            — minisign private key for updater bundles
+#   TAURI_SIGNING_PRIVATE_KEY_PASSWORD   — password for the minisign key
 #
 # All values stored in repo Settings → Secrets and variables → Actions.
 # Never inline any of them here, even as examples.
@@ -161,19 +163,28 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Updater bundle signing (minisign). Without these set, the
+          # "app" target in tauri.conf.json bundle.targets refuses to
+          # produce .app.tar.gz + .sig — set both secrets before cutting
+          # the first tag after this lands.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           args: --target ${{ matrix.target }}
 
-      - name: Upload .dmg as workflow artifact
-        # Hands the bundle off to the `release` job (which runs on Linux,
-        # so it can't reach into this macOS runner's filesystem directly).
-        # Short retention because the .dmg also lands on the GitHub
-        # Release within minutes — this is a job-to-job carrier, not a
-        # long-term archive.
+      - name: Upload .dmg + updater bundle as workflow artifact
+        # Hands every release artifact for this arch off to the `release`
+        # job (Linux runner, can't reach into this macOS runner's
+        # filesystem directly). Short retention because everything also
+        # lands on the GitHub Release within minutes — workflow artifacts
+        # are a job-to-job carrier, not a long-term archive.
         uses: actions/upload-artifact@v4
         with:
-          name: dmg-${{ matrix.target }}
-          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          name: bundles-${{ matrix.target }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz
+            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz.sig
           if-no-files-found: error
           retention-days: 7
 
@@ -190,13 +201,13 @@ jobs:
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: dmg-*
+          pattern: bundles-*
           path: artifacts
           # `merge-multiple` flattens the per-matrix subdirectories so
           # the final `files:` glob doesn't need a level of indirection.
           merge-multiple: true
 
-      - name: Create draft release with .dmgs attached
+      - name: Create draft release with .dmgs + updater bundles attached
         uses: softprops/action-gh-release@v2
         with:
           # DRAFT — never auto-publish. The user reviews the body, edits
@@ -205,5 +216,13 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body: ${{ needs.changelog.outputs.content }}
-          files: artifacts/*.dmg
+          # Attach .dmg (installs), .app.tar.gz (updater payload), and
+          # .app.tar.gz.sig (minisign signature consumed by the updater
+          # plugin to verify the payload before installing). The manifest
+          # that points at the .app.tar.gz URLs is produced in a follow-up
+          # workflow change.
+          files: |
+            artifacts/*.dmg
+            artifacts/*.app.tar.gz
+            artifacts/*.app.tar.gz.sig
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 # Tag-triggered signed + notarized macOS release.
 #
-# Push a `v*` tag (e.g. `v0.1.0`, `v0.2.0-rc.1`) → this workflow builds a
-# universal (Apple Silicon + Intel) signed + notarized .dmg, creates a
-# DRAFT GitHub Release for that tag, and attaches the .dmg.
+# Push a `v*` tag (e.g. `v0.1.0`, `v0.2.0-rc.1`) → this workflow builds
+# both per-arch signed + notarized .dmgs in parallel, creates a DRAFT
+# GitHub Release for that tag, and attaches both .dmgs.
 #
 # The release stays in DRAFT state. Review it in the GitHub UI and click
 # Publish when ready — never auto-published.
@@ -13,7 +13,7 @@
 #      filtered out by cliff.toml so the version-bump commit doesn't show
 #      up in the next release's changelog.
 #   3. git tag vX.Y.Z && git push origin main --tags
-#   4. Wait ~10 min, then publish the draft from the Releases page
+#   4. Wait ~15 min, then publish the draft from the Releases page
 #
 # Required repo secrets (settings → Secrets and variables → Actions):
 #   APPLE_CERTIFICATE           — base64-encoded Developer ID .p12
@@ -27,7 +27,7 @@
 # All values stored in repo Settings → Secrets and variables → Actions.
 # Never inline any of them here, even as examples.
 
-name: Release (signed + notarized universal macOS build)
+name: Release (signed + notarized per-arch macOS builds)
 
 on:
   push:
@@ -43,13 +43,18 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    name: Build + draft release (universal macOS, signed + notarized)
-    # Pinned runner (not `macos-latest`) so the build environment is stable
-    # across GitHub's runner rollouts. Bump deliberately when needed.
-    runs-on: macos-15
-    timeout-minutes: 90
-
+  # Job 1: figure out the changelog ONCE, on a free Linux runner, and
+  # pass it to the macOS build matrix + final release step via job
+  # outputs. Doing it in each matrix entry would duplicate the work and
+  # risk cliff drift between them.
+  changelog:
+    name: Compute changelog
+    runs-on: ubuntu-latest
+    outputs:
+      first_release: ${{ steps.previous_tag.outputs.first_release }}
+      # Fallback to the literal "first release" string when changelog
+      # step was skipped (very first tag has no ancestor to diff against).
+      content: ${{ steps.changelog.outputs.content || 'first release' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,37 +62,6 @@ jobs:
           # Full history is required so git-cliff (and `git describe`) can
           # walk back to the previous tag and compute the changelog range.
           fetch-depth: 0
-
-      - name: Install Bun
-        # Reads the version from the checked-in `.bun-version` file —
-        # bumping Bun is a one-line change to that file, reviewed like any
-        # other source change.
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install Rust toolchain (universal targets)
-        # Both targets are required so cargo can produce two binaries that
-        # tauri-action then `lipo`s into a single universal binary.
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
-
-      - name: Cache Cargo registry + build artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          # Cache key carries runner.arch + the target triple so caches are
-          # never reused across architectures or build targets. Different
-          # target triple from the manual workflow → first run of this
-          # workflow will cold-build, which is intentional.
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-universal-apple-darwin-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cargo-universal-apple-darwin-
-
-      - name: Install frontend dependencies
-        run: bun install
 
       - name: Determine previous tag (for changelog range)
         id: previous_tag
@@ -122,12 +96,62 @@ jobs:
           config: cliff.toml
           args: --strip header ${{ steps.previous_tag.outputs.previous_tag }}..${{ github.ref_name }}
 
-      - name: Tauri build (universal, signed + notarized)
+  # Job 2: build + sign + notarize each macOS arch in parallel. Each
+  # matrix entry produces ONE per-arch .dmg; the matching .dmg name
+  # contains the arch suffix (Tauri bundler default — `_aarch64` /
+  # `_x64`). `fail-fast: false` so a flake on one arch doesn't cancel
+  # the other; the `release` job's `needs:` will simply not be
+  # satisfied and no draft is created — re-run the failing entry.
+  build:
+    name: Build ${{ matrix.target }}
+    needs: [changelog]
+    runs-on: macos-15
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - x86_64-apple-darwin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        # Reads the version from the checked-in `.bun-version` file —
+        # bumping Bun is a one-line change to that file, reviewed like any
+        # other source change.
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Cargo registry + build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          # Cache key carries the target triple so the two matrix entries
+          # keep separate caches. Different triples = different compiled
+          # artifacts; sharing the cache would just cause misses every time.
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ matrix.target }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-${{ matrix.target }}-
+
+      - name: Install frontend dependencies
+        run: bun install
+
+      - name: Tauri build (signed + notarized)
         # tauri-action handles: cert decode + temp keychain import +
-        # `bun tauri build` + `lipo` of the two arch binaries + signing +
-        # notarization + stapling. Skipping `tagName` means the action does
-        # NOT create a release itself — softprops/action-gh-release does
-        # that in the next step.
+        # `bun tauri build` + signing + notarization + stapling. Skipping
+        # `tagName` means the action does NOT create a release itself —
+        # the dedicated `release` job below does that, once both matrix
+        # entries succeed.
         uses: tauri-apps/tauri-action@v0
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -138,22 +162,48 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          # Universal binary — single .dmg runs on both Apple Silicon and
-          # Intel Macs. Doubles cold-build time vs arm64-only, but ships a
-          # single artifact users can download regardless of hardware.
-          args: --target universal-apple-darwin
+          args: --target ${{ matrix.target }}
 
-      - name: Create draft release with .dmg attached
+      - name: Upload .dmg as workflow artifact
+        # Hands the bundle off to the `release` job (which runs on Linux,
+        # so it can't reach into this macOS runner's filesystem directly).
+        # Short retention because the .dmg also lands on the GitHub
+        # Release within minutes — this is a job-to-job carrier, not a
+        # long-term archive.
+        uses: actions/upload-artifact@v4
+        with:
+          name: dmg-${{ matrix.target }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+          retention-days: 7
+
+  # Job 3: create the draft release with BOTH .dmgs attached. Lives
+  # outside the matrix because softprops/action-gh-release running inside
+  # the matrix would create two separate releases (one per matrix entry)
+  # and the second would 422 because the tag already has a release.
+  # Linux runner — this job just downloads artifacts + POSTs to the API.
+  release:
+    name: Create draft release
+    needs: [changelog, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dmg-*
+          path: artifacts
+          # `merge-multiple` flattens the per-matrix subdirectories so
+          # the final `files:` glob doesn't need a level of indirection.
+          merge-multiple: true
+
+      - name: Create draft release with .dmgs attached
         uses: softprops/action-gh-release@v2
         with:
-          # DRAFT — never auto-publish. The user reviews the body, edits if
-          # needed, and clicks Publish in the GitHub UI.
+          # DRAFT — never auto-publish. The user reviews the body, edits
+          # if needed, and clicks Publish in the GitHub UI.
           draft: true
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          # First release → literal "first release" body. Otherwise → the
-          # git-cliff-rendered changelog. The `||` fallback fires when the
-          # changelog step was skipped (its output is empty in that case).
-          body: ${{ steps.changelog.outputs.content || 'first release' }}
-          files: src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+          body: ${{ needs.changelog.outputs.content }}
+          files: artifacts/*.dmg
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,51 @@ jobs:
           # the final `files:` glob doesn't need a level of indirection.
           merge-multiple: true
 
-      - name: Create draft release with .dmgs + updater bundles attached
+      - name: Generate latest.json manifest
+        # Discovers asset filenames from the downloaded artifacts so the
+        # script doesn't have to predict Tauri's productName-to-filename
+        # sanitisation (current bundler converts "Agent Terminal" →
+        # "Agent.Terminal" in DMGs; .app.tar.gz follows the same shape).
+        # The URLs embedded in the manifest use the basenames of the
+        # discovered files, which is what GitHub serves as
+        # /releases/download/<tag>/<basename>.
+        run: |
+          set -euo pipefail
+          mkdir -p manifest
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          AARCH64_TAR=$(ls artifacts/*aarch64*.app.tar.gz | head -n 1)
+          X64_TAR=$(ls artifacts/*x64*.app.tar.gz | head -n 1)
+          AARCH64_BASENAME=$(basename "${AARCH64_TAR}")
+          X64_BASENAME=$(basename "${X64_TAR}")
+          AARCH64_SIG=$(cat "${AARCH64_TAR}.sig")
+          X64_SIG=$(cat "${X64_TAR}.sig")
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          jq -n \
+            --arg version "${VERSION}" \
+            --arg notes "${RELEASE_NOTES}" \
+            --arg pub_date "${PUB_DATE}" \
+            --arg aarch64_sig "${AARCH64_SIG}" \
+            --arg aarch64_url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${AARCH64_BASENAME}" \
+            --arg x64_sig "${X64_SIG}" \
+            --arg x64_url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${X64_BASENAME}" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "darwin-aarch64": { signature: $aarch64_sig, url: $aarch64_url },
+                "darwin-x86_64":  { signature: $x64_sig,     url: $x64_url     }
+              }
+            }' > manifest/latest.json
+
+          echo "Generated latest.json:"
+          cat manifest/latest.json
+        env:
+          RELEASE_NOTES: ${{ needs.changelog.outputs.content }}
+
+      - name: Create draft release with .dmgs + updater bundles + manifest
         uses: softprops/action-gh-release@v2
         with:
           # DRAFT — never auto-publish. The user reviews the body, edits
@@ -216,13 +260,32 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body: ${{ needs.changelog.outputs.content }}
-          # Attach .dmg (installs), .app.tar.gz (updater payload), and
-          # .app.tar.gz.sig (minisign signature consumed by the updater
-          # plugin to verify the payload before installing). The manifest
-          # that points at the .app.tar.gz URLs is produced in a follow-up
-          # workflow change.
+          # Attach .dmg (installs), .app.tar.gz (updater payload),
+          # .app.tar.gz.sig (minisign signature), and latest.json (the
+          # manifest — duplicated here as an audit copy of what was
+          # published to the release-manifest branch).
           files: |
             artifacts/*.dmg
             artifacts/*.app.tar.gz
             artifacts/*.app.tar.gz.sig
+            manifest/latest.json
           fail_on_unmatched_files: true
+
+      - name: Publish manifest to release-manifest branch
+        # Sidesteps GitHub's /releases/latest/download/ redirect (which
+        # excludes pre-releases). The manifest is served at:
+        #
+        #   https://raw.githubusercontent.com/${{ github.repository }}/release-manifest/latest.json
+        #
+        # raw.githubusercontent.com caches for ~5 min — installed apps
+        # see new releases within that window. The release-manifest
+        # branch must exist as an empty orphan branch before the first
+        # run; creating it from main would carry the codebase into the
+        # manifest branch (handled in the bootstrap step documented
+        # alongside this change).
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: release-manifest
+          publish_dir: ./manifest
+          commit_message: "release: ${{ github.ref_name }} manifest"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thank you for your interest in contributing. Agent Terminal is in early active d
 - [Adding a new agent (MOD system guide)](#adding-a-new-agent-mod-system-guide)
 - [Reporting bugs](#reporting-bugs)
 - [Requesting features](#requesting-features)
+- [Releasing](#releasing)
 
 ---
 
@@ -288,6 +289,28 @@ Open an issue on GitHub with:
 
 - **New agent support:** [request on X →](https://x.com/dani_akash_)
 - **Other features:** open a GitHub issue with the `enhancement` label and describe your use case
+
+---
+
+## Releasing
+
+Releases are tag-triggered. Pushing a `vX.Y.Z` (or `vX.Y.Z-rc.N`) tag fires the workflow, which builds, signs, and notarizes per-arch `.dmg`s in parallel, attaches them plus the updater bundles to a draft GitHub release, and publishes the updater manifest to the `release-manifest` branch.
+
+```sh
+# Bump version in three places so the tag matches the bundle metadata
+# (package.json, src-tauri/tauri.conf.json, src-tauri/Cargo.toml)
+git commit -m "chore(release): vX.Y.Z"   # `chore(release)` is filtered out of the next changelog
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+The workflow takes ~15 min. When it finishes:
+
+1. Review the draft on the [releases page](https://github.com/DaniAkash/agent-terminal/releases). Both per-arch `.dmg`s, both `.app.tar.gz`s, both `.sig`s, and `latest.json` should be attached.
+2. Verify `https://raw.githubusercontent.com/DaniAkash/agent-terminal/release-manifest/latest.json` reflects the new version (cached ~5 min by raw.githubusercontent.com).
+3. Click **Publish**. Installed apps see the update on their next launch (or immediately via **Check for Updates…**).
+
+Pre-releases work the same way — tick the "pre-release" box when publishing. The manifest endpoint isn't gated by the "Latest" flag, so installed apps still see pre-releases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   **A terminal workspace built around AI coding agents.**
 
-  [![Download](https://img.shields.io/github/v/release/DaniAkash/agent-terminal?include_prereleases&label=Download%20DMG&color=blue)](https://github.com/DaniAkash/agent-terminal/releases/download/v0.1.3/Agent.Terminal_0.1.3_universal.dmg)
+  [![Latest release](https://img.shields.io/github/v/release/DaniAkash/agent-terminal?include_prereleases&label=latest&color=blue)](https://github.com/DaniAkash/agent-terminal/releases)
   [![Status](https://img.shields.io/badge/status-pre--alpha-orange)](#status)
   [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey)](#download)
 </div>
@@ -32,9 +32,17 @@ Agent Terminal is a terminal that knows the difference between a shell and an ag
 
 ## Download
 
-1. Grab the latest `.dmg` (universal binary — Apple Silicon + Intel) from the [releases page](https://github.com/DaniAkash/agent-terminal/releases).
+Pick the `.dmg` that matches your Mac on the [releases page](https://github.com/DaniAkash/agent-terminal/releases):
+
+| Apple Silicon (M1 / M2 / M3 / M4) | Intel |
+| --- | --- |
+| `agent-terminal_<version>_aarch64.dmg` | `agent-terminal_<version>_x64.dmg` |
+
+Not sure which? Click the Apple menu → About This Mac. "Chip: Apple M…" means Apple Silicon; "Processor: Intel…" means Intel.
+
+1. Download the matching `.dmg`.
 2. Open it, drag **Agent Terminal** to your Applications folder.
-3. First launch: right-click → Open (the app isn't notarised yet, so macOS Gatekeeper will warn — pre-alpha).
+3. Launch.
 
 That's it. No config files, no daemons, no tmux setup.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Not sure which? Click the Apple menu → About This Mac. "Chip: Apple M…" mean
 
 That's it. No config files, no daemons, no tmux setup.
 
+### Updates
+
+Agent Terminal checks for new versions on launch and via the app menu (**Agent Terminal → Check for Updates…**). When an update is available, a small banner offers to install it; clicking through downloads, verifies, and restarts into the new version.
+
+Versions older than the first release with built-in updates can't auto-update — install the latest `.dmg` manually one last time and future releases will arrive in-app.
+
 ---
 
 ## What you actually get

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2",
         "@tauri-apps/plugin-updater": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
@@ -366,6 +367,8 @@
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
 
     "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-updater": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -365,6 +366,8 @@
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-updater": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-updater": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,11 @@ tauri-plugin-single-instance = "2"
 # attributes notifications to com.apple.Terminal, which is fine for visibility
 # but means clicks don't route back to us — see the focus-event heuristic.
 tauri-plugin-notification = "2"
+# Self-update via signed Tauri update bundles. Disabled at build time in
+# the `dev-instance` feature (dev builds share the prod manifest endpoint
+# only by accident; letting them auto-update would overlay the prod .app
+# onto the dev bundle id).
+tauri-plugin-updater = "2"
 # Release-mode notifications (debug_assertions = false). Wraps the native
 # UNUserNotificationCenter on macOS so we get real per-notification click
 # callbacks via UNUserNotificationCenterDelegate. Mock mode falls back to

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,9 @@ tauri-plugin-notification = "2"
 # only by accident; letting them auto-update would overlay the prod .app
 # onto the dev bundle id).
 tauri-plugin-updater = "2"
+# Exposes process::relaunch() to the renderer so the update flow can
+# boot the new binary after the updater swaps it in.
+tauri-plugin-process = "2"
 # Release-mode notifications (debug_assertions = false). Wraps the native
 # UNUserNotificationCenter on macOS so we get real per-notification click
 # callbacks via UNUserNotificationCenterDelegate. Mock mode falls back to

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "core:window:allow-start-dragging",
-    "notification:default"
+    "notification:default",
+    "updater:default"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "opener:default",
     "core:window:allow-start-dragging",
     "notification:default",
-    "updater:default"
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,7 +38,7 @@ use std::sync::{Arc, Mutex};
 pub fn run() {
     let pty_map: PtyMap = Arc::new(Mutex::new(HashMap::new()));
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         // Single-instance MUST be the first plugin so duplicate launches
         // (notification clicks routing to a fresh .app, double-clicking the
         // dock icon, etc.) get intercepted before any other plugin tries to
@@ -53,7 +53,17 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_notification::init());
+
+    // Self-update — only the prod-namespaced build registers the plugin.
+    // The dev bundle id (com.daniakash.agent-terminal-dev) cannot be the
+    // legitimate target of a manifest signed for the prod app, so
+    // dev-instance builds skip the plugin entirely rather than risk an
+    // update attempt that overlays a foreign bundle.
+    #[cfg(not(feature = "dev-instance"))]
+    let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+
+    builder
         .setup(|app| {
             // Custom macOS menu — omits the default items whose shortcuts
             // conflict with our keyboard handlers:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,8 +28,12 @@ use mod_engine::{
 use notifications::NotificationService;
 use shell_integration::setup_shell_integration;
 use tauri::Manager;
+#[cfg(all(target_os = "macos", not(feature = "dev-instance")))]
+use tauri::Emitter;
 #[cfg(target_os = "macos")]
 use tauri::menu::{MenuBuilder, SubmenuBuilder};
+#[cfg(all(target_os = "macos", not(feature = "dev-instance")))]
+use tauri::menu::MenuItemBuilder;
 use pty_manager::PtyMap;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -59,9 +63,13 @@ pub fn run() {
     // The dev bundle id (com.daniakash.agent-terminal-dev) cannot be the
     // legitimate target of a manifest signed for the prod app, so
     // dev-instance builds skip the plugin entirely rather than risk an
-    // update attempt that overlays a foreign bundle.
+    // update attempt that overlays a foreign bundle. process plugin is
+    // gated under the same cfg because its only consumer here is the
+    // updater flow's post-install relaunch.
     #[cfg(not(feature = "dev-instance"))]
-    let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+    let builder = builder
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init());
 
     builder
         .setup(|app| {
@@ -86,6 +94,16 @@ pub fn run() {
             if let Err(e) = install_app_menu(app) {
                 eprintln!("[agent-terminal] menu setup failed: {e}");
             }
+
+            // Forward the "Check for Updates…" menu click to the renderer
+            // as a `menu:check-for-updates` event. The renderer's
+            // checkForUpdate() handler drives the rest of the flow.
+            #[cfg(all(target_os = "macos", not(feature = "dev-instance")))]
+            app.on_menu_event(|app_handle, event| {
+                if event.id() == "check-for-updates" {
+                    let _ = app_handle.emit("menu:check-for-updates", ());
+                }
+            });
 
             // Best-effort: write shell integration scripts. Never fail app startup.
             if let Err(e) = setup_shell_integration() {
@@ -162,6 +180,31 @@ pub fn run() {
 fn install_app_menu(
     app: &tauri::App,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // "Check for Updates…" goes between About and Services in the prod
+    // app menu. dev-instance builds intentionally skip it because the
+    // updater plugin isn't registered in those — surfacing a menu item
+    // that does nothing would be a worse footgun than not having it.
+    #[cfg(not(feature = "dev-instance"))]
+    let app_submenu = {
+        let check_for_updates =
+            MenuItemBuilder::with_id("check-for-updates", "Check for Updates…")
+                .build(app)?;
+        SubmenuBuilder::new(app, "Agent Terminal")
+            .about(None)
+            .separator()
+            .item(&check_for_updates)
+            .separator()
+            .services()
+            .separator()
+            .hide()
+            .hide_others()
+            .show_all()
+            .separator()
+            .quit()
+            .build()?
+    };
+
+    #[cfg(feature = "dev-instance")]
     let app_submenu = SubmenuBuilder::new(app, "Agent Terminal")
         .about(None)
         .separator()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["dmg", "app"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -39,6 +39,14 @@
       "minimumSystemVersion": "10.15",
       "hardenedRuntime": true,
       "entitlements": "macos/entitlements.plist"
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://raw.githubusercontent.com/DaniAkash/agent-terminal/release-manifest/latest.json"
+      ],
+      "pubkey": "REPLACE_BEFORE_MERGE_SEE_PR_DESCRIPTION"
     }
   }
 }

--- a/src/components/UpdateBanner/UpdateBanner.tsx
+++ b/src/components/UpdateBanner/UpdateBanner.tsx
@@ -1,0 +1,125 @@
+import { useStore } from '@nanostores/react'
+import { Download, RefreshCw, X } from 'lucide-react'
+import { $updater } from '@/modules/updater/$updater'
+import { installUpdate } from '@/modules/updater/installUpdate'
+
+/**
+ * Floating banner anchored above the status bar. Renders per `$updater`
+ * state — only the user-actionable states (available, downloading,
+ * ready-to-install, error, manual-check up-to-date) draw a frame. The
+ * idle and silent-checking states render nothing so the chrome stays
+ * out of the way until there's something to say.
+ */
+export function UpdateBanner() {
+  const state = useStore($updater)
+
+  if (state.kind === 'idle' || state.kind === 'checking') return null
+
+  return (
+    <div
+      className="pointer-events-auto absolute right-3 bottom-9 z-20 flex max-w-md items-start gap-3 rounded-md border border-border bg-popover px-3 py-2 text-xs shadow-lg"
+      style={{ fontFamily: 'var(--font-ui)' }}
+      role="status"
+      aria-live="polite"
+    >
+      {state.kind === 'available' && (
+        <>
+          <Download size={14} className="mt-0.5 shrink-0" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <div className="font-medium">
+              Update available — v{state.version}
+            </div>
+            {state.notes && (
+              <div className="mt-0.5 line-clamp-3 text-muted-foreground">
+                {state.notes}
+              </div>
+            )}
+            <div className="mt-2 flex gap-2">
+              <button
+                type="button"
+                onClick={() => installUpdate()}
+                className="rounded bg-primary px-2 py-1 text-primary-foreground hover:opacity-90"
+              >
+                Install now
+              </button>
+              <button
+                type="button"
+                onClick={() => $updater.set({ kind: 'idle' })}
+                className="rounded px-2 py-1 hover:bg-accent"
+              >
+                Later
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {state.kind === 'downloading' && (
+        <>
+          <RefreshCw
+            size={14}
+            className="mt-0.5 shrink-0 animate-spin"
+            aria-hidden
+          />
+          <div className="min-w-0 flex-1">
+            <div className="font-medium">
+              Downloading update… {Math.round(state.progress * 100)}%
+            </div>
+            <div className="mt-1 h-1 w-full overflow-hidden rounded bg-muted">
+              <div
+                className="h-full bg-primary transition-[width] duration-150"
+                style={{ width: `${Math.round(state.progress * 100)}%` }}
+              />
+            </div>
+          </div>
+        </>
+      )}
+
+      {state.kind === 'ready-to-install' && (
+        <>
+          <Download size={14} className="mt-0.5 shrink-0" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <div className="font-medium">Update installed — restarting…</div>
+          </div>
+        </>
+      )}
+
+      {state.kind === 'up-to-date' && (
+        <>
+          <div className="min-w-0 flex-1">
+            You're up to date (v{state.currentVersion}).
+          </div>
+          <button
+            type="button"
+            onClick={() => $updater.set({ kind: 'idle' })}
+            className="-mr-1 rounded p-1 hover:bg-accent"
+            aria-label="Dismiss"
+          >
+            <X size={12} />
+          </button>
+        </>
+      )}
+
+      {state.kind === 'error' && (
+        <>
+          <div className="min-w-0 flex-1">
+            <div className="font-medium text-destructive">
+              Couldn't check for updates
+            </div>
+            <div className="mt-0.5 line-clamp-3 text-muted-foreground">
+              {state.message}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => $updater.set({ kind: 'idle' })}
+            className="-mr-1 rounded p-1 hover:bg-accent"
+            aria-label="Dismiss"
+          >
+            <X size={12} />
+          </button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/modules/stores/useMetaHeldTracker.ts
+++ b/src/modules/stores/useMetaHeldTracker.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { $metaHeld } from '@/modules/stores/$keyboard'
+
+/**
+ * Mirrors physical Cmd-key state into `$metaHeld` so the sidebar can
+ * show project-number badges while Cmd is held. The blur listener
+ * resets the flag if the window loses focus mid-hold, preventing a
+ * stuck overlay.
+ */
+export function useMetaHeldTracker(): void {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Meta') $metaHeld.set(true)
+    }
+    function onKeyUp(e: KeyboardEvent) {
+      if (e.key === 'Meta') $metaHeld.set(false)
+    }
+    function onBlur() {
+      $metaHeld.set(false)
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+      window.removeEventListener('blur', onBlur)
+    }
+  }, [])
+}

--- a/src/modules/updater/$updater.test.ts
+++ b/src/modules/updater/$updater.test.ts
@@ -1,0 +1,157 @@
+import { mock } from 'bun:test'
+
+// Mock the @tauri-apps modules before importing checkForUpdate — the
+// real plugins invoke Tauri commands that don't exist in the test
+// runtime. We control what `check()` resolves to per test.
+const mockCheck = mock<
+  () => Promise<{ version: string; body: string | null } | null>
+>(() => Promise.resolve(null))
+
+mock.module('@tauri-apps/plugin-updater', () => ({
+  check: mockCheck,
+}))
+
+mock.module('@tauri-apps/api/app', () => ({
+  getVersion: mock(() => Promise.resolve('0.1.3')),
+}))
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+import {
+  $hasCheckedThisSession,
+  $updater,
+  type UpdaterState,
+} from '@/modules/updater/$updater'
+import { checkForUpdate } from '@/modules/updater/checkForUpdate'
+
+beforeEach(() => {
+  $updater.set({ kind: 'idle' })
+  $hasCheckedThisSession.set(false)
+  mockCheck.mockReset()
+})
+
+/* ---------------------------------------------------------------------------
+ * $updater store — discriminated-union state shape
+ * -------------------------------------------------------------------------*/
+describe('$updater store', () => {
+  test('1: starts in idle', () => {
+    expect($updater.get()).toEqual({ kind: 'idle' })
+  })
+
+  test('2: accepts every kind in the discriminated union', () => {
+    const cases: UpdaterState[] = [
+      { kind: 'idle' },
+      { kind: 'checking' },
+      { kind: 'available', version: '1.0.0', notes: 'notes' },
+      { kind: 'downloading', progress: 0.5 },
+      { kind: 'ready-to-install' },
+      { kind: 'error', message: 'boom' },
+      { kind: 'up-to-date', currentVersion: '0.1.3' },
+    ]
+    for (const s of cases) {
+      $updater.set(s)
+      expect($updater.get()).toEqual(s)
+    }
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * $hasCheckedThisSession — sticky one-shot flag
+ * -------------------------------------------------------------------------*/
+describe('$hasCheckedThisSession', () => {
+  test('3: starts false', () => {
+    expect($hasCheckedThisSession.get()).toBe(false)
+  })
+
+  test('4: set(true) sticks across reads', () => {
+    $hasCheckedThisSession.set(true)
+    expect($hasCheckedThisSession.get()).toBe(true)
+    expect($hasCheckedThisSession.get()).toBe(true)
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * checkForUpdate() — composes check() with the store
+ * -------------------------------------------------------------------------*/
+describe('checkForUpdate()', () => {
+  test('5: moves through checking → up-to-date when no update is returned', async () => {
+    mockCheck.mockResolvedValue(null)
+    const states: UpdaterState[] = []
+    const unsub = $updater.subscribe((s) => states.push(s))
+
+    await checkForUpdate()
+    unsub()
+
+    // First state is the initial idle pushed at subscribe time.
+    expect(states[0]).toEqual({ kind: 'idle' })
+    expect(states.some((s) => s.kind === 'checking')).toBe(true)
+    expect($updater.get()).toEqual({
+      kind: 'up-to-date',
+      currentVersion: '0.1.3',
+    })
+  })
+
+  test('6: moves to available with version + notes when check resolves', async () => {
+    mockCheck.mockResolvedValue({
+      version: '0.2.0',
+      body: 'New stuff.',
+    })
+
+    await checkForUpdate()
+
+    expect($updater.get()).toEqual({
+      kind: 'available',
+      version: '0.2.0',
+      notes: 'New stuff.',
+    })
+  })
+
+  test('7: tolerates a missing notes body (null → empty string)', async () => {
+    mockCheck.mockResolvedValue({ version: '0.2.0', body: null })
+
+    await checkForUpdate()
+
+    expect($updater.get()).toEqual({
+      kind: 'available',
+      version: '0.2.0',
+      notes: '',
+    })
+  })
+
+  test('8: silentOnFailure=true falls back to idle on check() rejection', async () => {
+    mockCheck.mockRejectedValue(new Error('offline'))
+
+    await checkForUpdate({ silentOnFailure: true })
+
+    expect($updater.get()).toEqual({ kind: 'idle' })
+  })
+
+  test('9: silentOnFailure=false surfaces the error in the store', async () => {
+    mockCheck.mockRejectedValue(new Error('endpoint 500'))
+
+    await checkForUpdate({ silentOnFailure: false })
+
+    expect($updater.get()).toEqual({
+      kind: 'error',
+      message: 'endpoint 500',
+    })
+  })
+
+  test('10: a non-Error rejection is coerced to a string', async () => {
+    mockCheck.mockRejectedValue('thrown a string for some reason')
+
+    await checkForUpdate()
+
+    expect($updater.get()).toEqual({
+      kind: 'error',
+      message: 'thrown a string for some reason',
+    })
+  })
+
+  test('11: default options surface errors (silentOnFailure defaults to false)', async () => {
+    mockCheck.mockRejectedValue(new Error('boom'))
+
+    await checkForUpdate()
+
+    expect($updater.get()).toEqual({ kind: 'error', message: 'boom' })
+  })
+})

--- a/src/modules/updater/$updater.ts
+++ b/src/modules/updater/$updater.ts
@@ -1,0 +1,16 @@
+import { atom } from 'nanostores'
+
+export type UpdaterState =
+  | { kind: 'idle' }
+  | { kind: 'checking' }
+  | { kind: 'available'; version: string; notes: string }
+  | { kind: 'downloading'; progress: number }
+  | { kind: 'ready-to-install' }
+  | { kind: 'error'; message: string }
+  | { kind: 'up-to-date'; currentVersion: string }
+
+export const $updater = atom<UpdaterState>({ kind: 'idle' })
+
+// Sticky session flag so the launch auto-check fires exactly once per
+// app process. Manual menu-triggered checks ignore it.
+export const $hasCheckedThisSession = atom<boolean>(false)

--- a/src/modules/updater/checkForUpdate.ts
+++ b/src/modules/updater/checkForUpdate.ts
@@ -1,0 +1,41 @@
+import { getVersion } from '@tauri-apps/api/app'
+import { check } from '@tauri-apps/plugin-updater'
+import { $updater } from '@/modules/updater/$updater'
+
+/**
+ * Hit the updater endpoint and feed the result into `$updater`.
+ *
+ * `silentOnFailure` controls the failure behaviour: silent on the
+ * startup auto-check (so an offline user doesn't see a useless toast),
+ * loud on manual menu-triggered checks (so the user knows their
+ * intentional action did something).
+ */
+export async function checkForUpdate(opts?: {
+  silentOnFailure?: boolean
+}): Promise<void> {
+  $updater.set({ kind: 'checking' })
+  try {
+    const update = await check()
+    if (!update) {
+      // Surface the currently-installed version so the menu-triggered
+      // "you're up to date" toast can show what the user is on.
+      const currentVersion = await getVersion()
+      $updater.set({ kind: 'up-to-date', currentVersion })
+      return
+    }
+    $updater.set({
+      kind: 'available',
+      version: update.version,
+      notes: update.body ?? '',
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (opts?.silentOnFailure) {
+      // biome-ignore lint/suspicious/noConsole: silent-failure path needs a breadcrumb in devtools
+      console.warn('[updater] check failed:', message)
+      $updater.set({ kind: 'idle' })
+      return
+    }
+    $updater.set({ kind: 'error', message })
+  }
+}

--- a/src/modules/updater/installUpdate.ts
+++ b/src/modules/updater/installUpdate.ts
@@ -1,0 +1,56 @@
+import { relaunch } from '@tauri-apps/plugin-process'
+import { check, type Update } from '@tauri-apps/plugin-updater'
+import { $updater } from '@/modules/updater/$updater'
+
+/**
+ * Download + install the pending update, then relaunch the app.
+ *
+ * The check() call is repeated here (rather than passed in from the
+ * caller) because the Update object's downloadAndInstall is bound to a
+ * specific check() invocation — passing it across a UI event would
+ * require either captured state or a Promise lifetime that survives
+ * the React render that triggered the call.
+ */
+export async function installUpdate(): Promise<void> {
+  let update: Update | null
+  try {
+    update = await check()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    $updater.set({ kind: 'error', message })
+    return
+  }
+  if (!update) {
+    $updater.set({ kind: 'idle' })
+    return
+  }
+
+  $updater.set({ kind: 'downloading', progress: 0 })
+
+  let downloaded = 0
+  let total = 0
+
+  try {
+    await update.downloadAndInstall((event) => {
+      switch (event.event) {
+        case 'Started':
+          total = event.data.contentLength ?? 0
+          break
+        case 'Progress':
+          downloaded += event.data.chunkLength
+          $updater.set({
+            kind: 'downloading',
+            progress: total > 0 ? downloaded / total : 0,
+          })
+          break
+        case 'Finished':
+          $updater.set({ kind: 'ready-to-install' })
+          break
+      }
+    })
+    await relaunch()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    $updater.set({ kind: 'error', message })
+  }
+}

--- a/src/modules/updater/useUpdaterWiring.ts
+++ b/src/modules/updater/useUpdaterWiring.ts
@@ -1,0 +1,31 @@
+import { listen } from '@tauri-apps/api/event'
+import { useEffect } from 'react'
+import { $hasCheckedThisSession } from '@/modules/updater/$updater'
+import { checkForUpdate } from '@/modules/updater/checkForUpdate'
+
+/**
+ * Wires the renderer side of the updater flow once per app session:
+ * one deferred startup check (silent on failure) and a listener for
+ * the "Check for Updates…" menu item event.
+ */
+export function useUpdaterWiring(): void {
+  useEffect(() => {
+    if ($hasCheckedThisSession.get()) return
+    $hasCheckedThisSession.set(true)
+    // Defer past the launch sequence so PTY spawn / mod init isn't
+    // sharing the event loop with a network round-trip.
+    const t = setTimeout(() => {
+      checkForUpdate({ silentOnFailure: true })
+    }, 3000)
+    return () => clearTimeout(t)
+  }, [])
+
+  useEffect(() => {
+    const unlistenPromise = listen('menu:check-for-updates', () => {
+      checkForUpdate({ silentOnFailure: false })
+    })
+    return () => {
+      unlistenPromise.then((fn) => fn()).catch(() => {})
+    }
+  }, [])
+}

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -5,6 +5,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { Sidebar } from '@/components/Sidebar/Sidebar'
 import { StatusBar } from '@/components/StatusBar/StatusBar'
 import { TerminalSearchBar } from '@/components/TerminalSearchBar/TerminalSearchBar'
+import { UpdateBanner } from '@/components/UpdateBanner/UpdateBanner'
 import { formatDropPayload } from '@/modules/dragDrop/dropPayload'
 import { Keys, Mod } from '@/modules/keymap/keys'
 import { $activeSearch, openSearch } from '@/modules/stores/$activeSearch'
@@ -15,7 +16,6 @@ import {
   increaseFontSize,
   resetFontSize,
 } from '@/modules/stores/$fontSize'
-import { $metaHeld } from '@/modules/stores/$keyboard'
 import {
   $activeProjectId,
   $activeTabId,
@@ -30,11 +30,9 @@ import {
   removeTab,
   restoreTabLabel,
 } from '@/modules/stores/$projects'
+import { useMetaHeldTracker } from '@/modules/stores/useMetaHeldTracker'
+import { useUpdaterWiring } from '@/modules/updater/useUpdaterWiring'
 import { WorkspaceView } from '@/screens/workspace/WorkspaceView'
-
-/* ---------------------------------------------------------------------------
- * WorkspaceLayout
- * -------------------------------------------------------------------------*/
 
 export function WorkspaceLayout() {
   const projects = useStore($projects)
@@ -63,29 +61,7 @@ export function WorkspaceLayout() {
     }
   }, [projects, activeProjectId])
 
-  // Track whether Cmd is physically held so the sidebar can show project-number
-  // badges. The blur listener resets the flag if the window loses focus while
-  // Cmd is held — prevents the overlay from getting stuck.
-  useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Meta') $metaHeld.set(true)
-    }
-    function onKeyUp(e: KeyboardEvent) {
-      if (e.key === 'Meta') $metaHeld.set(false)
-    }
-    function onBlur() {
-      $metaHeld.set(false)
-    }
-
-    window.addEventListener('keydown', onKeyDown)
-    window.addEventListener('keyup', onKeyUp)
-    window.addEventListener('blur', onBlur)
-    return () => {
-      window.removeEventListener('keydown', onKeyDown)
-      window.removeEventListener('keyup', onKeyUp)
-      window.removeEventListener('blur', onBlur)
-    }
-  }, [])
+  useMetaHeldTracker()
 
   // File drag-drop — Tauri 2 captures the OS drop at the window level
   // (default `dragDropEnabled: true`) and emits a JS event. On `drop` we
@@ -108,6 +84,8 @@ export function WorkspaceLayout() {
       unlistenPromise.then((fn) => fn()).catch(() => {})
     }
   }, [])
+
+  useUpdaterWiring()
 
   // enableOnFormTags is required because xterm uses a hidden <textarea> to
   // capture keyboard input. Without it react-hotkeys-hook silently ignores
@@ -309,6 +287,7 @@ export function WorkspaceLayout() {
         </div>
       </div>
       <StatusBar />
+      <UpdateBanner />
     </div>
   )
 }


### PR DESCRIPTION
> Stacked on top of #57 (which is stacked on #56, on #55, on #54). Top of the stack — review the earlier PRs first.

## Summary

Documentation pass for the auto-update + per-arch work shipped in the prior PRs.

## README

The Download section already lists both per-arch \`.dmg\`s (added in #54). This PR adds an **Updates** subsection right under it explaining the launch + on-demand check + auto-install flow, with a note that anyone on a version older than the first build-with-updater has to install the latest \`.dmg\` manually one last time.

## CONTRIBUTING

New **Releasing** section walking through:

- The version-bump + tag + push flow
- What artifacts to expect on the draft release (both \`.dmg\`s, both \`.app.tar.gz\`s, both \`.sig\`s, \`latest.json\`)
- How to verify the manifest endpoint after publish
- That pre-releases work end-to-end through the manifest endpoint (because the endpoint isn't gated by GitHub's \"Latest\" flag)

TOC updated to include the new section.

## Test plan

- [ ] Render the README on GitHub and confirm the table + Updates section look right
- [ ] Render CONTRIBUTING on GitHub and confirm the Releasing section + TOC link work