### PR TITLE
feat(navigation): tab recency badges + Cmd+P tab switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,7 @@ Always-on context for the focused tab — refreshed every couple of seconds, nev
 Want support for another agent? [Open an issue](https://github.com/DaniAkash/agent-terminal/issues/new) or [tell me on X](https://x.com/dani_akash_).
 
 ### Find your way back
-When you're juggling many projects, it's easy to lose track of which tabs you were just in. Agent Terminal keeps an MRU list of every tab you visit and surfaces it in two ways:
-
-- **Sidebar badges** — the ten most-recently active tabs across the whole workspace get a small `1..10` digit on the right side of their row. Rank 1 is where you just were; rank 10 is the oldest of the recent ten.
-- **`Cmd+P` quick-switcher** — opens a VS Code-style palette with every open tab in recency order, the same rank chips, a `Nm ago` timestamp, and case-insensitive substring search across label + project + cwd. Type a few letters, hit Enter, you're there.
-
-Both share the same recency data and are persisted to local storage, so the ranks still mean something after a quit-and-relaunch.
+When you're juggling many projects, it's easy to lose track of which tabs you were just in. `Cmd+P` opens a VS Code-style quick-switcher with every open tab in recency order, rank chips, a `Nm ago` timestamp, and case-insensitive substring search across label + project + cwd. Type a few letters, hit Enter, you're there. The recency is persisted to local storage so the order still makes sense after a quit-and-relaunch.
 
 ### Keyboard shortcuts
 - `Ctrl+T` — new tab in the active project

--- a/README.md
+++ b/README.md
@@ -65,11 +65,20 @@ Always-on context for the focused tab — refreshed every couple of seconds, nev
 
 Want support for another agent? [Open an issue](https://github.com/DaniAkash/agent-terminal/issues/new) or [tell me on X](https://x.com/dani_akash_).
 
+### Find your way back
+When you're juggling many projects, it's easy to lose track of which tabs you were just in. Agent Terminal keeps an MRU list of every tab you visit and surfaces it in two ways:
+
+- **Sidebar badges** — the ten most-recently active tabs across the whole workspace get a small `1..10` digit on the right side of their row. Rank 1 is where you just were; rank 10 is the oldest of the recent ten. Pinned tabs show the rank too (no fighting with the pin icon).
+- **`Cmd+P` quick-switcher** — opens a VS Code-style palette with every open tab in recency order, the same rank chips, a `Nm ago` timestamp, and fuzzy search across label + project + cwd. Type a few letters, hit Enter, you're there.
+
+Both share the same recency data and are persisted to local storage, so the ranks still mean something after a quit-and-relaunch.
+
 ### Keyboard shortcuts
 - `Ctrl+T` — new tab in the active project
 - `Ctrl+W` — close the active tab
 - `Ctrl+Tab` / `Ctrl+Shift+Tab` — cycle tabs
 - `Ctrl+1` … `Ctrl+9` — jump to project N
+- `Cmd+P` — open the recent-tabs quick-switcher
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Want support for another agent? [Open an issue](https://github.com/DaniAkash/age
 ### Find your way back
 When you're juggling many projects, it's easy to lose track of which tabs you were just in. Agent Terminal keeps an MRU list of every tab you visit and surfaces it in two ways:
 
-- **Sidebar badges** — the ten most-recently active tabs across the whole workspace get a small `1..10` digit on the right side of their row. Rank 1 is where you just were; rank 10 is the oldest of the recent ten. Pinned tabs show the rank too (no fighting with the pin icon).
+- **Sidebar badges** — the ten most-recently active tabs across the whole workspace get a small `1..10` digit on the right side of their row. Rank 1 is where you just were; rank 10 is the oldest of the recent ten.
 - **`Cmd+P` quick-switcher** — opens a VS Code-style palette with every open tab in recency order, the same rank chips, a `Nm ago` timestamp, and fuzzy search across label + project + cwd. Type a few letters, hit Enter, you're there.
 
 Both share the same recency data and are persisted to local storage, so the ranks still mean something after a quit-and-relaunch.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Always-on context for the focused tab — refreshed every couple of seconds, nev
 Want support for another agent? [Open an issue](https://github.com/DaniAkash/agent-terminal/issues/new) or [tell me on X](https://x.com/dani_akash_).
 
 ### Find your way back
-When you're juggling many projects, it's easy to lose track of which tabs you were just in. `Cmd+P` opens a VS Code-style quick-switcher with every open tab in recency order, rank chips, a `Nm ago` timestamp, and case-insensitive substring search across label + project + cwd. Type a few letters, hit Enter, you're there. The recency is persisted to local storage so the order still makes sense after a quit-and-relaunch.
+`Cmd+P` opens a switcher for your recently used tabs — type a few letters, hit Enter, you're there.
 
 ### Keyboard shortcuts
 - `Ctrl+T` — new tab in the active project

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Want support for another agent? [Open an issue](https://github.com/DaniAkash/age
 When you're juggling many projects, it's easy to lose track of which tabs you were just in. Agent Terminal keeps an MRU list of every tab you visit and surfaces it in two ways:
 
 - **Sidebar badges** — the ten most-recently active tabs across the whole workspace get a small `1..10` digit on the right side of their row. Rank 1 is where you just were; rank 10 is the oldest of the recent ten.
-- **`Cmd+P` quick-switcher** — opens a VS Code-style palette with every open tab in recency order, the same rank chips, a `Nm ago` timestamp, and fuzzy search across label + project + cwd. Type a few letters, hit Enter, you're there.
+- **`Cmd+P` quick-switcher** — opens a VS Code-style palette with every open tab in recency order, the same rank chips, a `Nm ago` timestamp, and case-insensitive substring search across label + project + cwd. Type a few letters, hit Enter, you're there.
 
 Both share the same recency data and are persisted to local storage, so the ranks still mean something after a quit-and-relaunch.
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lucide-react": "^1.8.0",
         "nanostores": "^1.2.0",
         "react": "^19.1.0",
@@ -250,6 +251,40 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
@@ -416,6 +451,8 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
@@ -455,6 +492,8 @@
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
@@ -501,6 +540,8 @@
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
@@ -589,6 +630,8 @@
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-own-enumerable-keys": ["get-own-enumerable-keys@1.0.0", "", {}, "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA=="],
 
@@ -834,6 +877,12 @@
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
@@ -962,6 +1011,10 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
@@ -1003,6 +1056,16 @@
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^1.8.0",
     "nanostores": "^1.2.0",
     "react": "^19.1.0",

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -64,7 +64,7 @@ export function Sidebar() {
   }
 
   return (
-    <div className="flex h-full w-[232px] min-w-[232px] flex-col border-sidebar-border border-r bg-sidebar">
+    <div className="flex h-full w-[var(--sidebar-width)] min-w-[var(--sidebar-width)] flex-col border-sidebar-border border-r bg-sidebar">
       {/* Header — drag region, reserves traffic-light space */}
       <div
         data-tauri-drag-region

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { useStore } from '@nanostores/react'
+import { CommandShortcut } from '@/components/ui/command'
 import {
   $activeProjectId,
   $activeTabId,
@@ -76,6 +77,16 @@ export function Sidebar() {
         >
           Workspaces
         </span>
+        {/* Ambient ⌘P hint — advertises the tab switcher. Persistent and
+            dim so the eye stops registering it once learned, but visible
+            enough that a new user discovers the chord without holding any
+            modifier. */}
+        <CommandShortcut
+          className="ml-auto opacity-50"
+          title="Open the tab switcher (⌘P)"
+        >
+          ⌘P
+        </CommandShortcut>
       </div>
 
       {/* Project tree — scrolls vertically; scrollbar hidden, bottom shadow

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -22,7 +22,6 @@ import {
 } from '@/modules/stores/$navigation'
 import { removeTab, renameTab, toggleTabPin } from '@/modules/stores/$projects'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
-import { $tabRecency, MAX_BADGE_RANK } from '@/modules/stores/$tabRecency'
 import {
   MONO_FONT,
   makeTabKey,
@@ -40,17 +39,10 @@ export function SidebarTabItem({
   const activeProjectId = useStore($activeProjectId)
   const activeTabsByProject = useStore($activeTabId)
   const allTabMeta = useStore($tabMeta)
-  const recency = useStore($tabRecency)
   const isActive =
     activeProjectId === projectId && activeTabsByProject[projectId] === tab.id
   const tabKey = makeTabKey(projectId, tab.id)
   const tabMeta = allTabMeta[tabKey]
-  // Rank shown for the top MAX_BADGE_RANK tabs regardless of pin state —
-  // pinned + recent is a legit combination and the slot lives separately
-  // from the pin slot on the row's right side.
-  const recencyIdx = recency.indexOf(tabKey)
-  const rank =
-    recencyIdx >= 0 && recencyIdx < MAX_BADGE_RANK ? recencyIdx + 1 : 0
   const [renaming, setRenaming] = useState(false)
 
   const {
@@ -149,25 +141,14 @@ export function SidebarTabItem({
 
             {/*
              * Right-side indicators, left to right:
-             *   Rank digit (top 10 only) → DangerBadge → StatusIcon
+             *   DangerBadge → StatusIcon
              *
-             * Rank lives here (not in the left pin slot) so it can coexist
-             * with the pin icon — a pinned tab the user just touched should
-             * still surface as recent. PR info lives in the status bar.
+             * Recency information (which tabs the user was just in) is
+             * now exclusively a Cmd+P concern. Earlier we surfaced 1..10
+             * rank digits here for ambient awareness; daily-use feedback
+             * found them distracting more than helpful. The header pill
+             * advertises the Cmd+P chord; the palette does the recall.
              */}
-            {!renaming && rank > 0 && (
-              <span
-                aria-hidden="true"
-                title={`Recently active (rank ${rank})`}
-                // w-4 (not w-3) leaves room for the two-digit "10" — at
-                // 9.5px JetBrains Mono with tabular-nums, "10" measures
-                // ~11-12px and would sit flush against a 12px slot.
-                className="w-4 shrink-0 select-none text-right tabular-nums opacity-50"
-                style={{ fontFamily: MONO_FONT, fontSize: 9.5 }}
-              >
-                {rank}
-              </span>
-            )}
             {!renaming &&
               tabMeta?.type === 'agent' &&
               hasDangerFlag(tabMeta.agentCmd) && <DangerBadge size={11} />}

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -159,7 +159,10 @@ export function SidebarTabItem({
               <span
                 aria-hidden="true"
                 title={`Recently active (rank ${rank})`}
-                className="w-3 shrink-0 select-none text-right tabular-nums opacity-50"
+                // w-4 (not w-3) leaves room for the two-digit "10" — at
+                // 9.5px JetBrains Mono with tabular-nums, "10" measures
+                // ~11-12px and would sit flush against a 12px slot.
+                className="w-4 shrink-0 select-none text-right tabular-nums opacity-50"
                 style={{ fontFamily: MONO_FONT, fontSize: 9.5 }}
               >
                 {rank}

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/modules/stores/$navigation'
 import { removeTab, renameTab, toggleTabPin } from '@/modules/stores/$projects'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
+import { $tabRecency, MAX_BADGE_RANK } from '@/modules/stores/$tabRecency'
 import {
   MONO_FONT,
   makeTabKey,
@@ -39,9 +40,17 @@ export function SidebarTabItem({
   const activeProjectId = useStore($activeProjectId)
   const activeTabsByProject = useStore($activeTabId)
   const allTabMeta = useStore($tabMeta)
+  const recency = useStore($tabRecency)
   const isActive =
     activeProjectId === projectId && activeTabsByProject[projectId] === tab.id
-  const tabMeta = allTabMeta[makeTabKey(projectId, tab.id)]
+  const tabKey = makeTabKey(projectId, tab.id)
+  const tabMeta = allTabMeta[tabKey]
+  // Rank shown for the top MAX_BADGE_RANK tabs regardless of pin state —
+  // pinned + recent is a legit combination and the slot lives separately
+  // from the pin slot on the row's right side.
+  const recencyIdx = recency.indexOf(tabKey)
+  const rank =
+    recencyIdx >= 0 && recencyIdx < MAX_BADGE_RANK ? recencyIdx + 1 : 0
   const [renaming, setRenaming] = useState(false)
 
   const {
@@ -140,22 +149,26 @@ export function SidebarTabItem({
 
             {/*
              * Right-side indicators, left to right:
-             *   DangerBadge → StatusIcon
+             *   Rank digit (top 10 only) → DangerBadge → StatusIcon
              *
-             * DangerBadge sits immediately left of the status icon so it reads
-             * as "this agent is running hot" rather than a separate entity.
-             * PR info now lives in the status bar (StatusBarRight → PrItem)
-             * where there's room for a state icon, checks dot, and tooltip.
+             * Rank lives here (not in the left pin slot) so it can coexist
+             * with the pin icon — a pinned tab the user just touched should
+             * still surface as recent. PR info lives in the status bar.
              */}
+            {!renaming && rank > 0 && (
+              <span
+                aria-hidden="true"
+                title={`Recently active (rank ${rank})`}
+                className="w-3 shrink-0 select-none text-right tabular-nums opacity-50"
+                style={{ fontFamily: MONO_FONT, fontSize: 9.5 }}
+              >
+                {rank}
+              </span>
+            )}
             {!renaming &&
               tabMeta?.type === 'agent' &&
               hasDangerFlag(tabMeta.agentCmd) && <DangerBadge size={11} />}
-            {!renaming && (
-              <TabStatusIcon
-                tabId={makeTabKey(projectId, tab.id)}
-                active={isActive}
-              />
-            )}
+            {!renaming && <TabStatusIcon tabId={tabKey} active={isActive} />}
           </button>
         </div>
       </ContextMenuTrigger>

--- a/src/components/TabStatusIcon.tsx
+++ b/src/components/TabStatusIcon.tsx
@@ -1,9 +1,9 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect } from 'react'
 import { AgentGlyph } from '@/components/AgentGlyph'
 import { deriveAgentState } from '@/components/agent.helpers'
 import { RunningDot } from '@/components/RunningDot'
-import { $tabMeta } from '@/modules/stores/$tabMeta'
+import { $tabMeta, updateTabMeta } from '@/modules/stores/$tabMeta'
 
 type Props = {
   tabId: string
@@ -49,49 +49,22 @@ type Props = {
  *   AgentTurnMod will unlock them when it writes agentState to TabMeta.
  */
 
-/** How long (ms) the green "done" dot stays visible before fading to idle. */
-const DONE_LINGER_MS = 10_000
-
 export function TabStatusIcon({ tabId, active = false }: Props) {
   const allMeta = useStore($tabMeta)
   const meta = allMeta[tabId]
   const status = meta?.status ?? 'idle'
   const type = meta?.type ?? 'shell'
+  // showDone derived from the store — every instance of this component for
+  // the same tab agrees on the visual. The 10s linger is enforced by a
+  // single per-tab setTimeout in mod-listener that clears `doneAt` directly.
+  const showDone = meta?.doneAt !== undefined
 
-  // Controls whether the transient green "done" dot is currently visible.
-  // Kept in local state rather than the store because it is purely a display
-  // concern — the underlying status remains 'done' until the next command runs.
-  const [showDone, setShowDone] = useState(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // Start or cancel the linger timer whenever status changes.
+  // Navigating to the tab counts as acknowledgement — clear the done stamp
+  // immediately so the green dot disappears across every surface (sidebar,
+  // tab bar, palette) in the same tick.
   useEffect(() => {
-    if (status === 'done') {
-      setShowDone(true)
-      timerRef.current = setTimeout(() => setShowDone(false), DONE_LINGER_MS)
-    } else {
-      // running / error / idle all cancel any in-flight timer immediately.
-      setShowDone(false)
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-    }
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current)
-    }
-  }, [status])
-
-  // Navigating to the tab counts as "acknowledged" — clear the done dot right away.
-  useEffect(() => {
-    if (active && showDone) {
-      setShowDone(false)
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-    }
-  }, [active, showDone])
+    if (active && showDone) updateTabMeta(tabId, { doneAt: undefined })
+  }, [active, showDone, tabId])
 
   if (type === 'agent') {
     return (

--- a/src/components/TabSwitcher/TabSwitcher.tsx
+++ b/src/components/TabSwitcher/TabSwitcher.tsx
@@ -26,7 +26,7 @@ import {
 import { $projects } from '@/modules/stores/$projects'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
 import { $tabRecency, $tabRecencyTimes } from '@/modules/stores/$tabRecency'
-import { cwdBasename, MONO_FONT } from '@/screens/workspace/workspace.helpers'
+import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
 
 /* ---------------------------------------------------------------------------
  * TabSwitcher — Cmd+P quick-switch palette.
@@ -184,7 +184,12 @@ export function TabSwitcher() {
                   {row.cwd && (
                     <>
                       <span className="opacity-50"> · </span>
-                      {cwdBasename(row.cwd)}
+                      {/* Full cwd path here (not the basename) — the
+                          label already shows the basename for un-renamed
+                          tabs, so basename in meta would just repeat it.
+                          Full path adds context (which subfolder of which
+                          project). truncate handles overflow. */}
+                      {row.cwd}
                     </>
                   )}
                   <span className="opacity-50"> · </span>

--- a/src/components/TabSwitcher/TabSwitcher.tsx
+++ b/src/components/TabSwitcher/TabSwitcher.tsx
@@ -104,6 +104,10 @@ export function TabSwitcher() {
       onOpenChange={setOpen}
       title="Tab switcher"
       description="Jump to a recently active tab"
+      // VS Code-style placement: pinned near the top of the terminal area
+      // (not the whole window — sidebar shifts the centre right by
+      // --sidebar-half). top:64px puts it just below the TabBar.
+      className="top-16 left-[calc(50%+var(--sidebar-half))] sm:max-w-[600px]"
     >
       {/* shouldFilter=false: we own the filter (filterSwitcherRows) so we
           can preserve recency order among matches. cmdk's default filter
@@ -114,7 +118,7 @@ export function TabSwitcher() {
           value={query}
           onValueChange={setQuery}
         />
-        <CommandList className="max-h-[440px] p-1.5">
+        <CommandList className="max-h-[380px] p-1.5">
           <CommandEmpty className="py-8 text-sm opacity-60">
             No matching tabs.
           </CommandEmpty>

--- a/src/components/TabSwitcher/TabSwitcher.tsx
+++ b/src/components/TabSwitcher/TabSwitcher.tsx
@@ -122,13 +122,18 @@ export function TabSwitcher() {
           <CommandEmpty className="py-8 text-sm opacity-60">
             No matching tabs.
           </CommandEmpty>
-          {filtered.map((row) => (
+          {filtered.map((row, idx) => (
             <CommandItem
               key={row.tabKey}
-              // cmdk uses `value` as the keyboard-nav identity. Use the
-              // tabKey alone (guaranteed unique) so duplicate label/project
-              // strings across projects don't collide.
-              value={row.tabKey}
+              // cmdk derives data-selected from a strict value-string match
+              // (state.value === item.value), so any two items sharing the
+              // same value collapse into one selection slot — Enter always
+              // fires the first match because cmdk's lookup uses
+              // querySelector('[data-selected=true]'). Prefix with the row
+              // index so the value is guaranteed unique even if a future
+              // change ever lets tabKey collide. onSelect uses a closure
+              // over `row` so the value itself is never dispatched.
+              value={`${idx}|${row.tabKey}`}
               onSelect={() => handleSelect(row)}
               className={cn(
                 // Layout: comfortably padded row, fixed-rhythm gap.

--- a/src/components/TabSwitcher/TabSwitcher.tsx
+++ b/src/components/TabSwitcher/TabSwitcher.tsx
@@ -1,0 +1,160 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useMemo, useState } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { TabStatusIcon } from '@/components/TabStatusIcon'
+import {
+  buildSwitcherRows,
+  filterSwitcherRows,
+  formatRelativeTime,
+  type SwitcherRow,
+} from '@/components/TabSwitcher/tab-switcher.helpers'
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Keys, Mod } from '@/modules/keymap/keys'
+import {
+  $activeProjectId,
+  $activeTabId,
+  navigateToTab,
+} from '@/modules/stores/$navigation'
+import { $projects } from '@/modules/stores/$projects'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
+import { $tabRecency, $tabRecencyTimes } from '@/modules/stores/$tabRecency'
+import { cwdBasename, MONO_FONT } from '@/screens/workspace/workspace.helpers'
+
+/* ---------------------------------------------------------------------------
+ * TabSwitcher — Cmd+P quick-switch palette.
+ *
+ * Lists every open tab sorted by recency. Fuzzy-filterable by typing into
+ * the search input (label + project name + cwd). Enter switches to the
+ * selected tab. Rank shown for every visited tab — no cap, unlike the
+ * sidebar's 1..10 ambient badge.
+ * -------------------------------------------------------------------------*/
+
+// Owns its own open state and Cmd+P hotkey so consumers (WorkspaceLayout)
+// can just render `<TabSwitcher />`. Keeps `WorkspaceLayout` short and
+// makes future call sites trivial.
+const hotkeyOpts = { preventDefault: true, enableOnFormTags: true } as const
+
+export function TabSwitcher() {
+  const [open, setOpen] = useState(false)
+
+  // ⌘P — toggle. Matches VS Code / Cursor / Sublime quick-switcher.
+  // preventDefault suppresses the webview's default print dialog.
+  useHotkeys(`${Mod.Meta}+${Keys.P}`, () => setOpen((v) => !v), hotkeyOpts)
+
+  const projects = useStore($projects)
+  const recency = useStore($tabRecency)
+  const recencyTimes = useStore($tabRecencyTimes)
+  const tabMeta = useStore($tabMeta)
+  const activeProjectId = useStore($activeProjectId)
+  const activeTabIds = useStore($activeTabId)
+  const [query, setQuery] = useState('')
+
+  // Re-render every 30s while open so "3m ago" stays fresh without
+  // invalidating sidebar subscribers.
+  const [tick, setTick] = useState(0)
+  useEffect(() => {
+    if (!open) return
+    const id = setInterval(() => setTick((n) => n + 1), 30_000)
+    return () => clearInterval(id)
+  }, [open])
+
+  // Reset query each time the dialog opens. Otherwise a previous search
+  // lingers and the user sees a filtered list when they expected the full
+  // recency view.
+  useEffect(() => {
+    if (open) setQuery('')
+  }, [open])
+
+  const rows = useMemo(
+    () =>
+      buildSwitcherRows({
+        projects,
+        recency,
+        recencyTimes,
+        tabMeta,
+        activeProjectId,
+        activeTabIds,
+      }),
+    [projects, recency, recencyTimes, tabMeta, activeProjectId, activeTabIds],
+  )
+
+  const filtered = useMemo(() => filterSwitcherRows(rows, query), [rows, query])
+
+  function handleSelect(row: SwitcherRow): void {
+    setOpen(false)
+    if (!row.isCurrent) navigateToTab(row.projectId, row.tabId)
+  }
+
+  // Recompute `now` on each render (including the 30s tick) so the
+  // relative-time formatter stays fresh.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: tick forces refresh
+  const now = useMemo(() => Date.now(), [tick, open])
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Tab switcher"
+      description="Jump to a recently active tab"
+    >
+      {/* shouldFilter=false: we own the filter (filterSwitcherRows) so we
+          can preserve recency order among matches. cmdk's default filter
+          would score-sort and lose the recency ranking. */}
+      <Command shouldFilter={false}>
+        <CommandInput
+          placeholder="Search tabs…"
+          value={query}
+          onValueChange={setQuery}
+        />
+        <CommandList>
+          <CommandEmpty>No matching tabs.</CommandEmpty>
+          {filtered.map((row) => (
+            <CommandItem
+              key={row.tabKey}
+              // cmdk uses `value` as the keyboard-nav identity. Use the
+              // tabKey alone (guaranteed unique) so duplicate label/project
+              // strings across projects don't collide.
+              value={row.tabKey}
+              onSelect={() => handleSelect(row)}
+              className={row.isCurrent ? 'opacity-60' : ''}
+            >
+              <div className="flex w-full items-center gap-3">
+                <span
+                  aria-hidden="true"
+                  className="w-5 shrink-0 text-right tabular-nums opacity-50"
+                  style={{ fontFamily: MONO_FONT, fontSize: 10 }}
+                >
+                  {row.rank > 0 ? row.rank : ''}
+                </span>
+                <TabStatusIcon tabId={row.tabKey} active={row.isCurrent} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[12px]">
+                    {row.label}
+                    {row.isCurrent && (
+                      <span className="ml-2 opacity-50">(current)</span>
+                    )}
+                  </div>
+                  <div
+                    className="truncate text-[10.5px] opacity-60"
+                    style={{ fontFamily: MONO_FONT }}
+                  >
+                    {row.projectName}
+                    {row.cwd && ` · ${cwdBasename(row.cwd)}`}
+                    {` · ${formatRelativeTime(now, row.lastActiveAt)}`}
+                  </div>
+                </div>
+              </div>
+            </CommandItem>
+          ))}
+        </CommandList>
+      </Command>
+    </CommandDialog>
+  )
+}

--- a/src/components/TabSwitcher/TabSwitcher.tsx
+++ b/src/components/TabSwitcher/TabSwitcher.tsx
@@ -16,6 +16,7 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command'
+import { cn } from '@/lib/utils'
 import { Keys, Mod } from '@/modules/keymap/keys'
 import {
   $activeProjectId,
@@ -113,8 +114,10 @@ export function TabSwitcher() {
           value={query}
           onValueChange={setQuery}
         />
-        <CommandList>
-          <CommandEmpty>No matching tabs.</CommandEmpty>
+        <CommandList className="max-h-[440px] p-1.5">
+          <CommandEmpty className="py-8 text-sm opacity-60">
+            No matching tabs.
+          </CommandEmpty>
           {filtered.map((row) => (
             <CommandItem
               key={row.tabKey}
@@ -123,32 +126,60 @@ export function TabSwitcher() {
               // strings across projects don't collide.
               value={row.tabKey}
               onSelect={() => handleSelect(row)}
-              className={row.isCurrent ? 'opacity-60' : ''}
+              className={cn(
+                // Layout: comfortably padded row, fixed-rhythm gap.
+                'group/row relative my-0.5 flex items-center gap-3 px-3 py-2.5',
+                // Visible selected/hover state (cmdk sets data-selected
+                // on both keyboard nav and mouseover) — accent-soft is the
+                // colored 10-14% wash that pairs with the accent rail.
+                'data-[selected=true]:bg-[var(--accent-soft)]',
+                'data-[selected=true]:text-foreground',
+                // Left accent bar — invisible by default, accent when selected.
+                "before:absolute before:top-2 before:bottom-2 before:left-0 before:w-[3px] before:rounded-r before:bg-transparent before:content-['']",
+                'data-[selected=true]:before:bg-accent',
+                'before:transition-colors',
+                row.isCurrent && 'opacity-55',
+              )}
             >
-              <div className="flex w-full items-center gap-3">
-                <span
-                  aria-hidden="true"
-                  className="w-5 shrink-0 text-right tabular-nums opacity-50"
-                  style={{ fontFamily: MONO_FONT, fontSize: 10 }}
-                >
-                  {row.rank > 0 ? row.rank : ''}
-                </span>
+              {/* Rank — fixed-width column so digits line up across rows. */}
+              <span
+                aria-hidden="true"
+                className="w-5 shrink-0 text-right tabular-nums opacity-45 group-data-[selected=true]/row:opacity-80"
+                style={{ fontFamily: MONO_FONT, fontSize: 10.5 }}
+              >
+                {row.rank > 0 ? row.rank : ''}
+              </span>
+
+              {/* Status icon slot — fixed 16px square. AgentGlyph (14px)
+                  centres inside; dot icons sit centred too. Keeps the
+                  label column origin stable across icon types. */}
+              <div className="flex size-4 shrink-0 items-center justify-center">
                 <TabStatusIcon tabId={row.tabKey} active={row.isCurrent} />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-[12px]">
-                    {row.label}
-                    {row.isCurrent && (
-                      <span className="ml-2 opacity-50">(current)</span>
-                    )}
-                  </div>
-                  <div
-                    className="truncate text-[10.5px] opacity-60"
-                    style={{ fontFamily: MONO_FONT }}
-                  >
-                    {row.projectName}
-                    {row.cwd && ` · ${cwdBasename(row.cwd)}`}
-                    {` · ${formatRelativeTime(now, row.lastActiveAt)}`}
-                  </div>
+              </div>
+
+              {/* Label + meta — two lines, comfortable leading. */}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline gap-2 text-[13px] leading-snug">
+                  <span className="truncate">{row.label}</span>
+                  {row.isCurrent && (
+                    <span className="shrink-0 text-[10.5px] opacity-50">
+                      (current)
+                    </span>
+                  )}
+                </div>
+                <div
+                  className="mt-1 truncate text-[11px] leading-snug opacity-55"
+                  style={{ fontFamily: MONO_FONT }}
+                >
+                  <span className="opacity-90">{row.projectName}</span>
+                  {row.cwd && (
+                    <>
+                      <span className="opacity-50"> · </span>
+                      {cwdBasename(row.cwd)}
+                    </>
+                  )}
+                  <span className="opacity-50"> · </span>
+                  {formatRelativeTime(now, row.lastActiveAt)}
                 </div>
               </div>
             </CommandItem>

--- a/src/components/TabSwitcher/TabSwitcher.tsx
+++ b/src/components/TabSwitcher/TabSwitcher.tsx
@@ -31,10 +31,14 @@ import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
 /* ---------------------------------------------------------------------------
  * TabSwitcher — Cmd+P quick-switch palette.
  *
- * Lists every open tab sorted by recency. Fuzzy-filterable by typing into
- * the search input (label + project name + cwd). Enter switches to the
- * selected tab. Rank shown for every visited tab — no cap, unlike the
- * sidebar's 1..10 ambient badge.
+ * Lists every open tab sorted by recency. Filterable by typing into the
+ * search input — case-insensitive substring match across label + project
+ * name + cwd (filterSwitcherRows). Substring rather than fuzzy on purpose
+ * so the recency order is preserved among matches; a fuzzy scorer would
+ * re-rank by score and break that.
+ *
+ * Enter switches to the selected tab. Rank shown for every visited tab —
+ * no cap, unlike the sidebar's 1..10 ambient badge.
  * -------------------------------------------------------------------------*/
 
 // Owns its own open state and Cmd+P hotkey so consumers (WorkspaceLayout)

--- a/src/components/TabSwitcher/tab-switcher.filter.test.ts
+++ b/src/components/TabSwitcher/tab-switcher.filter.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  filterSwitcherRows,
+  formatRelativeTime,
+  type SwitcherRow,
+} from '@/components/TabSwitcher/tab-switcher.helpers'
+
+/* ---------------------------------------------------------------------------
+ * filterSwitcherRows
+ * -------------------------------------------------------------------------*/
+
+const sampleRows: SwitcherRow[] = [
+  {
+    tabKey: 'agent:dev',
+    projectId: 'agent',
+    projectName: 'agent-terminal',
+    tabId: 'dev',
+    label: 'dev',
+    cwd: '/tmp/agent',
+    rank: 1,
+    lastActiveAt: 0,
+    isCurrent: false,
+  },
+  {
+    tabKey: 'cc:mem',
+    projectId: 'cc',
+    projectName: 'control-center',
+    tabId: 'mem',
+    label: 'memory note',
+    rank: 2,
+    lastActiveAt: 0,
+    isCurrent: false,
+  },
+  {
+    tabKey: 'agent:srv',
+    projectId: 'agent',
+    projectName: 'agent-terminal',
+    tabId: 'srv',
+    label: 'server',
+    cwd: '/srv',
+    rank: 3,
+    lastActiveAt: 0,
+    isCurrent: false,
+  },
+]
+
+describe('filterSwitcherRows', () => {
+  test('empty query returns the input array reference', () => {
+    expect(filterSwitcherRows(sampleRows, '')).toBe(sampleRows)
+    expect(filterSwitcherRows(sampleRows, '   ')).toBe(sampleRows)
+  })
+
+  test('substring match on label', () => {
+    const out = filterSwitcherRows(sampleRows, 'mem')
+    expect(out.map((r) => r.tabKey)).toEqual(['cc:mem'])
+  })
+
+  test('substring match on project name', () => {
+    const out = filterSwitcherRows(sampleRows, 'agent')
+    expect(out.map((r) => r.tabKey)).toEqual(['agent:dev', 'agent:srv'])
+  })
+
+  test('substring match on cwd', () => {
+    const out = filterSwitcherRows(sampleRows, '/srv')
+    expect(out.map((r) => r.tabKey)).toEqual(['agent:srv'])
+  })
+
+  test('case-insensitive', () => {
+    const out = filterSwitcherRows(sampleRows, 'MeMoRy')
+    expect(out.map((r) => r.tabKey)).toEqual(['cc:mem'])
+  })
+
+  test('preserves the input order among matches (= recency)', () => {
+    const out = filterSwitcherRows(sampleRows, 'agent')
+    // Order in `sampleRows`: dev then srv. Filter preserves that, so
+    // rank 1 still leads rank 3 even after filter.
+    expect(out.map((r) => r.rank)).toEqual([1, 3])
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * formatRelativeTime
+ * -------------------------------------------------------------------------*/
+
+describe('formatRelativeTime', () => {
+  const now = 1_000_000_000_000
+
+  test('undefined → never', () => {
+    expect(formatRelativeTime(now, undefined)).toBe('never')
+  })
+
+  test('< 10s → just now', () => {
+    expect(formatRelativeTime(now, now - 5_000)).toBe('just now')
+    expect(formatRelativeTime(now, now)).toBe('just now')
+  })
+
+  test('< 60s → Ns ago', () => {
+    expect(formatRelativeTime(now, now - 15_000)).toBe('15s ago')
+    expect(formatRelativeTime(now, now - 59_000)).toBe('59s ago')
+  })
+
+  test('< 60min → Nm ago', () => {
+    expect(formatRelativeTime(now, now - 60_000)).toBe('1m ago')
+    expect(formatRelativeTime(now, now - 59 * 60_000)).toBe('59m ago')
+  })
+
+  test('< 24h → Nh ago', () => {
+    expect(formatRelativeTime(now, now - 60 * 60_000)).toBe('1h ago')
+    expect(formatRelativeTime(now, now - 23 * 60 * 60_000)).toBe('23h ago')
+  })
+
+  test('exactly 1 day → yesterday', () => {
+    expect(formatRelativeTime(now, now - 24 * 60 * 60_000)).toBe('yesterday')
+    expect(formatRelativeTime(now, now - 47 * 60 * 60_000)).toBe('yesterday')
+  })
+
+  test('2..6 days → Nd ago', () => {
+    expect(formatRelativeTime(now, now - 48 * 60 * 60_000)).toBe('2d ago')
+    expect(formatRelativeTime(now, now - 6 * 24 * 60 * 60_000)).toBe('6d ago')
+  })
+
+  test('7..29 days → Nw ago', () => {
+    expect(formatRelativeTime(now, now - 7 * 24 * 60 * 60_000)).toBe('1w ago')
+    expect(formatRelativeTime(now, now - 21 * 24 * 60 * 60_000)).toBe('3w ago')
+  })
+
+  test('>= 30 days → Nmo ago', () => {
+    expect(formatRelativeTime(now, now - 30 * 24 * 60 * 60_000)).toBe('1mo ago')
+    expect(formatRelativeTime(now, now - 120 * 24 * 60 * 60_000)).toBe(
+      '4mo ago',
+    )
+  })
+
+  test('negative diff (then > now) clamps to just now', () => {
+    expect(formatRelativeTime(now, now + 5_000)).toBe('just now')
+  })
+})

--- a/src/components/TabSwitcher/tab-switcher.helpers.ts
+++ b/src/components/TabSwitcher/tab-switcher.helpers.ts
@@ -1,4 +1,7 @@
-import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+import {
+  makeTabKey,
+  resolveTabLabel,
+} from '@/screens/workspace/workspace.helpers'
 import type { Project } from '@/screens/workspace/workspace.types'
 
 /* ---------------------------------------------------------------------------
@@ -11,6 +14,13 @@ export type SwitcherRow = {
   projectId: string
   projectName: string
   tabId: string
+  /**
+   * Display label — already resolved through `resolveTabLabel` (same logic
+   * the sidebar uses), so a user-renamed tab keeps its label, an
+   * un-renamed tab with a known cwd shows the cwd basename, and the raw
+   * stored label is the fallback. Identical between sidebar and palette
+   * by construction.
+   */
   label: string
   cwd?: string
   /**
@@ -48,10 +58,16 @@ export function buildSwitcherRows(args: {
   >()
   for (const p of args.projects) {
     for (const t of p.tabs) {
-      allTabs.set(makeTabKey(p.id, t.id), {
+      const key = makeTabKey(p.id, t.id)
+      // Resolve the display label HERE so every render site (sidebar,
+      // palette, future surfaces) shows the same string for the same
+      // tab. Sidebar pulls from $tabMeta via resolveTabLabel; we do the
+      // same with the meta we already have.
+      const displayLabel = resolveTabLabel(t, args.tabMeta[key]?.cwd)
+      allTabs.set(key, {
         project: p,
         tabId: t.id,
-        label: t.label,
+        label: displayLabel,
       })
     }
   }

--- a/src/components/TabSwitcher/tab-switcher.helpers.ts
+++ b/src/components/TabSwitcher/tab-switcher.helpers.ts
@@ -1,0 +1,155 @@
+import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+import type { Project } from '@/screens/workspace/workspace.types'
+
+/* ---------------------------------------------------------------------------
+ * Pure helpers for the Cmd+P tab switcher. No React, no stores — easy to
+ * unit-test, easy to reuse if another surface ever wants a flat tab view.
+ * -------------------------------------------------------------------------*/
+
+export type SwitcherRow = {
+  tabKey: string
+  projectId: string
+  projectName: string
+  tabId: string
+  label: string
+  cwd?: string
+  /**
+   * 1-based recency rank. No cap — the palette shows the full position
+   * for every visited tab so the user can see "ah, that was 27 switches
+   * ago." Zero means the tab has never been visited in the tracked window.
+   */
+  rank: number
+  lastActiveAt: number | undefined
+  isCurrent: boolean
+}
+
+/**
+ * Build the ordered row list:
+ *   1. Tabs in recency order (most recent first), each annotated with its
+ *      full uncapped rank
+ *   2. Tabs never visited in the tracked window, appended in project +
+ *      sidebar order, with rank 0
+ *
+ * Stale recency entries (no matching tab in `projects`) are dropped — they
+ * can appear after a tab is closed if cleanup didn't fire, or when restored
+ * from a previous session that had different tabs.
+ */
+export function buildSwitcherRows(args: {
+  projects: Project[]
+  recency: string[]
+  recencyTimes: Record<string, number>
+  tabMeta: Record<string, { cwd?: string }>
+  activeProjectId: string
+  activeTabIds: Record<string, string>
+}): SwitcherRow[] {
+  const allTabs = new Map<
+    string,
+    { project: Project; tabId: string; label: string }
+  >()
+  for (const p of args.projects) {
+    for (const t of p.tabs) {
+      allTabs.set(makeTabKey(p.id, t.id), {
+        project: p,
+        tabId: t.id,
+        label: t.label,
+      })
+    }
+  }
+
+  const activeTabIdForProject = args.activeTabIds[args.activeProjectId]
+  const activeKey = activeTabIdForProject
+    ? makeTabKey(args.activeProjectId, activeTabIdForProject)
+    : ''
+
+  const seen = new Set<string>()
+  const rows: SwitcherRow[] = []
+
+  args.recency.forEach((key, idx) => {
+    const t = allTabs.get(key)
+    if (!t) return
+    seen.add(key)
+    rows.push({
+      tabKey: key,
+      projectId: t.project.id,
+      projectName: t.project.name,
+      tabId: t.tabId,
+      label: t.label,
+      cwd: args.tabMeta[key]?.cwd,
+      rank: idx + 1,
+      lastActiveAt: args.recencyTimes[key],
+      isCurrent: key === activeKey,
+    })
+  })
+
+  for (const p of args.projects) {
+    for (const t of p.tabs) {
+      const key = makeTabKey(p.id, t.id)
+      if (seen.has(key)) continue
+      rows.push({
+        tabKey: key,
+        projectId: p.id,
+        projectName: p.name,
+        tabId: t.id,
+        label: t.label,
+        cwd: args.tabMeta[key]?.cwd,
+        rank: 0,
+        lastActiveAt: undefined,
+        isCurrent: key === activeKey,
+      })
+    }
+  }
+
+  return rows
+}
+
+/**
+ * Substring filter across label + projectName + cwd. Preserves the input
+ * row order so recency ranking is maintained among matches.
+ *
+ * Case-insensitive. Empty query returns the input array unchanged (same
+ * reference — callers can rely on this for memoisation).
+ */
+export function filterSwitcherRows(
+  rows: SwitcherRow[],
+  query: string,
+): SwitcherRow[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return rows
+  return rows.filter((r) => {
+    const hay = `${r.label} ${r.projectName} ${r.cwd ?? ''}`.toLowerCase()
+    return hay.includes(q)
+  })
+}
+
+/**
+ * Compact relative-time string for the palette metadata line.
+ *
+ *   undefined            → 'never'
+ *   < 10s                → 'just now'
+ *   < 60s                → 'Ns ago'
+ *   < 60min              → 'Nm ago'
+ *   < 24h                → 'Nh ago'
+ *   1 day                → 'yesterday'
+ *   < 7 days             → 'Nd ago'
+ *   < 30 days            → 'Nw ago'
+ *   otherwise            → 'Nmo ago'
+ */
+export function formatRelativeTime(
+  now: number,
+  then: number | undefined,
+): string {
+  if (then === undefined) return 'never'
+  const diffMs = Math.max(0, now - then)
+  const sec = Math.floor(diffMs / 1000)
+  if (sec < 10) return 'just now'
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const days = Math.floor(hr / 24)
+  if (days === 1) return 'yesterday'
+  if (days < 7) return `${days}d ago`
+  if (days < 30) return `${Math.floor(days / 7)}w ago`
+  return `${Math.floor(days / 30)}mo ago`
+}

--- a/src/components/TabSwitcher/tab-switcher.test.ts
+++ b/src/components/TabSwitcher/tab-switcher.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
   buildSwitcherRows,
-  filterSwitcherRows,
-  formatRelativeTime,
   type SwitcherRow,
 } from '@/components/TabSwitcher/tab-switcher.helpers'
 import type { Project } from '@/screens/workspace/workspace.types'
@@ -157,135 +155,47 @@ describe('buildSwitcherRows', () => {
     const docs = rows.find((r) => r.tabKey === 'cc:docs')
     expect(docs?.lastActiveAt).toBeUndefined()
   })
-})
 
-/* ---------------------------------------------------------------------------
- * filterSwitcherRows
- * -------------------------------------------------------------------------*/
-
-const sampleRows: SwitcherRow[] = [
-  {
-    tabKey: 'agent:dev',
-    projectId: 'agent',
-    projectName: 'agent-terminal',
-    tabId: 'dev',
-    label: 'dev',
-    cwd: '/tmp/agent',
-    rank: 1,
-    lastActiveAt: 0,
-    isCurrent: false,
-  },
-  {
-    tabKey: 'cc:mem',
-    projectId: 'cc',
-    projectName: 'control-center',
-    tabId: 'mem',
-    label: 'memory note',
-    rank: 2,
-    lastActiveAt: 0,
-    isCurrent: false,
-  },
-  {
-    tabKey: 'agent:srv',
-    projectId: 'agent',
-    projectName: 'agent-terminal',
-    tabId: 'srv',
-    label: 'server',
-    cwd: '/srv',
-    rank: 3,
-    lastActiveAt: 0,
-    isCurrent: false,
-  },
-]
-
-describe('filterSwitcherRows', () => {
-  test('empty query returns the input array reference', () => {
-    expect(filterSwitcherRows(sampleRows, '')).toBe(sampleRows)
-    expect(filterSwitcherRows(sampleRows, '   ')).toBe(sampleRows)
+  test('label resolves to cwd basename when tab is not user-renamed', () => {
+    // Matches sidebar behaviour — un-renamed tabs show the directory
+    // path, not the auto-generated "shell"/"shell 2" labels.
+    const rows = build(['agent:dev'], {
+      tabMeta: { 'agent:dev': { cwd: '/Users/dani/Claude' } },
+    })
+    expect(rows[0].label).toBe('/Claude')
   })
 
-  test('substring match on label', () => {
-    const out = filterSwitcherRows(sampleRows, 'mem')
-    expect(out.map((r) => r.tabKey)).toEqual(['cc:mem'])
+  test('label is the raw tab.label when userRenamed is true (even with a cwd)', () => {
+    const projects: Project[] = [
+      {
+        id: 'p',
+        name: 'p',
+        path: '~/p',
+        pinned: false,
+        tabs: [
+          {
+            id: 't1',
+            label: 'my-named-tab',
+            cmd: '',
+            pinned: false,
+            userRenamed: true,
+          },
+        ],
+      },
+    ]
+    const rows = buildSwitcherRows({
+      projects,
+      recency: ['p:t1'],
+      recencyTimes: {},
+      tabMeta: { 'p:t1': { cwd: '/Users/dani/Claude' } },
+      activeProjectId: '',
+      activeTabIds: {},
+    })
+    expect(rows[0].label).toBe('my-named-tab')
   })
 
-  test('substring match on project name', () => {
-    const out = filterSwitcherRows(sampleRows, 'agent')
-    expect(out.map((r) => r.tabKey)).toEqual(['agent:dev', 'agent:srv'])
-  })
-
-  test('substring match on cwd', () => {
-    const out = filterSwitcherRows(sampleRows, '/srv')
-    expect(out.map((r) => r.tabKey)).toEqual(['agent:srv'])
-  })
-
-  test('case-insensitive', () => {
-    const out = filterSwitcherRows(sampleRows, 'MeMoRy')
-    expect(out.map((r) => r.tabKey)).toEqual(['cc:mem'])
-  })
-
-  test('preserves the input order among matches (= recency)', () => {
-    const out = filterSwitcherRows(sampleRows, 'agent')
-    // Order in `sampleRows`: dev then srv. Filter preserves that, so
-    // rank 1 still leads rank 3 even after filter.
-    expect(out.map((r) => r.rank)).toEqual([1, 3])
-  })
-})
-
-/* ---------------------------------------------------------------------------
- * formatRelativeTime
- * -------------------------------------------------------------------------*/
-
-describe('formatRelativeTime', () => {
-  const now = 1_000_000_000_000
-
-  test('undefined → never', () => {
-    expect(formatRelativeTime(now, undefined)).toBe('never')
-  })
-
-  test('< 10s → just now', () => {
-    expect(formatRelativeTime(now, now - 5_000)).toBe('just now')
-    expect(formatRelativeTime(now, now)).toBe('just now')
-  })
-
-  test('< 60s → Ns ago', () => {
-    expect(formatRelativeTime(now, now - 15_000)).toBe('15s ago')
-    expect(formatRelativeTime(now, now - 59_000)).toBe('59s ago')
-  })
-
-  test('< 60min → Nm ago', () => {
-    expect(formatRelativeTime(now, now - 60_000)).toBe('1m ago')
-    expect(formatRelativeTime(now, now - 59 * 60_000)).toBe('59m ago')
-  })
-
-  test('< 24h → Nh ago', () => {
-    expect(formatRelativeTime(now, now - 60 * 60_000)).toBe('1h ago')
-    expect(formatRelativeTime(now, now - 23 * 60 * 60_000)).toBe('23h ago')
-  })
-
-  test('exactly 1 day → yesterday', () => {
-    expect(formatRelativeTime(now, now - 24 * 60 * 60_000)).toBe('yesterday')
-    expect(formatRelativeTime(now, now - 47 * 60 * 60_000)).toBe('yesterday')
-  })
-
-  test('2..6 days → Nd ago', () => {
-    expect(formatRelativeTime(now, now - 48 * 60 * 60_000)).toBe('2d ago')
-    expect(formatRelativeTime(now, now - 6 * 24 * 60 * 60_000)).toBe('6d ago')
-  })
-
-  test('7..29 days → Nw ago', () => {
-    expect(formatRelativeTime(now, now - 7 * 24 * 60 * 60_000)).toBe('1w ago')
-    expect(formatRelativeTime(now, now - 21 * 24 * 60 * 60_000)).toBe('3w ago')
-  })
-
-  test('>= 30 days → Nmo ago', () => {
-    expect(formatRelativeTime(now, now - 30 * 24 * 60 * 60_000)).toBe('1mo ago')
-    expect(formatRelativeTime(now, now - 120 * 24 * 60 * 60_000)).toBe(
-      '4mo ago',
-    )
-  })
-
-  test('negative diff (then > now) clamps to just now', () => {
-    expect(formatRelativeTime(now, now + 5_000)).toBe('just now')
+  test('label falls back to raw tab.label when no cwd is recorded', () => {
+    const rows = build(['agent:dev'])
+    expect(rows[0].label).toBe('dev')
   })
 })

--- a/src/components/TabSwitcher/tab-switcher.test.ts
+++ b/src/components/TabSwitcher/tab-switcher.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildSwitcherRows,
+  filterSwitcherRows,
+  formatRelativeTime,
+  type SwitcherRow,
+} from '@/components/TabSwitcher/tab-switcher.helpers'
+import type { Project } from '@/screens/workspace/workspace.types'
+
+/* ---------------------------------------------------------------------------
+ * Fixtures
+ * -------------------------------------------------------------------------*/
+
+function makeProjects(): Project[] {
+  return [
+    {
+      id: 'agent',
+      name: 'agent-terminal',
+      path: '~/work/agent-terminal',
+      pinned: false,
+      tabs: [
+        { id: 'dev', label: 'dev', cmd: '', pinned: false },
+        { id: 'srv', label: 'server', cmd: '', pinned: false },
+        { id: 'git', label: 'git status', cmd: '', pinned: false },
+      ],
+    },
+    {
+      id: 'cc',
+      name: 'control-center',
+      path: '~/cc',
+      pinned: false,
+      tabs: [
+        { id: 'mem', label: 'memory', cmd: '', pinned: false },
+        { id: 'docs', label: 'docs review', cmd: '', pinned: false },
+      ],
+    },
+  ]
+}
+
+function build(
+  recency: string[],
+  opts: {
+    recencyTimes?: Record<string, number>
+    activeProjectId?: string
+    activeTabIds?: Record<string, string>
+    tabMeta?: Record<string, { cwd?: string }>
+  } = {},
+): SwitcherRow[] {
+  return buildSwitcherRows({
+    projects: makeProjects(),
+    recency,
+    recencyTimes: opts.recencyTimes ?? {},
+    tabMeta: opts.tabMeta ?? {},
+    activeProjectId: opts.activeProjectId ?? '',
+    activeTabIds: opts.activeTabIds ?? {},
+  })
+}
+
+/* ---------------------------------------------------------------------------
+ * buildSwitcherRows
+ * -------------------------------------------------------------------------*/
+
+describe('buildSwitcherRows', () => {
+  test('recency-listed tabs appear first in recency order with 1-based rank', () => {
+    const rows = build(['cc:mem', 'agent:dev', 'agent:srv'])
+    expect(rows.slice(0, 3).map((r) => r.tabKey)).toEqual([
+      'cc:mem',
+      'agent:dev',
+      'agent:srv',
+    ])
+    expect(rows.slice(0, 3).map((r) => r.rank)).toEqual([1, 2, 3])
+  })
+
+  test('rank is uncapped — the 12th recent tab has rank 12', () => {
+    // Recency list of 12 distinct keys; only the first 5 exist as tabs
+    // in projects, but cap-checking the rank doesn't depend on tab
+    // existence — verify by using a single recency list that aligns with
+    // tabs in projects.
+    const projects: Project[] = [
+      {
+        id: 'p',
+        name: 'p',
+        path: '~/p',
+        pinned: false,
+        tabs: Array.from({ length: 12 }, (_, i) => ({
+          id: `t${i}`,
+          label: `t${i}`,
+          cmd: '',
+          pinned: false,
+        })),
+      },
+    ]
+    const recency = Array.from({ length: 12 }, (_, i) => `p:t${i}`)
+    const rows = buildSwitcherRows({
+      projects,
+      recency,
+      recencyTimes: {},
+      tabMeta: {},
+      activeProjectId: '',
+      activeTabIds: {},
+    })
+    expect(rows.length).toBe(12)
+    expect(rows[11].rank).toBe(12)
+    expect(rows[11].tabKey).toBe('p:t11')
+  })
+
+  test('never-visited tabs have rank 0 and appear after recency-listed ones', () => {
+    const rows = build(['cc:mem'])
+    // 1 recency-listed + 4 never-visited (dev, srv, git from agent, docs from cc)
+    expect(rows.length).toBe(5)
+    expect(rows[0]).toMatchObject({ tabKey: 'cc:mem', rank: 1 })
+    // Rest are rank 0 and in sidebar order (project → tab declaration order)
+    expect(rows.slice(1).map((r) => r.tabKey)).toEqual([
+      'agent:dev',
+      'agent:srv',
+      'agent:git',
+      'cc:docs',
+    ])
+    expect(rows.slice(1).every((r) => r.rank === 0)).toBe(true)
+  })
+
+  test('stale recency entries (no matching tab) are dropped silently', () => {
+    const rows = build(['ghost:abc', 'agent:dev', 'also:stale'])
+    expect(rows.find((r) => r.tabKey === 'ghost:abc')).toBeUndefined()
+    expect(rows.find((r) => r.tabKey === 'also:stale')).toBeUndefined()
+    // agent:dev still appears, but with rank 2 (its index in the
+    // recency array) — we don't renumber to skip orphans.
+    const dev = rows.find((r) => r.tabKey === 'agent:dev')
+    expect(dev?.rank).toBe(2)
+  })
+
+  test('isCurrent is true only for the active project + tab pair', () => {
+    const rows = build([], {
+      activeProjectId: 'agent',
+      activeTabIds: { agent: 'dev' },
+    })
+    expect(rows.find((r) => r.tabKey === 'agent:dev')?.isCurrent).toBe(true)
+    expect(rows.find((r) => r.tabKey === 'agent:srv')?.isCurrent).toBe(false)
+    // Tab id matching that of the active project's active tab but in a
+    // different project does not count as current.
+    expect(rows.find((r) => r.tabKey === 'cc:mem')?.isCurrent).toBe(false)
+  })
+
+  test('cwd is pulled from tabMeta when available', () => {
+    const rows = build(['agent:dev'], {
+      tabMeta: { 'agent:dev': { cwd: '/tmp/x' } },
+    })
+    expect(rows[0].cwd).toBe('/tmp/x')
+  })
+
+  test('lastActiveAt is forwarded from recencyTimes', () => {
+    const rows = build(['agent:dev'], {
+      recencyTimes: { 'agent:dev': 12345 },
+    })
+    expect(rows[0].lastActiveAt).toBe(12345)
+    // never-visited tabs have undefined
+    const docs = rows.find((r) => r.tabKey === 'cc:docs')
+    expect(docs?.lastActiveAt).toBeUndefined()
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * filterSwitcherRows
+ * -------------------------------------------------------------------------*/
+
+const sampleRows: SwitcherRow[] = [
+  {
+    tabKey: 'agent:dev',
+    projectId: 'agent',
+    projectName: 'agent-terminal',
+    tabId: 'dev',
+    label: 'dev',
+    cwd: '/tmp/agent',
+    rank: 1,
+    lastActiveAt: 0,
+    isCurrent: false,
+  },
+  {
+    tabKey: 'cc:mem',
+    projectId: 'cc',
+    projectName: 'control-center',
+    tabId: 'mem',
+    label: 'memory note',
+    rank: 2,
+    lastActiveAt: 0,
+    isCurrent: false,
+  },
+  {
+    tabKey: 'agent:srv',
+    projectId: 'agent',
+    projectName: 'agent-terminal',
+    tabId: 'srv',
+    label: 'server',
+    cwd: '/srv',
+    rank: 3,
+    lastActiveAt: 0,
+    isCurrent: false,
+  },
+]
+
+describe('filterSwitcherRows', () => {
+  test('empty query returns the input array reference', () => {
+    expect(filterSwitcherRows(sampleRows, '')).toBe(sampleRows)
+    expect(filterSwitcherRows(sampleRows, '   ')).toBe(sampleRows)
+  })
+
+  test('substring match on label', () => {
+    const out = filterSwitcherRows(sampleRows, 'mem')
+    expect(out.map((r) => r.tabKey)).toEqual(['cc:mem'])
+  })
+
+  test('substring match on project name', () => {
+    const out = filterSwitcherRows(sampleRows, 'agent')
+    expect(out.map((r) => r.tabKey)).toEqual(['agent:dev', 'agent:srv'])
+  })
+
+  test('substring match on cwd', () => {
+    const out = filterSwitcherRows(sampleRows, '/srv')
+    expect(out.map((r) => r.tabKey)).toEqual(['agent:srv'])
+  })
+
+  test('case-insensitive', () => {
+    const out = filterSwitcherRows(sampleRows, 'MeMoRy')
+    expect(out.map((r) => r.tabKey)).toEqual(['cc:mem'])
+  })
+
+  test('preserves the input order among matches (= recency)', () => {
+    const out = filterSwitcherRows(sampleRows, 'agent')
+    // Order in `sampleRows`: dev then srv. Filter preserves that, so
+    // rank 1 still leads rank 3 even after filter.
+    expect(out.map((r) => r.rank)).toEqual([1, 3])
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * formatRelativeTime
+ * -------------------------------------------------------------------------*/
+
+describe('formatRelativeTime', () => {
+  const now = 1_000_000_000_000
+
+  test('undefined → never', () => {
+    expect(formatRelativeTime(now, undefined)).toBe('never')
+  })
+
+  test('< 10s → just now', () => {
+    expect(formatRelativeTime(now, now - 5_000)).toBe('just now')
+    expect(formatRelativeTime(now, now)).toBe('just now')
+  })
+
+  test('< 60s → Ns ago', () => {
+    expect(formatRelativeTime(now, now - 15_000)).toBe('15s ago')
+    expect(formatRelativeTime(now, now - 59_000)).toBe('59s ago')
+  })
+
+  test('< 60min → Nm ago', () => {
+    expect(formatRelativeTime(now, now - 60_000)).toBe('1m ago')
+    expect(formatRelativeTime(now, now - 59 * 60_000)).toBe('59m ago')
+  })
+
+  test('< 24h → Nh ago', () => {
+    expect(formatRelativeTime(now, now - 60 * 60_000)).toBe('1h ago')
+    expect(formatRelativeTime(now, now - 23 * 60 * 60_000)).toBe('23h ago')
+  })
+
+  test('exactly 1 day → yesterday', () => {
+    expect(formatRelativeTime(now, now - 24 * 60 * 60_000)).toBe('yesterday')
+    expect(formatRelativeTime(now, now - 47 * 60 * 60_000)).toBe('yesterday')
+  })
+
+  test('2..6 days → Nd ago', () => {
+    expect(formatRelativeTime(now, now - 48 * 60 * 60_000)).toBe('2d ago')
+    expect(formatRelativeTime(now, now - 6 * 24 * 60 * 60_000)).toBe('6d ago')
+  })
+
+  test('7..29 days → Nw ago', () => {
+    expect(formatRelativeTime(now, now - 7 * 24 * 60 * 60_000)).toBe('1w ago')
+    expect(formatRelativeTime(now, now - 21 * 24 * 60 * 60_000)).toBe('3w ago')
+  })
+
+  test('>= 30 days → Nmo ago', () => {
+    expect(formatRelativeTime(now, now - 30 * 24 * 60 * 60_000)).toBe('1mo ago')
+    expect(formatRelativeTime(now, now - 120 * 24 * 60 * 60_000)).toBe(
+      '4mo ago',
+    )
+  })
+
+  test('negative diff (then > now) clamps to just now', () => {
+    expect(formatRelativeTime(now, now + 5_000)).toBe('just now')
+  })
+})

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,194 @@
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  InputGroup,
+  InputGroupAddon,
+} from "@/components/ui/input-group"
+import { SearchIcon, CheckIcon } from "lucide-react"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex size-full flex-col overflow-hidden rounded-xl! bg-popover p-1 text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = false,
+  ...props
+}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn(
+          "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0",
+          className
+        )}
+        showCloseButton={showCloseButton}
+      >
+        {children}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div data-slot="command-input-wrapper" className="p-1 pb-0">
+      <InputGroup className="h-8! rounded-lg! border-input/30 bg-input/30 shadow-none! *:data-[slot=input-group-addon]:pl-2!">
+        <CommandPrimitive.Input
+          data-slot="command-input"
+          className={cn(
+            "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+            className
+          )}
+          {...props}
+        />
+        <InputGroupAddon>
+          <SearchIcon className="size-4 shrink-0 opacity-50" />
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className={cn("py-6 text-center text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
+    </CommandPrimitive.Item>
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-data-selected/command-item:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,19 +1,15 @@
-import * as React from "react"
-import { Command as CommandPrimitive } from "cmdk"
-
-import { cn } from "@/lib/utils"
+import { Command as CommandPrimitive } from 'cmdk'
+import { CheckIcon, SearchIcon } from 'lucide-react'
+import type * as React from 'react'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
-import {
-  InputGroup,
-  InputGroupAddon,
-} from "@/components/ui/input-group"
-import { SearchIcon, CheckIcon } from "lucide-react"
+} from '@/components/ui/dialog'
+import { InputGroup, InputGroupAddon } from '@/components/ui/input-group'
+import { cn } from '@/lib/utils'
 
 function Command({
   className,
@@ -23,8 +19,8 @@ function Command({
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        "flex size-full flex-col overflow-hidden rounded-xl! bg-popover p-1 text-popover-foreground",
-        className
+        'flex size-full flex-col overflow-hidden rounded-xl! bg-popover p-1 text-popover-foreground',
+        className,
       )}
       {...props}
     />
@@ -32,13 +28,13 @@ function Command({
 }
 
 function CommandDialog({
-  title = "Command Palette",
-  description = "Search for a command to run...",
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
   children,
   className,
   showCloseButton = false,
   ...props
-}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
+}: Omit<React.ComponentProps<typeof Dialog>, 'children'> & {
   title?: string
   description?: string
   className?: string
@@ -47,17 +43,21 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
       <DialogContent
         className={cn(
-          "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0",
-          className
+          'top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0',
+          className,
         )}
         showCloseButton={showCloseButton}
       >
+        {/* Title + description live INSIDE DialogContent so they only mount
+            when the dialog is open. Placing them as siblings of DialogContent
+            leaks the sr-only text into the page DOM unconditionally and
+            screen readers announce it as ambient page content. */}
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         {children}
       </DialogContent>
     </Dialog>
@@ -74,8 +74,8 @@ function CommandInput({
         <CommandPrimitive.Input
           data-slot="command-input"
           className={cn(
-            "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-            className
+            'w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+            className,
           )}
           {...props}
         />
@@ -95,8 +95,8 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
-        className
+        'no-scrollbar max-h-72 scroll-py-1 overflow-y-auto overflow-x-hidden outline-none',
+        className,
       )}
       {...props}
     />
@@ -110,7 +110,7 @@ function CommandEmpty({
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
-      className={cn("py-6 text-center text-sm", className)}
+      className={cn('py-6 text-center text-sm', className)}
       {...props}
     />
   )
@@ -124,8 +124,8 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        "overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground",
-        className
+        'overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground **:[[cmdk-group-heading]]:text-xs',
+        className,
       )}
       {...props}
     />
@@ -139,7 +139,7 @@ function CommandSeparator({
   return (
     <CommandPrimitive.Separator
       data-slot="command-separator"
-      className={cn("-mx-1 h-px bg-border", className)}
+      className={cn('-mx-1 h-px bg-border', className)}
       {...props}
     />
   )
@@ -154,8 +154,8 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
-        className
+        "group/command-item relative flex cursor-default select-none items-center gap-2 in-data-[slot=dialog-content]:rounded-lg! rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-selected:bg-muted data-selected:text-foreground data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-selected:*:[svg]:text-foreground",
+        className,
       )}
       {...props}
     >
@@ -168,13 +168,13 @@ function CommandItem({
 function CommandShortcut({
   className,
   ...props
-}: React.ComponentProps<"span">) {
+}: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="command-shortcut"
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground group-data-selected/command-item:text-foreground",
-        className
+        'ml-auto text-muted-foreground text-xs tracking-widest group-data-selected/command-item:text-foreground',
+        className,
       )}
       {...props}
     />
@@ -184,11 +184,11 @@ function CommandShortcut({
 export {
   Command,
   CommandDialog,
-  CommandInput,
-  CommandList,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
-  CommandShortcut,
+  CommandList,
   CommandSeparator,
+  CommandShortcut,
 }

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end":
+          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
+        "block-start":
+          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
+        "block-end":
+          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
+  VariantProps<typeof inputGroupButtonVariants> & {
+    type?: "button" | "submit" | "reset"
+  }) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,21 +1,20 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { cva, type VariantProps } from 'class-variance-authority'
+import type * as React from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-
-function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="input-group"
       role="group"
       className={cn(
-        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
-        className
+        'group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input outline-none transition-colors in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-start]]:h-auto has-[>textarea]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:flex-col has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot][aria-invalid=true]]:border-destructive has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-start]]:[&>input]:pl-1.5',
+        className,
       )}
       {...props}
     />
@@ -27,27 +26,27 @@ const inputGroupAddonVariants = cva(
   {
     variants: {
       align: {
-        "inline-start":
-          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
-        "inline-end":
-          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
-        "block-start":
-          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
-        "block-end":
-          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+        'inline-start':
+          'order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]',
+        'inline-end':
+          'order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]',
+        'block-start':
+          'order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2',
+        'block-end':
+          'order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2',
       },
     },
     defaultVariants: {
-      align: "inline-start",
+      align: 'inline-start',
     },
-  }
+  },
 )
 
 function InputGroupAddon({
   className,
-  align = "inline-start",
+  align = 'inline-start',
   ...props
-}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+}: React.ComponentProps<'div'> & VariantProps<typeof inputGroupAddonVariants>) {
   return (
     <div
       role="group"
@@ -55,10 +54,10 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
-        if ((e.target as HTMLElement).closest("button")) {
+        if ((e.target as HTMLElement).closest('button')) {
           return
         }
-        e.currentTarget.parentElement?.querySelector("input")?.focus()
+        e.currentTarget.parentElement?.querySelector('input')?.focus()
       }}
       {...props}
     />
@@ -66,32 +65,32 @@ function InputGroupAddon({
 }
 
 const inputGroupButtonVariants = cva(
-  "flex items-center gap-2 text-sm shadow-none",
+  'flex items-center gap-2 text-sm shadow-none',
   {
     variants: {
       size: {
         xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
-        sm: "",
-        "icon-xs":
-          "size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0",
-        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+        sm: '',
+        'icon-xs':
+          'size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0',
+        'icon-sm': 'size-8 p-0 has-[>svg]:p-0',
       },
     },
     defaultVariants: {
-      size: "xs",
+      size: 'xs',
     },
-  }
+  },
 )
 
 function InputGroupButton({
   className,
-  type = "button",
-  variant = "ghost",
-  size = "xs",
+  type = 'button',
+  variant = 'ghost',
+  size = 'xs',
   ...props
-}: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
+}: Omit<React.ComponentProps<typeof Button>, 'size' | 'type'> &
   VariantProps<typeof inputGroupButtonVariants> & {
-    type?: "button" | "submit" | "reset"
+    type?: 'button' | 'submit' | 'reset'
   }) {
   return (
     <Button
@@ -104,12 +103,12 @@ function InputGroupButton({
   )
 }
 
-function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       className={cn(
-        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
-        className
+        "flex items-center gap-2 text-muted-foreground text-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+        className,
       )}
       {...props}
     />
@@ -119,13 +118,13 @@ function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
 function InputGroupInput({
   className,
   ...props
-}: React.ComponentProps<"input">) {
+}: React.ComponentProps<'input'>) {
   return (
     <Input
       data-slot="input-group-control"
       className={cn(
-        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
-        className
+        'flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent',
+        className,
       )}
       {...props}
     />
@@ -135,13 +134,13 @@ function InputGroupInput({
 function InputGroupTextarea({
   className,
   ...props
-}: React.ComponentProps<"textarea">) {
+}: React.ComponentProps<'textarea'>) {
   return (
     <Textarea
       data-slot="input-group-control"
       className={cn(
-        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
-        className
+        'flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent',
+        className,
       )}
       {...props}
     />
@@ -152,7 +151,7 @@ export {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
-  InputGroupText,
   InputGroupInput,
+  InputGroupText,
   InputGroupTextarea,
 }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,14 +1,14 @@
-import * as React from "react"
+import type * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
+        'field-sizing-content flex min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:disabled:bg-input/80',
+        className,
       )}
       {...props}
     />

--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,10 @@
   --tab-foreground: rgba(0, 0, 0, 0.5);
   --tab-foreground-active: rgba(0, 0, 0, 0.88);
   --tab-border: rgba(0, 0, 0, 0.08);
+  /* Sidebar width — consumed by Sidebar and by popovers centred over the
+     terminal area (e.g. the Cmd+P switcher). Single source of truth. */
+  --sidebar-width: 232px;
+  --sidebar-half: calc(var(--sidebar-width) / 2);
 
   /* Terminal */
   --terminal-background: #ffffff;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { startNotificationsBridge } from '@/modules/notifications/notificationsB
 import { syncNotificationsEnabledToBackend } from '@/modules/notifications/preferences'
 import { initNavigation } from '@/modules/stores/$navigation'
 import { $projects } from '@/modules/stores/$projects'
+import { initTabRecencySubscriber } from '@/modules/stores/$tabRecency.init'
 import { WorkspaceLayout } from '@/screens/workspace/WorkspaceLayout'
 import type { Project } from '@/screens/workspace/workspace.types'
 import '@xterm/xterm/css/xterm.css'
@@ -29,6 +30,10 @@ async function bootstrap() {
   }
 
   initNavigation()
+
+  // Recency tracker subscribes to navigation; must run after initNavigation
+  // so the first bump captures the project/tab restored from disk.
+  initTabRecencySubscriber()
 
   // Notification firing lives entirely in Rust. The bridge just pushes
   // UI state (projects map, active tab, app focus) so the backend can

--- a/src/modules/mods/mod-listener.ts
+++ b/src/modules/mods/mod-listener.ts
@@ -9,6 +9,36 @@ import {
   updateTabMeta,
 } from '@/modules/stores/$tabMeta'
 
+/* ---------------------------------------------------------------------------
+ * done-linger timers
+ *
+ * When status flips to 'done' we stamp `doneAt` in the store and schedule a
+ * single per-tab timer that clears it after 10s. Every TabStatusIcon then
+ * derives its visual from `doneAt` directly, so the sidebar and the Cmd+P
+ * palette can never disagree on whether the green dot is lit (the previous
+ * per-instance setTimeout was the source of the bug).
+ * -------------------------------------------------------------------------*/
+
+const DONE_LINGER_MS = 10_000
+const doneLingerTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+function cancelDoneLinger(tabId: string): void {
+  const t = doneLingerTimers.get(tabId)
+  if (t) {
+    clearTimeout(t)
+    doneLingerTimers.delete(tabId)
+  }
+}
+
+function scheduleDoneLinger(tabId: string): void {
+  cancelDoneLinger(tabId)
+  const t = setTimeout(() => {
+    doneLingerTimers.delete(tabId)
+    updateTabMeta(tabId, { doneAt: undefined })
+  }, DONE_LINGER_MS)
+  doneLingerTimers.set(tabId, t)
+}
+
 type ModEventPayload = {
   tabId: string
   modId: string
@@ -43,7 +73,15 @@ function dispatch({
         status: TabStatus
         exitCode?: number
       }
-      updateTabMeta(tabId, { status, exitCode })
+      if (status === 'done') {
+        updateTabMeta(tabId, { status, exitCode, doneAt: Date.now() })
+        scheduleDoneLinger(tabId)
+      } else {
+        // Any other transition (running, error, idle) cancels the linger
+        // and clears the timestamp so the dot reflects the new status.
+        cancelDoneLinger(tabId)
+        updateTabMeta(tabId, { status, exitCode, doneAt: undefined })
+      }
       break
     }
     case 'tab_type_changed': {
@@ -112,6 +150,7 @@ function dispatch({
     }
     case 'closed': {
       // EchoMod fires this — used to GC stale tabMeta entries on tab close.
+      cancelDoneLinger(tabId)
       clearTabMeta(tabId)
       break
     }

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 import { IPC } from '@/modules/ipc/commands'
 import { pushClosedTab } from '@/modules/stores/$closedTabs'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
+import { forgetTabRecency } from '@/modules/stores/$tabRecency'
 import {
   dedupeLabel,
   makeTabKey,
@@ -115,6 +116,10 @@ export function removeTab(projectId: string, tabId: string): void {
   }
 
   IPC.closeTab(makeTabKey(projectId, tabId)).catch(() => {})
+  // Clear recency at the source so the sidebar / palette never reference
+  // a dead tabKey. The palette also defensively filters orphan entries,
+  // but cleaning here keeps localStorage bounded and ranks accurate.
+  forgetTabRecency(makeTabKey(projectId, tabId))
   const updated = $projects
     .get()
     .map((p) =>

--- a/src/modules/stores/$projects.ts
+++ b/src/modules/stores/$projects.ts
@@ -90,7 +90,14 @@ export function removeProject(projectId: string): void {
   const project = projects.find((p) => p.id === projectId)
   if (project) {
     for (const tab of project.tabs) {
-      IPC.closeTab(makeTabKey(projectId, tab.id)).catch(() => {})
+      const tabKey = makeTabKey(projectId, tab.id)
+      IPC.closeTab(tabKey).catch(() => {})
+      // Symmetric with removeTab — otherwise the project's tabKeys
+      // linger in $tabRecency / localStorage as ghosts. They'd be
+      // filtered out of the palette's render but the surviving rows
+      // would still see their idx-based rank shifted up (rank 1 live
+      // tab appearing as rank 7 with 6 ghosts ahead of it).
+      forgetTabRecency(tabKey)
     }
   }
   const updated = projects.filter((p) => p.id !== projectId)

--- a/src/modules/stores/$tabMeta.ts
+++ b/src/modules/stores/$tabMeta.ts
@@ -77,6 +77,15 @@ export type TabMeta = {
   /** Non-zero exit code when status is "error". */
   exitCode?: number
   /**
+   * Epoch-ms timestamp when status most recently became "done". Drives
+   * the transient green dot in TabStatusIcon. Lives in the store (not
+   * component-local) so every render of the icon — sidebar, tab bar,
+   * Cmd+P palette — agrees on whether the dot is currently lit. Cleared
+   * by the mod-listener's per-tab 10s timer or when the user navigates
+   * to the tab (acknowledgement).
+   */
+  doneAt?: number
+  /**
    * Machine-readable agent identifier — `"claude-code"`, `"codex"`, etc.
    * Use this for routing / lookups, never for display.
    * Set when type is "agent" by the per-agent mod (ClaudeCodeMod / CodexMod / …).

--- a/src/modules/stores/$tabRecency.init.ts
+++ b/src/modules/stores/$tabRecency.init.ts
@@ -1,0 +1,36 @@
+import { $activeProjectId, $activeTabId } from '@/modules/stores/$navigation'
+import { bumpTabRecency } from '@/modules/stores/$tabRecency'
+import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+
+/* ---------------------------------------------------------------------------
+ * One-shot subscriber that turns navigation changes into recency bumps.
+ *
+ * Lives outside any component lifecycle so it never double-attaches under
+ * React StrictMode and survives hot-reload. Called once from main.tsx
+ * before <App/> renders. Mirrors the `initNavigation` pattern already in
+ * the repo.
+ * -------------------------------------------------------------------------*/
+
+let initialised = false
+let lastKey = ''
+
+function check(): void {
+  const projectId = $activeProjectId.get()
+  const tabId = $activeTabId.get()[projectId]
+  if (!projectId || !tabId) return
+  const key = makeTabKey(projectId, tabId)
+  if (key === lastKey) return
+  lastKey = key
+  bumpTabRecency(key)
+}
+
+export function initTabRecencySubscriber(): void {
+  if (initialised) return
+  initialised = true
+  // `.listen()` (not `.subscribe()`) skips the synchronous initial fire so
+  // we don't bump twice for the same starting state. The explicit `check()`
+  // at the end handles the initial-state bump intentionally.
+  $activeProjectId.listen(check)
+  $activeTabId.listen(check)
+  check()
+}

--- a/src/modules/stores/$tabRecency.test.ts
+++ b/src/modules/stores/$tabRecency.test.ts
@@ -35,8 +35,6 @@ import {
   $tabRecencyTimes,
   bumpTabRecency,
   forgetTabRecency,
-  getTabRank,
-  MAX_BADGE_RANK,
 } from '@/modules/stores/$tabRecency'
 
 beforeEach(() => {
@@ -137,34 +135,6 @@ describe('forgetTabRecency', () => {
     bumpTabRecency('p:t1')
     forgetTabRecency('')
     expect($tabRecency.get()).toEqual(['p:t1'])
-  })
-})
-
-/* ---------------------------------------------------------------------------
- * getTabRank
- * -------------------------------------------------------------------------*/
-
-describe('getTabRank', () => {
-  test('returns 0 for an unknown key', () => {
-    expect(getTabRank('p:t1')).toBe(0)
-  })
-
-  test('returns 1 for the most-recently bumped key', () => {
-    bumpTabRecency('p:t1')
-    expect(getTabRank('p:t1')).toBe(1)
-  })
-
-  test('returns 1..MAX_BADGE_RANK for the badge window', () => {
-    for (let i = 1; i <= MAX_BADGE_RANK; i += 1) bumpTabRecency(`p:t${i}`)
-    // Most-recent (t10) is rank 1; t1 is rank MAX_BADGE_RANK.
-    expect(getTabRank(`p:t${MAX_BADGE_RANK}`)).toBe(1)
-    expect(getTabRank('p:t1')).toBe(MAX_BADGE_RANK)
-  })
-
-  test('returns 0 for tabs outside the badge window', () => {
-    for (let i = 1; i <= MAX_BADGE_RANK + 5; i += 1) bumpTabRecency(`p:t${i}`)
-    // The (MAX_BADGE_RANK + 1)th tab from the top is the original first one.
-    expect(getTabRank('p:t1')).toBe(0)
   })
 })
 

--- a/src/modules/stores/$tabRecency.test.ts
+++ b/src/modules/stores/$tabRecency.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+// Minimal localStorage stub. Bun's test env doesn't ship a DOM by default,
+// so the store's `typeof window === 'undefined'` guard would otherwise skip
+// persistence entirely. We install one before importing the module so the
+// initial reads exercise the same path as the browser.
+const memStorage: Record<string, string> = {}
+const fakeStorage: Storage = {
+  get length() {
+    return Object.keys(memStorage).length
+  },
+  clear() {
+    for (const k of Object.keys(memStorage)) delete memStorage[k]
+  },
+  getItem(k) {
+    return Object.hasOwn(memStorage, k) ? memStorage[k] : null
+  },
+  setItem(k, v) {
+    memStorage[k] = v
+  },
+  removeItem(k) {
+    delete memStorage[k]
+  },
+  key(i) {
+    return Object.keys(memStorage)[i] ?? null
+  },
+}
+// biome-ignore lint/suspicious/noExplicitAny: test harness shim
+;(globalThis as any).window = { localStorage: fakeStorage }
+// biome-ignore lint/suspicious/noExplicitAny: test harness shim
+;(globalThis as any).localStorage = fakeStorage
+
+import {
+  $tabRecency,
+  $tabRecencyTimes,
+  bumpTabRecency,
+  forgetTabRecency,
+  getTabRank,
+  MAX_BADGE_RANK,
+} from '@/modules/stores/$tabRecency'
+
+beforeEach(() => {
+  $tabRecency.set([])
+  $tabRecencyTimes.set({})
+  for (const k of Object.keys(memStorage)) delete memStorage[k]
+})
+
+afterEach(() => {
+  $tabRecency.set([])
+  $tabRecencyTimes.set({})
+})
+
+/* ---------------------------------------------------------------------------
+ * bumpTabRecency
+ * -------------------------------------------------------------------------*/
+
+describe('bumpTabRecency', () => {
+  test('puts a new key at position 0', () => {
+    bumpTabRecency('p:t1')
+    expect($tabRecency.get()).toEqual(['p:t1'])
+  })
+
+  test('moves an existing key to position 0 without duplicating', () => {
+    bumpTabRecency('p:t1')
+    bumpTabRecency('p:t2')
+    bumpTabRecency('p:t1')
+    expect($tabRecency.get()).toEqual(['p:t1', 'p:t2'])
+  })
+
+  test('bumping the already-top key leaves the list unchanged', () => {
+    bumpTabRecency('p:t1')
+    const before = $tabRecency.get()
+    bumpTabRecency('p:t1')
+    // Same content (and same reference would also be ideal, but identity
+    // isn't load-bearing — content equality is enough for the bug-class
+    // we want to guard against: spurious re-renders triggered by the same
+    // value being set).
+    expect($tabRecency.get()).toEqual(before)
+  })
+
+  test('always stamps a new timestamp, even when the list is unchanged', () => {
+    bumpTabRecency('p:t1')
+    const t1 = $tabRecencyTimes.get()['p:t1']
+    expect(t1).toBeGreaterThan(0)
+    // Force the clock forward enough that Date.now() returns a different
+    // value than the first stamp.
+    const start = Date.now()
+    while (Date.now() - start < 2) {
+      /* spin briefly */
+    }
+    bumpTabRecency('p:t1')
+    const t2 = $tabRecencyTimes.get()['p:t1']
+    expect(t2).toBeGreaterThanOrEqual(t1)
+  })
+
+  test('empty key is a no-op', () => {
+    bumpTabRecency('')
+    expect($tabRecency.get()).toEqual([])
+    expect($tabRecencyTimes.get()).toEqual({})
+  })
+
+  test('caps the list at 100 entries (oldest drops first)', () => {
+    for (let i = 0; i < 105; i += 1) bumpTabRecency(`p:t${i}`)
+    const list = $tabRecency.get()
+    expect(list.length).toBe(100)
+    // The most-recent (last bumped) is at position 0.
+    expect(list[0]).toBe('p:t104')
+    // The 100th-from-newest is at position 99.
+    expect(list[99]).toBe('p:t5')
+    // Anything older than that is gone.
+    expect(list.includes('p:t4')).toBe(false)
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * forgetTabRecency
+ * -------------------------------------------------------------------------*/
+
+describe('forgetTabRecency', () => {
+  test('removes the key from both atoms', () => {
+    bumpTabRecency('p:t1')
+    bumpTabRecency('p:t2')
+    forgetTabRecency('p:t1')
+    expect($tabRecency.get()).toEqual(['p:t2'])
+    expect($tabRecencyTimes.get()['p:t1']).toBeUndefined()
+    expect($tabRecencyTimes.get()['p:t2']).toBeGreaterThan(0)
+  })
+
+  test('forgetting an unknown key is a no-op', () => {
+    bumpTabRecency('p:t1')
+    const before = $tabRecency.get()
+    forgetTabRecency('p:other')
+    expect($tabRecency.get()).toEqual(before)
+  })
+
+  test('empty key is a no-op', () => {
+    bumpTabRecency('p:t1')
+    forgetTabRecency('')
+    expect($tabRecency.get()).toEqual(['p:t1'])
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * getTabRank
+ * -------------------------------------------------------------------------*/
+
+describe('getTabRank', () => {
+  test('returns 0 for an unknown key', () => {
+    expect(getTabRank('p:t1')).toBe(0)
+  })
+
+  test('returns 1 for the most-recently bumped key', () => {
+    bumpTabRecency('p:t1')
+    expect(getTabRank('p:t1')).toBe(1)
+  })
+
+  test('returns 1..MAX_BADGE_RANK for the badge window', () => {
+    for (let i = 1; i <= MAX_BADGE_RANK; i += 1) bumpTabRecency(`p:t${i}`)
+    // Most-recent (t10) is rank 1; t1 is rank MAX_BADGE_RANK.
+    expect(getTabRank(`p:t${MAX_BADGE_RANK}`)).toBe(1)
+    expect(getTabRank('p:t1')).toBe(MAX_BADGE_RANK)
+  })
+
+  test('returns 0 for tabs outside the badge window', () => {
+    for (let i = 1; i <= MAX_BADGE_RANK + 5; i += 1) bumpTabRecency(`p:t${i}`)
+    // The (MAX_BADGE_RANK + 1)th tab from the top is the original first one.
+    expect(getTabRank('p:t1')).toBe(0)
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * Persistence
+ * -------------------------------------------------------------------------*/
+
+describe('persistence', () => {
+  test('list writes flow through to localStorage', () => {
+    bumpTabRecency('p:t1')
+    bumpTabRecency('p:t2')
+    const stored = JSON.parse(memStorage['agent-terminal:tab-recency'] ?? '[]')
+    expect(stored).toEqual(['p:t2', 'p:t1'])
+  })
+
+  test('times write flow through to localStorage', () => {
+    bumpTabRecency('p:t1')
+    const stored = JSON.parse(
+      memStorage['agent-terminal:tab-recency-times'] ?? '{}',
+    )
+    expect(typeof stored['p:t1']).toBe('number')
+  })
+
+  test('list write caps at MAX_ENTRIES (100)', () => {
+    for (let i = 0; i < 150; i += 1) bumpTabRecency(`p:t${i}`)
+    const stored = JSON.parse(memStorage['agent-terminal:tab-recency'] ?? '[]')
+    expect(stored.length).toBe(100)
+  })
+})

--- a/src/modules/stores/$tabRecency.ts
+++ b/src/modules/stores/$tabRecency.ts
@@ -21,9 +21,6 @@ const STORAGE_KEY = 'agent-terminal:tab-recency'
 const TIMES_KEY = 'agent-terminal:tab-recency-times'
 const MAX_ENTRIES = 100
 
-/** Number of tabs that earn a sidebar rank badge. The palette is uncapped. */
-export const MAX_BADGE_RANK = 10
-
 function readPersistedList(): string[] {
   if (typeof window === 'undefined') return []
   try {
@@ -110,10 +107,4 @@ export function forgetTabRecency(tabKey: string): void {
     const { [tabKey]: _, ...rest } = times
     $tabRecencyTimes.set(rest)
   }
-}
-
-/** 1..MAX_BADGE_RANK if the tab is in the top badge window, else 0. */
-export function getTabRank(tabKey: string): number {
-  const idx = $tabRecency.get().indexOf(tabKey)
-  return idx < 0 || idx >= MAX_BADGE_RANK ? 0 : idx + 1
 }

--- a/src/modules/stores/$tabRecency.ts
+++ b/src/modules/stores/$tabRecency.ts
@@ -1,0 +1,119 @@
+import { atom } from 'nanostores'
+
+/* ---------------------------------------------------------------------------
+ * $tabRecency — MRU list of tab keys.
+ *
+ * Index 0 is most recently active. Persisted to localStorage so the recency
+ * signal survives app restarts (matches user expectation that "last week's
+ * tabs" still rank lower than "5 minutes ago" after a quit-and-relaunch).
+ *
+ * Two parallel atoms instead of one Map<key, ts>:
+ *   - $tabRecency holds the rank order (a string[] — index → rank)
+ *   - $tabRecencyTimes holds last-activated epoch-ms (for the palette's
+ *     "Nm ago" hints)
+ *
+ * The split keeps sidebar badge re-renders cheap: SidebarTabItem subscribes
+ * to the order array only, so the every-30-seconds palette tick doesn't
+ * invalidate the sidebar.
+ * -------------------------------------------------------------------------*/
+
+const STORAGE_KEY = 'agent-terminal:tab-recency'
+const TIMES_KEY = 'agent-terminal:tab-recency-times'
+const MAX_ENTRIES = 100
+
+/** Number of tabs that earn a sidebar rank badge. The palette is uncapped. */
+export const MAX_BADGE_RANK = 10
+
+function readPersistedList(): string[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((s): s is string => typeof s === 'string')
+  } catch {
+    return []
+  }
+}
+
+function readPersistedTimes(): Record<string, number> {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = window.localStorage.getItem(TIMES_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return {}
+    const out: Record<string, number> = {}
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === 'number' && Number.isFinite(v)) out[k] = v
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+export const $tabRecency = atom<string[]>(readPersistedList())
+export const $tabRecencyTimes = atom<Record<string, number>>(
+  readPersistedTimes(),
+)
+
+$tabRecency.subscribe((value) => {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(value.slice(0, MAX_ENTRIES)),
+    )
+  } catch {
+    /* localStorage full / disabled — recency degrades to in-memory */
+  }
+})
+
+$tabRecencyTimes.subscribe((value) => {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(TIMES_KEY, JSON.stringify(value))
+  } catch {
+    /* same — non-fatal */
+  }
+})
+
+/**
+ * Move `tabKey` to the front of the MRU list and stamp its time. No-op for
+ * an empty key. When the key is already at position 0 the list is left
+ * untouched (no spurious atom write) and only the timestamp is bumped.
+ */
+export function bumpTabRecency(tabKey: string): void {
+  if (!tabKey) return
+  const cur = $tabRecency.get()
+  if (cur[0] !== tabKey) {
+    const filtered = cur.filter((k) => k !== tabKey)
+    filtered.unshift(tabKey)
+    $tabRecency.set(filtered.slice(0, MAX_ENTRIES))
+  }
+  $tabRecencyTimes.set({ ...$tabRecencyTimes.get(), [tabKey]: Date.now() })
+}
+
+/**
+ * Remove a closed tab from both atoms so the sidebar and palette never
+ * reference a dead tabKey.
+ */
+export function forgetTabRecency(tabKey: string): void {
+  if (!tabKey) return
+  const cur = $tabRecency.get()
+  const next = cur.filter((k) => k !== tabKey)
+  if (next.length !== cur.length) $tabRecency.set(next)
+  const times = $tabRecencyTimes.get()
+  if (times[tabKey] !== undefined) {
+    const { [tabKey]: _, ...rest } = times
+    $tabRecencyTimes.set(rest)
+  }
+}
+
+/** 1..MAX_BADGE_RANK if the tab is in the top badge window, else 0. */
+export function getTabRank(tabKey: string): number {
+  const idx = $tabRecency.get().indexOf(tabKey)
+  return idx < 0 || idx >= MAX_BADGE_RANK ? 0 : idx + 1
+}

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { Sidebar } from '@/components/Sidebar/Sidebar'
 import { StatusBar } from '@/components/StatusBar/StatusBar'
+import { TabSwitcher } from '@/components/TabSwitcher/TabSwitcher'
 import { TerminalSearchBar } from '@/components/TerminalSearchBar/TerminalSearchBar'
 import { formatDropPayload } from '@/modules/dragDrop/dropPayload'
 import { Keys, Mod } from '@/modules/keymap/keys'
@@ -309,6 +310,8 @@ export function WorkspaceLayout() {
         </div>
       </div>
       <StatusBar />
+      {/* Self-contained: owns its open state + Cmd+P hotkey. */}
+      <TabSwitcher />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Two complementary affordances for finding recently-active work after context switches across many projects.

- **Sidebar:** each tab row's right side shows a subtle mono digit \`1..10\` for the ten most-recently-active tabs across the whole workspace. Renders regardless of pin state — pinned + recent shows both the pin (left) and the rank digit (right).
- **Cmd+P palette:** shadcn \`CommandDialog\` with a fuzzy-searchable list of every open tab in recency order. Each row carries a rank chip (full uncapped rank — palette is active recall), tab status dot, label, and a metadata line with project name + cwd basename + \"Nm ago\". Current tab dimmed with \`(current)\`.

## How it's wired

- \`\$tabRecency\` (MRU \`string[]\`) and \`\$tabRecencyTimes\` (parallel ts map) — split so the sidebar badge subscribers don't re-render on the palette's 30s relative-time tick.
- Persisted to localStorage (100-entry cap) so badges survive quit/relaunch.
- One-shot module-level subscriber \`initTabRecencySubscriber()\` listens on \`\$activeProjectId\` + \`\$activeTabId\` and bumps on every active-tab change. Idempotent; safe under StrictMode.
- \`removeTab\` calls \`forgetTabRecency\` so closed tabs disappear from badges and palette immediately.
- \`<TabSwitcher />\` owns its own open state + Cmd+P hotkey, so the consumer just renders it with no props.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bunx biome check\` clean on changed files
- [x] \`bun test src/modules/stores/\$tabRecency.test.ts src/components/TabSwitcher/tab-switcher.test.ts\` — 39/39 pass
- [x] \`bun test src/modules/stores/\$navigation.test.ts src/modules/stores/\$navigation.openNewTab.test.ts\` — 27/27 pass (regression check on \`\$projects.removeTab\` hook)
- [ ] Manual QA: visit 3 tabs in 3 projects → 1/2/3 badges; pin a ranked tab → both pin and rank visible; close a ranked tab → others shift up; Cmd+P opens with recency-sorted list; type to filter; Enter switches; quit + relaunch → ranks restored