### PR TITLE
chore(release): v0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-terminal",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-terminal"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "axum",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-terminal"
-version = "0.1.3"
+version = "0.1.4"
 description = "Agent Terminal — a mouse-first project-scoped terminal workspace"
 authors = ["DaniAkash"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agent Terminal",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.daniakash.agent-terminal",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Bumps the app version from 0.1.3 → 0.1.4 across the three manifests and the Cargo lockfile. Pure version bump, no other changes.

## Files

- `package.json`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (auto-refreshed)

## Release flow after merge

1. Merge this PR
2. `git tag v0.1.4 && git push origin v0.1.4`
3. The release workflow builds per-arch signed/notarized .dmg + .app.tar.gz + .sig and publishes `latest.json` to the `release-manifest` branch
4. Review + publish the draft release from the Releases page

## Test plan

- [ ] Merge
- [ ] Tag and push v0.1.4
- [ ] Workflow run completes green
- [ ] Draft release attaches: 2× .dmg, 2× .app.tar.gz, 2× .sig, 1× latest.json
- [ ] `release-manifest` branch updated with the new `latest.json`
- [ ] Installed 0.1.3 picks up 0.1.4 via the in-app updater (banner appears within ~5 min cache window)