### PR TITLE
fix(release): emit signed updater artifacts with arch-suffixed names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,30 @@ jobs:
         with:
           args: --target ${{ matrix.target }}
 
+      - name: Suffix updater bundle with arch
+        # Tauri appends `_aarch64` / `_x64` to DMG filenames automatically
+        # but does NOT do the same for `.app.tar.gz` — both matrix entries
+        # produce `<ProductName>.app.tar.gz`. Two consequences:
+        #   1. GitHub Releases reject a second asset with a duplicate name,
+        #      so only one tarball would attach to the draft release.
+        #   2. The manifest script can't tell the arches apart by filename.
+        # Rename here so downstream steps (upload, release attach, manifest
+        # generation) can all rely on a stable arch suffix.
+        run: |
+          set -euo pipefail
+          cd src-tauri/target/${{ matrix.target }}/release/bundle/macos
+          case "${{ matrix.target }}" in
+            aarch64-apple-darwin) ARCH=aarch64 ;;
+            x86_64-apple-darwin)  ARCH=x64 ;;
+            *) echo "Unknown target ${{ matrix.target }}"; exit 1 ;;
+          esac
+          for f in *.app.tar.gz; do
+            base="${f%.app.tar.gz}"
+            mv -- "$f"     "${base}_${ARCH}.app.tar.gz"
+            mv -- "$f.sig" "${base}_${ARCH}.app.tar.gz.sig"
+          done
+          ls -la
+
       - name: Upload .dmg + updater bundle as workflow artifact
         # Hands every release artifact for this arch off to the `release`
         # job (Linux runner, can't reach into this macOS runner's

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
   "bundle": {
     "active": true,
     "targets": ["dmg", "app"],
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

\`v0.1.4-rc.3\` (testing #56) succeeded at building but the manifest-generation step failed with \`cat: .sig: No such file or directory\`. Two real root causes:

1. **\`.sig\` files were never produced.** \`tauri.conf.json\` lists \`bundle.targets: [\"dmg\", \"app\"]\` and the updater plugin is configured, but never sets the v2 flag that tells Tauri to actually sign the \`.app.tar.gz\` and emit the matching \`.sig\`. Without it, the \"app\" target produces an unsigned tarball and the \`TAURI_SIGNING_*\` env vars are never exercised.
2. **\`.app.tar.gz\` filenames don't include the arch.** Tauri appends \`_aarch64\` / \`_x64\` to DMG filenames automatically but does **not** do the same for \`.app.tar.gz\` — both matrix entries produce \`Agent Terminal.app.tar.gz\`. The manifest script's \`find … -name '*aarch64*'\` matches nothing, and even if it did, GitHub Releases rejects a second asset with a duplicate name.

## Changes

- **\`src-tauri/tauri.conf.json\`** — add \`bundle.createUpdaterArtifacts: true\`. This is the v2 switch that tells Tauri to sign the \`.app.tar.gz\` and emit the \`.sig\`.
- **\`.github/workflows/release.yml\`** — new \`Suffix updater bundle with arch\` step between \`tauri-action\` and \`upload-artifact\`. Maps \`aarch64-apple-darwin\` → \`aarch64\` and \`x86_64-apple-darwin\` → \`x64\` (matching what Tauri already does for DMGs) and renames \`<ProductName>.app.tar.gz{,.sig}\` to \`<ProductName>_<ARCH>.app.tar.gz{,.sig}\`. Downstream steps (upload, release attach, manifest generation) all rely on this suffix.

The existing manifest script's \`find artifacts -type f -name '*aarch64*.app.tar.gz'\` / \`*x64*\` globs work unchanged once the rename is in place.

## Test plan

- [ ] Push a test tag (e.g. \`v0.1.4-rc.4\`) on a throwaway branch
- [ ] Build job produces \`<ProductName>_aarch64.app.tar.gz\` + \`.sig\` and \`<ProductName>_x64.app.tar.gz\` + \`.sig\`
- [ ] Draft release attaches 7 files: 2× DMG, 2× tarball, 2× sig, 1× \`latest.json\`
- [ ] \`release-manifest\` branch gets a commit with the new \`latest.json\`
- [ ] \`curl https://raw.githubusercontent.com/DaniAkash/agent-terminal/release-manifest/latest.json\` returns valid JSON with both \`darwin-aarch64\` and \`darwin-x86_64\` entries

## Note on local prod builds

With \`createUpdaterArtifacts: true\` always-on, \`bun tauri:build\` locally will fail at the signing step unless \`TAURI_SIGNING_PRIVATE_KEY\` + \`TAURI_SIGNING_PRIVATE_KEY_PASSWORD\` are exported. This matches the existing design comment in the workflow ("set both secrets before cutting the first tag after this lands") — \`bun tauri:dev\` still works because the \`dev-instance\` feature skips the updater plugin entirely.