### PR TITLE
docs: download badges + stable filenames + release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,27 @@ jobs:
         with:
           args: --target ${{ matrix.target }}
 
+      - name: Add stable-named DMG copies
+        # The README pins its download badges to:
+        #   /releases/latest/download/agent-terminal-{aarch64,x64}.dmg
+        # That redirect resolves to the asset on whichever release is marked
+        # "Latest" — but only if the filename is stable across releases.
+        # The bundler-produced names (`Agent Terminal_0.1.4_aarch64.dmg`)
+        # change every version, so we ship side-by-side copies with
+        # versionless names. Keeps both audiences happy: the version-stamped
+        # download for the release page, the stable filename for the README.
+        run: |
+          set -euo pipefail
+          cd src-tauri/target/${{ matrix.target }}/release/bundle/dmg
+          case "${{ matrix.target }}" in
+            aarch64-apple-darwin) STABLE=agent-terminal-aarch64.dmg ;;
+            x86_64-apple-darwin)  STABLE=agent-terminal-x64.dmg ;;
+            *) echo "Unknown target ${{ matrix.target }}"; exit 1 ;;
+          esac
+          src=$(ls *.dmg | head -n 1)
+          cp -- "$src" "$STABLE"
+          ls -la
+
       - name: Suffix updater bundle with arch
         # Tauri appends `_aarch64` / `_x64` to DMG filenames automatically
         # but does NOT do the same for `.app.tar.gz` — both matrix entries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thank you for your interest in contributing. Agent Terminal is in early active d
 - [Adding a new agent (MOD system guide)](#adding-a-new-agent-mod-system-guide)
 - [Reporting bugs](#reporting-bugs)
 - [Requesting features](#requesting-features)
+- [Releasing](#releasing)
 
 ---
 
@@ -288,6 +289,47 @@ Open an issue on GitHub with:
 
 - **New agent support:** [request on X →](https://x.com/dani_akash_)
 - **Other features:** open a GitHub issue with the `enhancement` label and describe your use case
+
+---
+
+## Releasing
+
+Releases are tag-triggered. Pushing a `vX.Y.Z` (or `vX.Y.Z-rc.N`) tag fires the workflow, which builds, signs, and notarizes per-arch `.dmg`s in parallel, attaches them plus the updater bundles to a draft GitHub release, and publishes the updater manifest to the `release-manifest` branch.
+
+### Cutting a release
+
+1. **Bump the version** in three places so the tag matches the bundle metadata:
+   - `package.json`
+   - `src-tauri/tauri.conf.json`
+   - `src-tauri/Cargo.toml`
+
+   Then refresh `src-tauri/Cargo.lock` (`cargo update -p agent-terminal`) and open a PR titled `chore(release): vX.Y.Z`. The `chore(release)` prefix is filtered out of the next changelog.
+
+2. **Merge the bump PR**, then tag and push:
+
+   ```sh
+   git checkout main && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+3. **Wait for the workflow** (~10 min). When it finishes, a draft release appears on the [releases page](https://github.com/DaniAkash/agent-terminal/releases) with:
+   - 2× `Agent.Terminal_<version>_{aarch64,x64}.dmg` (versioned)
+   - 2× `agent-terminal-{aarch64,x64}.dmg` (stable filenames for the README's `/releases/latest/download/` badges)
+   - 2× `Agent.Terminal_{aarch64,x64}.app.tar.gz` + `.sig` (updater payloads)
+   - 1× `latest.json` (manifest copy)
+
+4. **Write the release notes** following the v0.1.x style: headline emoji, "Still pre-release" banner, **What's new** with feature blurbs, **Install** with both badge links, **Still on the heads-up list**, optional **Thanks**, **Feedback**.
+
+5. **Publish**, and:
+   - **Tick "Set as the latest release"** even if you're also ticking "Set as pre-release". This is required for `/releases/latest/download/` to redirect to this release — GitHub treats "latest" and "prerelease" as independent flags, but the `/latest/` redirect is off by default for pre-releases unless you opt in.
+   - Verify the README badges actually resolve: `curl -ILo /dev/null https://github.com/DaniAkash/agent-terminal/releases/latest/download/agent-terminal-aarch64.dmg` should redirect to the new asset.
+
+6. **Verify `latest.json`** at `https://raw.githubusercontent.com/DaniAkash/agent-terminal/release-manifest/latest.json` reflects the new version (cached ~5 min by raw.githubusercontent.com). Installed apps see the update on their next launch, or immediately via **Agent Terminal → Check for Updates…**.
+
+### Test tags
+
+For dry-runs (e.g., verifying a workflow change), push a `vX.Y.Z-rc.N` tag on a throwaway branch. The workflow treats it the same as a real release — full build, signing, notarization, draft release, manifest publish. Just don't publish the draft and don't tick "Set as latest"; delete the tag and draft afterwards if you want a clean releases page.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,14 @@
 
   [![Latest release](https://img.shields.io/github/v/release/DaniAkash/agent-terminal?include_prereleases&label=latest&color=blue)](https://github.com/DaniAkash/agent-terminal/releases)
   [![Status](https://img.shields.io/badge/status-pre--alpha-orange)](#status)
-  [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey)](#download)
+  [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey)](https://github.com/DaniAkash/agent-terminal/releases)
 </div>
+
+<p align="center">
+  <a href="https://github.com/DaniAkash/agent-terminal/releases/latest/download/agent-terminal-aarch64.dmg"><img src="https://img.shields.io/badge/Download_for-Apple%20Silicon-000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Apple Silicon"></a>
+  &nbsp;
+  <a href="https://github.com/DaniAkash/agent-terminal/releases/latest/download/agent-terminal-x64.dmg"><img src="https://img.shields.io/badge/Download_for-Intel-0071C5?style=for-the-badge&logo=intel&logoColor=white" alt="Download for Intel"></a>
+</p>
 
 <p align="center">
   <a href="https://www.producthunt.com/products/agent-terminal?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-agent-terminal" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1136595&theme=light&t=1777623264721" alt="Agent terminal - One terminal. Every agent. Total clarity. | Product Hunt" width="250" height="54" /></a>
@@ -27,26 +33,6 @@ If you live in a terminal alongside [Claude Code](https://claude.ai/code), [Code
 Agent Terminal is a terminal that knows the difference between a shell and an agent. It groups your tabs by project, recognises when an agent is running, and surfaces what's happening — the model in use, what's listening on which port, the git branch, your cwd — without you switching windows or running `ps`.
 
 ![Agent Terminal screenshot](./docs/assets/screenshot.png)
-
----
-
-## Download
-
-<p align="center">
-  <a href="https://github.com/DaniAkash/agent-terminal/releases/latest/download/agent-terminal-aarch64.dmg"><img src="https://img.shields.io/badge/Download_for-Apple%20Silicon-000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Apple Silicon"></a>
-  &nbsp;
-  <a href="https://github.com/DaniAkash/agent-terminal/releases/latest/download/agent-terminal-x64.dmg"><img src="https://img.shields.io/badge/Download_for-Intel-0071C5?style=for-the-badge&logo=intel&logoColor=white" alt="Download for Intel"></a>
-</p>
-
-Both badges always link to the current release — no version juggling. Full version history on the [releases page](https://github.com/DaniAkash/agent-terminal/releases).
-
-Not sure which? Click the Apple menu → About This Mac. "Chip: Apple M…" means Apple Silicon; "Processor: Intel…" means Intel.
-
-1. Download the matching `.dmg`.
-2. Open it, drag **Agent Terminal** to your Applications folder.
-3. Launch.
-
-That's it. No config files, no daemons, no tmux setup. Future updates arrive in-app — no manual downloads after the first install. Use **Agent Terminal → Check for Updates…** in the menu bar to force a check anytime.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ Agent Terminal is a terminal that knows the difference between a shell and an ag
 
 ## Download
 
-Pick the `.dmg` that matches your Mac on the [releases page](https://github.com/DaniAkash/agent-terminal/releases):
+<p align="center">
+  <a href="https://github.com/DaniAkash/agent-terminal/releases/latest/download/agent-terminal-aarch64.dmg"><img src="https://img.shields.io/badge/Download_for-Apple%20Silicon-000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Apple Silicon"></a>
+  &nbsp;
+  <a href="https://github.com/DaniAkash/agent-terminal/releases/latest/download/agent-terminal-x64.dmg"><img src="https://img.shields.io/badge/Download_for-Intel-0071C5?style=for-the-badge&logo=intel&logoColor=white" alt="Download for Intel"></a>
+</p>
 
-| Apple Silicon (M1 / M2 / M3 / M4) | Intel |
-| --- | --- |
-| `agent-terminal_<version>_aarch64.dmg` | `agent-terminal_<version>_x64.dmg` |
+Both badges always link to the current release — no version juggling. Full version history on the [releases page](https://github.com/DaniAkash/agent-terminal/releases).
 
 Not sure which? Click the Apple menu → About This Mac. "Chip: Apple M…" means Apple Silicon; "Processor: Intel…" means Intel.
 
@@ -44,7 +46,7 @@ Not sure which? Click the Apple menu → About This Mac. "Chip: Apple M…" mean
 2. Open it, drag **Agent Terminal** to your Applications folder.
 3. Launch.
 
-That's it. No config files, no daemons, no tmux setup.
+That's it. No config files, no daemons, no tmux setup. Future updates arrive in-app — no manual downloads after the first install. Use **Agent Terminal → Check for Updates…** in the menu bar to force a check anytime.
 
 ---
 


### PR DESCRIPTION
Replacement for #58 — that branch was 30+ files behind main and carried regressions from a stale base, so closing it and starting fresh against current main.

## Summary

Three tightly-coupled changes so the README's download link works without manual bumping every release.

### 1. README download badges

Replaced the placeholder file-name table with two prominent badges that link to `/releases/latest/download/agent-terminal-{aarch64,x64}.dmg`. GitHub redirects that URL to whichever release is currently marked "Latest", so the README never has to change between versions.

### 2. release.yml — stable-named DMG copies

The bundler produces `Agent Terminal_<version>_aarch64.dmg`, which is fine for the release page but breaks the stable-URL pattern. Added a step in each build matrix that copies the produced DMG to `agent-terminal-aarch64.dmg` (and `_x64.dmg`) before upload — both versions ship side-by-side on every release.

The versioned file stays as-is (audit/manual-install ergonomic). The stable filename feeds the badges.

### 3. CONTRIBUTING.md — Releasing section

Documents the full release flow:
- Tag-triggered workflow → per-arch signed/notarized DMGs + updater bundles + manifest
- **"Set as the latest release" tick is required** — GitHub treats "latest" and "prerelease" as independent flags, and the `/latest/` redirect is off by default for pre-releases unless you explicitly opt in. Without ticking it, the README badges 404.
- The rc.N test-tag dry-run path

## Backfilled v0.1.4 manually

The workflow change only fires on the *next* release. So the new README badges would 404 against today's v0.1.4 until v0.1.5 ships. To bridge the gap, I uploaded copies of v0.1.4's DMGs as `agent-terminal-{aarch64,x64}.dmg` manually:

```
$ gh release view v0.1.4 --json assets | jq '.assets[].name'
"agent-terminal-aarch64.dmg"     ← new
"agent-terminal-x64.dmg"         ← new
"Agent.Terminal_0.1.4_aarch64.dmg"
"Agent.Terminal_0.1.4_x64.dmg"
...
```

## Test plan

- [ ] Merge this PR
- [ ] When publishing v0.1.4: tick **both** "Set as a pre-release" and **"Set as the latest release"**
- [ ] After publish, `curl -ILo /dev/null https://github.com/DaniAkash/agent-terminal/releases/latest/download/agent-terminal-aarch64.dmg` returns `302` redirecting to the v0.1.4 asset
- [ ] README badges render and download on click
- [ ] Next release: workflow auto-uploads the stable-named copies (no manual backfill needed)