### PR TITLE
ci(release): normalize spaces in updater bundle filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,15 @@ jobs:
           esac
           for f in *.app.tar.gz; do
             base="${f%.app.tar.gz}"
+            # Tauri's bundler uses productName verbatim — e.g. for
+            # "Agent Terminal" it produces "Agent Terminal.app.tar.gz" with
+            # a literal space. GitHub Releases stores the asset fine but
+            # silently rewrites spaces to dots in the served URL path
+            # (`Agent.Terminal_…app.tar.gz`), so a manifest URL built from
+            # the spaced on-disk name 404s when the updater fetches it.
+            # Normalize here so the on-disk filename, the uploaded asset,
+            # and the manifest URL all agree on dotted form.
+            base="${base// /.}"
             mv -- "$f"     "${base}_${ARCH}.app.tar.gz"
             mv -- "$f.sig" "${base}_${ARCH}.app.tar.gz.sig"
           done


### PR DESCRIPTION
## What broke on v0.1.5

The in-app updater on v0.1.4 installs hit \`404 Not Found\` when trying to download the v0.1.5 update payload. Tauri's bundler produces \`Agent Terminal.app.tar.gz\` (literal space — productName is used verbatim). GitHub Releases stores the asset, but silently rewrites the space to a dot in the served URL path (\`Agent.Terminal_…\`). The workflow's manifest-generation step used \`basename\` on the still-spaced on-disk filename, so the URLs in \`latest.json\` ended up with a literal space:

\`\`\`json
\"url\": \"https://github.com/DaniAkash/agent-terminal/releases/download/v0.1.5/Agent Terminal_aarch64.app.tar.gz\"
\`\`\`

The updater plugin URL-encoded the space to %20; GitHub's asset router doesn't match that path:

\`\`\`
GET .../Agent%20Terminal_aarch64.app.tar.gz  → 404
GET .../Agent.Terminal_aarch64.app.tar.gz    → 302 → S3
\`\`\`

## Fix

Replace spaces with dots in the basename when adding the arch suffix. Bash parameter expansion (\`\${base// /.}\`) — one extra line, in the same loop that already renames the file:

\`\`\`bash
base=\"\${f%.app.tar.gz}\"
base=\"\${base// /.}\"   # NEW
mv -- \"\$f\" \"\${base}_\${ARCH}.app.tar.gz\"
\`\`\`

After this, the on-disk filename, the uploaded GitHub asset path, and the manifest URL all agree on dotted form.

## v0.1.5 in production

Already hot-patched by editing \`latest.json\` directly on the \`release-manifest\` branch (commit \`383a5ad\`). The live manifest now serves dotted URLs and existing v0.1.4 installs can complete the update within the ~5 min raw.githubusercontent.com cache window. This PR prevents the recurrence on v0.1.6+; no further action needed for v0.1.5.

## Test plan

- [ ] Merge
- [ ] Cut v0.1.6 (or test on a throwaway pre-release tag like \`v0.1.6-rc.1\`)
- [ ] Confirm the workflow's \"Suffix updater bundle with arch\" step logs filenames with dots: \`Agent.Terminal_aarch64.app.tar.gz\`
- [ ] Confirm the published \`latest.json\` URL HEAD returns 302 (not 404)
- [ ] Confirm the in-app updater can download + install end-to-end

## Notes

DMG bundling already produces dotted filenames (verified on v0.1.5 — \`Agent.Terminal_0.1.5_aarch64.dmg\`), so this fix only affects the \`.app.tar.gz\` rename step. No change needed to the manifest-generation step or anywhere else.