### PR TITLE
fix(render): scope WebGL to the active pane + force refresh on every transition

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
         "@tauri-apps/plugin-updater": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
-        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -436,8 +435,6 @@
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
     "@xterm/addon-search": ["@xterm/addon-search@0.16.0", "", {}, "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA=="],
-
-    "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.9.0", "", {}, "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.11.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@tauri-apps/plugin-updater": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
-    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",

--- a/src/components/TerminalPane/TerminalPane.tsx
+++ b/src/components/TerminalPane/TerminalPane.tsx
@@ -160,6 +160,7 @@ export const TerminalPane = React.memo(function TerminalPane({
       onData={handleData}
       onResize={handleResize}
       isAgent={isAgent}
+      isActive={isActive}
       className="h-full min-h-0 w-full"
     />
   )

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -2,11 +2,14 @@ import { useStore } from '@nanostores/react'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { FitAddon } from '@xterm/addon-fit'
 import { SearchAddon } from '@xterm/addon-search'
-import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { Terminal } from '@xterm/xterm'
 import React, { useEffect, useRef } from 'react'
+import {
+  createWebglLifecycle,
+  type WebglLifecycle,
+} from '@/components/XTermTerminal/xterm-terminal.webgl'
 import { $activeSearch } from '@/modules/stores/$activeSearch'
 import { $fontSize } from '@/modules/stores/$fontSize'
 
@@ -62,6 +65,13 @@ type Props = {
    * tabs those chords pass through unchanged.
    */
   isAgent: boolean
+  /**
+   * True when the pane is the visible one. WebGL rendering is scoped to
+   * the active pane so the per-page WebGL context count stays at 1
+   * regardless of how many tabs the user has visited (hidden panes use
+   * the DOM renderer, which is invisible anyway).
+   */
+  isActive: boolean
   className?: string
 }
 
@@ -92,28 +102,33 @@ export const XTermTerminal = React.memo(function XTermTerminal({
   onData,
   onResize,
   isAgent,
+  isActive,
   className,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const searchAddonRef = useRef<SearchAddon | null>(null)
+  const webglLifecycleRef = useRef<WebglLifecycle | null>(null)
   const fontSize = useStore($fontSize)
 
-  // Keep callbacks (and the agent flag) in refs so the mount-once effect
-  // always sees the latest versions without needing to re-run when they
-  // change reference. The custom key handler reads `isAgentRef.current`
-  // so toggling agent state mid-session reflects on the next keypress.
+  // Keep callbacks + flags in refs so the mount-once effect always sees
+  // the latest versions without needing to re-run when they change
+  // reference. `isActiveRef` is read by the WebGL lifecycle's
+  // microtask-deferred retry to bail out if the pane was deactivated
+  // between context loss and retry firing.
   const onReadyRef = useRef(onReady)
   const onDataRef = useRef(onData)
   const onResizeRef = useRef(onResize)
   const isAgentRef = useRef(isAgent)
+  const isActiveRef = useRef(isActive)
   useEffect(() => {
     onReadyRef.current = onReady
     onDataRef.current = onData
     onResizeRef.current = onResize
     isAgentRef.current = isAgent
-  }, [onReady, onData, onResize, isAgent])
+    isActiveRef.current = isActive
+  }, [onReady, onData, onResize, isAgent, isActive])
 
   useEffect(() => {
     const container = containerRef.current
@@ -121,7 +136,6 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     let disposed = false
     let resizeObserver: ResizeObserver | null = null
     let fitTimer: ReturnType<typeof setTimeout> | null = null
-    let webglAddon: WebglAddon | null = null
 
     const darkMq = window.matchMedia('(prefers-color-scheme: dark)')
 
@@ -141,7 +155,6 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     })
 
     const fitAddon = new FitAddon()
-    const unicode11Addon = new Unicode11Addon()
     const searchAddon = new SearchAddon()
     // Custom click handler — the addon's default calls window.open(), which
     // inside Tauri's webview either no-ops or hijacks the app window. Route
@@ -151,13 +164,9 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     })
 
     term.loadAddon(fitAddon)
-    term.loadAddon(unicode11Addon)
     term.loadAddon(searchAddon)
     term.loadAddon(webLinksAddon)
     term.open(container)
-
-    // Activate Unicode 11 after open() per addon docs.
-    term.unicode.activeVersion = '11'
 
     termRef.current = term
     fitAddonRef.current = fitAddon
@@ -176,20 +185,17 @@ export const XTermTerminal = React.memo(function XTermTerminal({
       }),
     )
 
-    // WebGL renderer — falls back to xterm's built-in DOM renderer on context
-    // loss. The canvas addon is not used: it is v5-only and was removed in v6.
-    try {
-      webglAddon = new WebglAddon()
-      webglAddon.onContextLoss(() => {
-        webglAddon?.dispose()
-        webglAddon = null
-        // xterm DOM renderer takes over automatically after WebGL is disposed.
-      })
-      term.loadAddon(webglAddon)
-    } catch {
-      // WebGL2 not available — xterm DOM renderer takes over automatically.
-      webglAddon = null
-    }
+    // WebGL renderer is scoped to the active pane and managed by the
+    // lifecycle helper — see xterm-terminal.webgl.ts for the rationale
+    // (one live context per page max; explicit refresh on every renderer
+    // transition; bounded retry on context loss).
+    const webglLifecycle = createWebglLifecycle({
+      term,
+      createAddon: () => new WebglAddon(),
+      isActive: () => isActiveRef.current,
+    })
+    webglLifecycleRef.current = webglLifecycle
+    if (isActiveRef.current) webglLifecycle.enableWebgl()
 
     // Single source of theme updates: the MutationObserver watches
     // `data-theme` on <html>. Both flows route through it —
@@ -272,10 +278,10 @@ export const XTermTerminal = React.memo(function XTermTerminal({
       resizeObserver?.disconnect()
       dataDisposable.dispose()
       resizeDisposable.dispose()
-      webglAddon?.dispose()
+      webglLifecycle.dispose()
+      webglLifecycleRef.current = null
       searchAddon.dispose()
       fitAddon.dispose()
-      unicode11Addon.dispose()
       webLinksAddon.dispose()
       term.dispose()
       termRef.current = null
@@ -284,14 +290,40 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     }
   }, []) // mount once — callbacks are accessed via stable refs
 
+  // Toggle WebGL on / off when the pane's activity state flips. Only
+  // the visible pane gets a live WebGL context — caps total contexts at
+  // 1 regardless of how many tabs the user has visited. The DOM
+  // renderer handles inactive panes (they're CSS-hidden, so visual
+  // fidelity doesn't matter). refresh() inside the lifecycle helpers
+  // guarantees the renderer that takes over paints the actual buffer.
+  useEffect(() => {
+    const lifecycle = webglLifecycleRef.current
+    if (!lifecycle) return
+    if (isActive) {
+      lifecycle.enableWebgl()
+      // Even if WebGL was already enabled (idempotent path), force a
+      // refresh — the pane may have been hidden long enough for atlas
+      // pages to merge, and a refresh re-resolves stale cell slots.
+      termRef.current?.refresh(0, Math.max(0, (termRef.current?.rows ?? 1) - 1))
+    } else {
+      lifecycle.disableWebgl()
+    }
+  }, [isActive])
+
   // React to font-size changes globally. Defer fit() so the canvas
-  // re-rasterizes glyphs at the new size before recomputing cols/rows.
+  // re-rasterizes glyphs at the new size before recomputing cols/rows;
+  // refresh after fit because the old-size glyphs still occupy atlas
+  // slots that the visible buffer's cells point at — refresh re-resolves
+  // them at the new size.
   useEffect(() => {
     const term = termRef.current
     const fit = fitAddonRef.current
     if (!term || !fit) return
     term.options.fontSize = fontSize
-    requestAnimationFrame(() => fit.fit())
+    requestAnimationFrame(() => {
+      fit.fit()
+      if (term.rows > 0) term.refresh(0, term.rows - 1)
+    })
   }, [fontSize])
 
   return (

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -301,10 +301,12 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     if (!lifecycle) return
     if (isActive) {
       lifecycle.enableWebgl()
-      // Even if WebGL was already enabled (idempotent path), force a
-      // refresh — the pane may have been hidden long enough for atlas
-      // pages to merge, and a refresh re-resolves stale cell slots.
-      termRef.current?.refresh(0, Math.max(0, (termRef.current?.rows ?? 1) - 1))
+      // Idempotent path skips refresh inside the helper; redo it here so
+      // an already-enabled pane that's been hidden long enough for atlas
+      // merge gets a clean re-render. Rows-guard matches the theme +
+      // font-size sites in this file.
+      const term = termRef.current
+      if (term && term.rows > 0) term.refresh(0, term.rows - 1)
     } else {
       lifecycle.disableWebgl()
     }

--- a/src/components/XTermTerminal/xterm-terminal.webgl.test.ts
+++ b/src/components/XTermTerminal/xterm-terminal.webgl.test.ts
@@ -1,0 +1,273 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { WebglAddon } from '@xterm/addon-webgl'
+import type { Terminal } from '@xterm/xterm'
+import { createWebglLifecycle } from '@/components/XTermTerminal/xterm-terminal.webgl'
+
+/* ---------------------------------------------------------------------------
+ * Minimal mocks for the two xterm objects the lifecycle touches.
+ *
+ * The lifecycle's contract is a small surface — onContextLoss capture,
+ * dispose, loadAddon, refresh, rows — so the mocks only model that.
+ * -------------------------------------------------------------------------*/
+
+function makeAddon() {
+  let onLoss: (() => void) | null = null
+  return {
+    onContextLoss: mock((cb: () => void) => {
+      onLoss = cb
+    }),
+    dispose: mock(() => {}),
+    fireContextLoss: () => onLoss?.(),
+  }
+}
+
+type FakeAddon = ReturnType<typeof makeAddon>
+
+function makeTerm(rows = 24) {
+  return {
+    rows,
+    loadAddon: mock((_addon: unknown) => {}),
+    refresh: mock((_start: number, _end: number) => {}),
+  }
+}
+
+type FakeTerm = ReturnType<typeof makeTerm>
+
+type Harness = {
+  term: FakeTerm
+  addons: FakeAddon[]
+  scheduled: Array<() => void>
+  flushScheduled: () => void
+  setActive: (v: boolean) => void
+  advanceTime: (ms: number) => void
+  // The active-tab predicate captured at construction so individual
+  // tests can flip it from true to false to exercise the
+  // microtask-bailout path.
+  isActive: () => boolean
+}
+
+function makeHarness(opts?: { startActive?: boolean }): {
+  harness: Harness
+  lifecycle: ReturnType<typeof createWebglLifecycle>
+} {
+  const term = makeTerm()
+  const addons: FakeAddon[] = []
+  const scheduled: Array<() => void> = []
+  let active = opts?.startActive ?? true
+  let virtualNow = 0
+
+  const harness: Harness = {
+    term,
+    addons,
+    scheduled,
+    flushScheduled: () => {
+      const queue = scheduled.splice(0, scheduled.length)
+      for (const fn of queue) fn()
+    },
+    setActive: (v) => {
+      active = v
+    },
+    advanceTime: (ms) => {
+      virtualNow += ms
+    },
+    isActive: () => active,
+  }
+
+  const lifecycle = createWebglLifecycle({
+    term: term as unknown as Terminal,
+    createAddon: () => {
+      const a = makeAddon()
+      addons.push(a)
+      return a as unknown as WebglAddon
+    },
+    isActive: () => active,
+    scheduleRetry: (fn) => {
+      scheduled.push(fn)
+    },
+    now: () => virtualNow,
+  })
+
+  return { harness, lifecycle }
+}
+
+let harness: Harness
+let lifecycle: ReturnType<typeof createWebglLifecycle>
+
+beforeEach(() => {
+  ;({ harness, lifecycle } = makeHarness())
+})
+
+/* ---------------------------------------------------------------------------
+ * enableWebgl() — construction + idempotency + refresh
+ * -------------------------------------------------------------------------*/
+describe('enableWebgl()', () => {
+  test('1: constructs an addon, loads it, refreshes the visible buffer', () => {
+    lifecycle.enableWebgl()
+    expect(harness.addons.length).toBe(1)
+    expect(harness.term.loadAddon).toHaveBeenCalledTimes(1)
+    expect(harness.term.refresh).toHaveBeenCalledTimes(1)
+    expect(harness.term.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  test('2: idempotent — a second call while already enabled is a no-op', () => {
+    lifecycle.enableWebgl()
+    lifecycle.enableWebgl()
+    expect(harness.addons.length).toBe(1)
+    expect(harness.term.loadAddon).toHaveBeenCalledTimes(1)
+    expect(harness.term.refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test('3: isEnabled reflects state', () => {
+    expect(lifecycle.isEnabled()).toBe(false)
+    lifecycle.enableWebgl()
+    expect(lifecycle.isEnabled()).toBe(true)
+  })
+
+  test('4: skips refresh when rows is zero (pre-fit), still loads addon', () => {
+    const { harness: h, lifecycle: lc } = makeHarness()
+    h.term.rows = 0
+    lc.enableWebgl()
+    expect(h.term.loadAddon).toHaveBeenCalledTimes(1)
+    expect(h.term.refresh).not.toHaveBeenCalled()
+  })
+
+  test('5: createAddon throwing leaves us cleanly disabled', () => {
+    const term = makeTerm()
+    const lc = createWebglLifecycle({
+      term: term as unknown as Terminal,
+      createAddon: () => {
+        throw new Error('WebGL2 not supported in this context')
+      },
+      isActive: () => true,
+    })
+    lc.enableWebgl()
+    expect(lc.isEnabled()).toBe(false)
+    expect(term.loadAddon).not.toHaveBeenCalled()
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * disableWebgl() — dispose + refresh on every transition
+ * -------------------------------------------------------------------------*/
+describe('disableWebgl()', () => {
+  test('6: disposes the addon and refreshes once', () => {
+    lifecycle.enableWebgl()
+    harness.term.refresh.mockClear()
+    lifecycle.disableWebgl()
+    expect(harness.addons[0].dispose).toHaveBeenCalledTimes(1)
+    expect(harness.term.refresh).toHaveBeenCalledTimes(1)
+    expect(lifecycle.isEnabled()).toBe(false)
+  })
+
+  test('7: no-op when not currently enabled', () => {
+    lifecycle.disableWebgl()
+    expect(harness.term.refresh).not.toHaveBeenCalled()
+  })
+
+  test('8: enable → disable → enable allocates a fresh addon', () => {
+    lifecycle.enableWebgl()
+    lifecycle.disableWebgl()
+    lifecycle.enableWebgl()
+    expect(harness.addons.length).toBe(2)
+    expect(harness.addons[0].dispose).toHaveBeenCalledTimes(1)
+    expect(harness.addons[1].dispose).not.toHaveBeenCalled()
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * onContextLoss — dispose, refresh, bounded microtask retry
+ * -------------------------------------------------------------------------*/
+describe('context loss handling', () => {
+  test('9: first loss disposes, refreshes, and schedules a retry', () => {
+    lifecycle.enableWebgl()
+    harness.term.refresh.mockClear()
+    harness.addons[0].fireContextLoss()
+
+    expect(harness.addons[0].dispose).toHaveBeenCalledTimes(1)
+    expect(harness.term.refresh).toHaveBeenCalledTimes(1)
+    expect(harness.scheduled.length).toBe(1)
+    expect(lifecycle.isEnabled()).toBe(false)
+  })
+
+  test('10: scheduled retry re-enables when isActive is still true', () => {
+    lifecycle.enableWebgl()
+    harness.addons[0].fireContextLoss()
+    harness.flushScheduled()
+    expect(harness.addons.length).toBe(2)
+    expect(lifecycle.isEnabled()).toBe(true)
+  })
+
+  test('11: scheduled retry bails out when isActive flips to false', () => {
+    lifecycle.enableWebgl()
+    harness.addons[0].fireContextLoss()
+    harness.setActive(false)
+    harness.flushScheduled()
+    expect(harness.addons.length).toBe(1)
+    expect(lifecycle.isEnabled()).toBe(false)
+  })
+
+  test('12: two losses inside the retry window — second skips the retry', () => {
+    lifecycle.enableWebgl()
+    harness.addons[0].fireContextLoss()
+    harness.flushScheduled()
+    // Now back to enabled. Loss again, immediately — no second retry.
+    harness.addons[1].fireContextLoss()
+    expect(harness.scheduled.length).toBe(0)
+    expect(lifecycle.isEnabled()).toBe(false)
+  })
+
+  test('13: a loss outside the retry window — retry happens', () => {
+    lifecycle.enableWebgl()
+    harness.addons[0].fireContextLoss()
+    harness.flushScheduled()
+    // Advance past the retry window so the second loss is not "recent".
+    harness.advanceTime(6000)
+    harness.addons[1].fireContextLoss()
+    expect(harness.scheduled.length).toBe(1)
+    harness.flushScheduled()
+    expect(harness.addons.length).toBe(3)
+    expect(lifecycle.isEnabled()).toBe(true)
+  })
+
+  test('14: loss handler refreshes even when isEnabled was set via the old addon', () => {
+    lifecycle.enableWebgl()
+    harness.term.refresh.mockClear()
+    harness.addons[0].fireContextLoss()
+    expect(harness.term.refresh).toHaveBeenCalledWith(0, 23)
+  })
+})
+
+/* ---------------------------------------------------------------------------
+ * dispose() — unmount path, no refresh side effect
+ * -------------------------------------------------------------------------*/
+describe('dispose()', () => {
+  test('15: disposes the live addon without firing refresh', () => {
+    lifecycle.enableWebgl()
+    harness.term.refresh.mockClear()
+    lifecycle.dispose()
+    expect(harness.addons[0].dispose).toHaveBeenCalledTimes(1)
+    expect(harness.term.refresh).not.toHaveBeenCalled()
+  })
+
+  test('16: enable after dispose is a no-op (lifecycle is one-shot)', () => {
+    lifecycle.dispose()
+    lifecycle.enableWebgl()
+    expect(harness.addons.length).toBe(0)
+    expect(lifecycle.isEnabled()).toBe(false)
+  })
+
+  test('17: queued retry after dispose does nothing', () => {
+    lifecycle.enableWebgl()
+    harness.addons[0].fireContextLoss()
+    // dispose happens between loss and retry firing.
+    lifecycle.dispose()
+    harness.flushScheduled()
+    expect(harness.addons.length).toBe(1)
+    expect(lifecycle.isEnabled()).toBe(false)
+  })
+
+  test('18: dispose with no live addon is a no-op', () => {
+    lifecycle.dispose()
+    expect(harness.term.refresh).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/XTermTerminal/xterm-terminal.webgl.ts
+++ b/src/components/XTermTerminal/xterm-terminal.webgl.ts
@@ -1,0 +1,133 @@
+import type { WebglAddon } from '@xterm/addon-webgl'
+import type { Terminal } from '@xterm/xterm'
+
+export type WebglLifecycleDeps = {
+  term: Terminal
+  /**
+   * Constructs and returns a fresh WebglAddon. Wrapping the constructor
+   * lets tests inject a stub without touching the real WebGL stack.
+   */
+  createAddon: () => WebglAddon
+  /**
+   * Reads the live "should WebGL be active" answer at call time. Lets
+   * the microtask-deferred retry bail out if the pane was deactivated
+   * between context loss and retry firing.
+   */
+  isActive: () => boolean
+  /**
+   * Schedule a function to run after the current task. Defaults to
+   * `queueMicrotask`; overridable so tests can flush deterministically.
+   */
+  scheduleRetry?: (fn: () => void) => void
+  /**
+   * Wall-clock-ish source for the retry-window check. Defaults to
+   * `performance.now()`; overridable so tests can advance virtual time.
+   */
+  now?: () => number
+}
+
+export type WebglLifecycle = {
+  enableWebgl: () => void
+  disableWebgl: () => void
+  /** True iff a WebglAddon is currently loaded on the terminal. */
+  isEnabled: () => boolean
+  /** Tear-down for unmount — disposes any live addon without refresh. */
+  dispose: () => void
+}
+
+/**
+ * Manages a single WebglAddon's lifecycle on a Terminal instance and
+ * guarantees `term.refresh` is called on every renderer transition.
+ *
+ * Behaviour contracts:
+ *   - enableWebgl() is idempotent — calling while already enabled is a
+ *     no-op (no extra addon allocated, no extra refresh).
+ *   - disableWebgl() refreshes the visible buffer once so the DOM
+ *     renderer that takes over (via WebglAddon.dispose() reinstalling
+ *     it) repaints what's actually in the buffer, instead of leaving
+ *     the stale WebGL canvas content visible.
+ *   - On context loss: dispose + refresh, then attempt ONE retry via
+ *     the scheduler. A second loss within the retry window (default
+ *     5 s) suppresses the retry — bounded so a persistently broken
+ *     GPU doesn't thrash the addon lifecycle.
+ *   - Retries no-op if `isActive()` is false at retry time — when the
+ *     pane has been deactivated between loss and retry, the disable
+ *     path already ran and we don't want to re-enable.
+ */
+const CONTEXT_LOSS_RETRY_WINDOW_MS = 5000
+
+export function createWebglLifecycle(deps: WebglLifecycleDeps): WebglLifecycle {
+  const scheduleRetry = deps.scheduleRetry ?? queueMicrotask
+  const now = deps.now ?? (() => performance.now())
+
+  let webglAddon: WebglAddon | null = null
+  let lastContextLossAt = -Infinity
+  let disposed = false
+
+  function refreshVisible() {
+    const term = deps.term
+    if (term.rows <= 0) return
+    term.refresh(0, term.rows - 1)
+  }
+
+  function onContextLossOf(addon: WebglAddon) {
+    return () => {
+      // Always dispose + refresh so the DOM renderer that WebglAddon's
+      // dispose path installs gets explicitly told to paint the buffer.
+      // Without this, the pane shows whatever stale frame the WebGL
+      // canvas had at the moment of loss.
+      addon.dispose()
+      if (webglAddon === addon) webglAddon = null
+      refreshVisible()
+
+      // Bounded retry: if another loss happened within the window, give
+      // up. Otherwise schedule a single retry via the injected scheduler
+      // (microtask in prod, manual in tests).
+      const t = now()
+      const recent = t - lastContextLossAt < CONTEXT_LOSS_RETRY_WINDOW_MS
+      lastContextLossAt = t
+      if (recent) return
+      scheduleRetry(() => {
+        if (disposed) return
+        if (!deps.isActive()) return
+        enableWebgl()
+      })
+    }
+  }
+
+  function enableWebgl(): void {
+    if (disposed) return
+    if (webglAddon) return
+    try {
+      const addon = deps.createAddon()
+      addon.onContextLoss(onContextLossOf(addon))
+      deps.term.loadAddon(addon)
+      webglAddon = addon
+      refreshVisible()
+    } catch {
+      // WebGL2 not available — leave the DOM renderer in place. Future
+      // enable attempts will retry naturally on next isActive flip.
+      webglAddon = null
+    }
+  }
+
+  function disableWebgl(): void {
+    if (!webglAddon) return
+    webglAddon.dispose()
+    webglAddon = null
+    refreshVisible()
+  }
+
+  function dispose(): void {
+    if (disposed) return
+    disposed = true
+    webglAddon?.dispose()
+    webglAddon = null
+  }
+
+  function isEnabled(): boolean {
+    return webglAddon !== null
+  }
+
+  return { enableWebgl, disableWebgl, dispose, isEnabled }
+}


### PR DESCRIPTION
## Summary

Fixes the two failure modes users hit on longer agent-terminal sessions:

1. **Missing characters** within otherwise-correct lines (e.g. \`Building map\` rendering as \`Bu ld ng ma\`).
2. **Garbled glyphs** — cells rendering with the wrong character (boxes, slanted bars, mismatched symbols where text used to be).

Bold + colored escape-styled text always renders fine, which is the giveaway: this is plain-text atlas glyph corruption in the WebGL renderer, not a logic bug.

## Root cause

Two compounding things:

- **Atlas page-merge eviction in \`@xterm/addon-webgl@0.19.0\`.** \`TextureAtlas.ts:155-200\` packs rasterised glyphs into fixed-size pages. When the page count hits its cap, the four most-used pages of the largest size are merged to free space. xterm.js v6 has no per-cell invalidation after the merge — cells that pointed at freed slots become stale. Result: blank cells (slot now drawing background) or wrong-glyph cells (slot now holds a different rasterised character).
- **N simultaneous WebGL contexts** — \`WorkspaceLayout.tsx:42-46\` and \`WorkspaceView.tsx:19-22\` keep every visited tab and project mounted forever. Each \`TerminalPane\` constructs its own \`Terminal\` + \`WebglAddon\`. A user with 10 visited tabs has 10 live WebGL contexts. Chrome's per-page WebGL2 cap is ~16; even within the cap, the contexts fight for GPU memory and atlas pressure.

There's also a third smaller bug: the existing context-loss handler at \`XTermTerminal.tsx:183-187\` disposes the addon but never calls \`term.refresh\`. \`WebglAddon.dispose()\`'s reinstall-DOM-renderer path calls \`handleResize\` only — which is a no-op when dimensions haven't changed. The DOM renderer takes over, but is never told to paint, so the pane shows whatever stale frame the WebGL canvas had at the moment of loss.

## The four fixes

1. **Scope WebGL to the active pane.** A new \`useEffect([isActive])\` calls \`enableWebgl()\` / \`disableWebgl()\` on the lifecycle helper. Caps live WebGL contexts at 1 regardless of how many tabs the user has visited.

2. **Force \`term.refresh(0, rows - 1)\` on every renderer transition** — after \`enableWebgl\`, after \`disableWebgl\`, after context loss, after every \`isActive\` toggle (covers atlas-may-be-stale on reactivation), and after \`fit()\` in the \`fontSize\` effect (covers wrong-cached-glyph-size after font change).

3. **Bounded retry on context loss.** The current handler permanently falls back to DOM after first loss. New behaviour: schedule one retry via the injected scheduler (\`queueMicrotask\` in prod), bail if \`isActive\` flipped false meanwhile, suppress retry if a second loss happens within 5 s of the first. Recovery is automatic when conditions improve; thrash is bounded.

4. **Drop \`@xterm/addon-unicode11\`.** It's a width classifier, not a renderer. xterm's default Unicode 6 width tables cover everything agent output actually contains (the only behavioural difference would be Emoji 11+ code points measured as single-width when they should be double — a tiny cursor-position miscount in niche cases vs. the current corruption). Removing it shrinks the texture-atlas working set that triggers the page-merge eviction in the first place.

## Why these four together close the loop

| Failure mode | Mechanism | Fix |
|---|---|---|
| Atlas eviction → blank cells | Page-merge frees slots; cells aren't re-rendered | (4) smaller working set → fewer merges. (1) one context → much higher headroom per atlas. (2) refresh on activation forces re-render when pane is shown again. |
| Atlas eviction → wrong-glyph cells | Freed slots reused; cell still points at old slot | Same as above. |
| Context loss → stale frame | \`handleResize\` is no-op when dims unchanged; DOM renderer never told to paint | (2) explicit refresh after dispose. (3) retry restores GPU when conditions improve. |
| Hidden tabs → atlas + GPU pressure | N WebGL contexts share GPU + each holds its own atlas | (1) only the visible pane has WebGL. |

Each fix is independently necessary; the sum is "rendering doesn't corrupt anymore."

## Architecture

The WebGL lifecycle is extracted into \`src/components/XTermTerminal/xterm-terminal.webgl.ts\` — same naming pattern as the existing \`xterm-terminal.keys.ts\` / \`xterm-terminal.themes.ts\`. The module exposes \`createWebglLifecycle(deps)\` with \`enableWebgl\` / \`disableWebgl\` / \`isEnabled\` / \`dispose\`, all behaviour-tested in isolation against mock \`Terminal\` and \`WebglAddon\` instances.

## Files

- **Modified** — \`src/components/XTermTerminal/XTermTerminal.tsx\` (add \`isActive\` prop + ref, replace inline WebGL setup with lifecycle, refresh in font-size effect, drop \`Unicode11Addon\` import + load + dispose + activeVersion). \`src/components/TerminalPane/TerminalPane.tsx\` (pass \`isActive\` through). \`package.json\` + \`bun.lock\` (drop \`@xterm/addon-unicode11\`).
- **Added** — \`src/components/XTermTerminal/xterm-terminal.webgl.ts\` (lifecycle module). \`src/components/XTermTerminal/xterm-terminal.webgl.test.ts\` (18 unit tests).

## Test plan

Unit tests (auto-run):

- [x] 18 lifecycle tests covering idempotency, refresh on every transition, context-loss retry policy (window + isActive gating), unmount race
- [x] 80 adjacent existing tests (modules/stores, modules/updater, etc.) still pass

Manual matrix (need to run on a real build):

- [ ] Repro on \`main\` first: open ~8 tabs across 2-3 projects, run \`seq 1 100000 | awk '{print \"line \" \$1 \" — agent output simulation ●\"}'\` in two of them, switch back and forth between tabs 20-30 times. Some cells should render blank or with wrong glyphs.
- [ ] Same procedure on the branch: no corruption.
- [ ] Switch away from a streaming-output tab, switch back: cells render fresh on activation.
- [ ] Open agent-terminal alongside ~12 WebGL2-heavy browser tabs. On \`main\`, panes whose context gets force-lost render garbage. On the branch, they refresh to DOM-renderer output, then retry WebGL via microtask.
- [ ] Cmd+= / Cmd+- font-size changes: buffer re-renders cleanly at the new size with no stale-glyph frame.
- [ ] 5-minute streaming smoke test: no corruption.