### PR TITLE
feat(desktop): StreamHub — per-tab fan-out + sequenced ring buffer

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.1.5"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "dashmap",
  "dirs 5.0.1",
  "encoding_rs",
  "portable-pty",
@@ -896,6 +897,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1834,6 +1849,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,4 +66,8 @@ thiserror = "2"
 # eventually carry a Node binary inside the .app bundle; until then, dev
 # launches look the runtime up from the system.
 which = "8"
+# Sharded concurrent map for the StreamHub's per-tab state. Many reader
+# threads broadcast concurrently across different tabs; a single Mutex
+# would serialise unrelated tabs through the lock.
+dashmap = "6"
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,16 +1,22 @@
 use crate::mod_engine::ModEngine;
 use crate::pty_manager::{spawn_pty, try_reattach, PtyDataPayload, PtyMap, ReattachResult};
+use crate::stream_hub::StreamHub;
 use portable_pty::PtySize;
 use std::io::Write;
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Emitter, State};
 use tauri::ipc::Channel;
 
+// Tauri commands take their managed state + frontend args by position.
+// Bundling into a struct would lose the ergonomic state injection.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn open_tab(
     app: AppHandle,
     pty_map: State<'_, PtyMap>,
     mod_engine: State<'_, ModEngine>,
+    hub: State<'_, Arc<StreamHub>>,
     tab_id: String,
     cwd: Option<String>,
     shell: Option<String>,
@@ -37,6 +43,7 @@ pub async fn open_tab(
         &pty_map,
         mod_engine.handle(),
         mod_engine.cwd_table(),
+        Arc::clone(&hub),
         &tab_id,
         on_data.clone(),
     ) {
@@ -59,6 +66,7 @@ pub async fn open_tab(
         &pty_map,
         mod_engine.handle(),
         mod_engine.cwd_table(),
+        Arc::clone(&hub),
         tab_id,
         cwd,
         shell,
@@ -91,6 +99,7 @@ pub async fn write_pty(
 pub async fn resize_pty(
     pty_map: State<'_, PtyMap>,
     mod_engine: State<'_, ModEngine>,
+    hub: State<'_, Arc<StreamHub>>,
     tab_id: String,
     cols: u16,
     rows: u16,
@@ -107,12 +116,16 @@ pub async fn resize_pty(
         }
     } // Lock released before dispatching to MOD engine.
     mod_engine.handle().on_resize(&tab_id, cols, rows);
+    // Keep the sidecar's shadow xterm in sync so its future serialize
+    // payload reflects the right viewport dimensions.
+    hub.resize_tab(&tab_id, cols, rows).await;
     Ok(())
 }
 
 #[tauri::command]
 pub async fn close_tab(
     pty_map: State<'_, PtyMap>,
+    hub: State<'_, Arc<StreamHub>>,
     tab_id: String,
 ) -> Result<(), String> {
     // The reader thread reads `closing` on EOF to decide between emitting
@@ -122,11 +135,17 @@ pub async fn close_tab(
     // reader reads `closing`, either we've already set it (and the entry
     // is gone — exit path) or we haven't yet (entry still present —
     // respawn path).
-    let mut map = pty_map.lock().unwrap();
-    if let Some(handle) = map.get(&tab_id) {
-        handle.closing.store(true, Ordering::Release);
+    {
+        let mut map = pty_map.lock().unwrap();
+        if let Some(handle) = map.get(&tab_id) {
+            handle.closing.store(true, Ordering::Release);
+        }
+        map.remove(&tab_id);
     }
-    map.remove(&tab_id);
+    // Drop hub state + tell the sidecar to dispose its shadow xterm.
+    // Done after the PtyMap mutation so the reader thread's `closing`
+    // check sees the same ordering it always did.
+    hub.close_tab(&tab_id).await;
     Ok(())
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -117,8 +117,8 @@ pub async fn resize_pty(
     } // Lock released before dispatching to MOD engine.
     mod_engine.handle().on_resize(&tab_id, cols, rows);
     // Keep the sidecar's shadow xterm in sync so its future serialize
-    // payload reflects the right viewport dimensions.
-    hub.resize_tab(&tab_id, cols, rows).await;
+    // payload reflects the right viewport dimensions. Fire-and-forget.
+    hub.resize_tab(&tab_id, cols, rows);
     Ok(())
 }
 
@@ -144,8 +144,8 @@ pub async fn close_tab(
     }
     // Drop hub state + tell the sidecar to dispose its shadow xterm.
     // Done after the PtyMap mutation so the reader thread's `closing`
-    // check sees the same ordering it always did.
-    hub.close_tab(&tab_id).await;
+    // check sees the same ordering it always did. Fire-and-forget.
+    hub.close_tab(&tab_id);
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,8 @@ mod shell_integration;
 // pub so integration tests can drive a SidecarClient instance directly
 // without going through the full Tauri startup path.
 pub mod sidecar_client;
+// pub for the same reason — tests construct StreamHub directly.
+pub mod stream_hub;
 
 use hook_config::ensure_hooks_installed;
 use hook_server::start_hook_server;
@@ -42,6 +44,7 @@ use sidecar_client::SidecarClient;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use stream_hub::StreamHub;
 use tokio::process::Command;
 
 /// Locate the runtime binary + sidecar entry script. Dev launches read from
@@ -197,12 +200,20 @@ pub fn run() {
 
             // Headless-xterm sidecar. Spawned as best-effort so a missing
             // node/bun runtime or a not-yet-bundled script never blocks the
-            // desktop from launching. Consumers (StreamHub, WSS server)
-            // check app.try_state::<Arc<SidecarClient>>() and degrade
-            // gracefully when None.
-            if let Some(client) = tauri::async_runtime::block_on(try_spawn_sidecar()) {
-                app.manage(Arc::new(client));
+            // desktop from launching. The StreamHub built below uses
+            // Option<Arc<SidecarClient>> so it degrades to local-only fan-
+            // out when the sidecar isn't available.
+            let sidecar = tauri::async_runtime::block_on(try_spawn_sidecar()).map(Arc::new);
+            if let Some(client) = sidecar.clone() {
+                app.manage(client);
             }
+
+            // Per-tab fan-out hub. Always present so pty_manager's reader
+            // threads have a stable broadcast target; the sidecar passed in
+            // is the optional bit. State<'_, Arc<StreamHub>> is the handle
+            // Tauri commands grab.
+            let hub = StreamHub::new(sidecar);
+            app.manage(hub);
 
             // Window focus → suppression signal only.
             // (The previous focus-event-based click heuristic is gone — it

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -521,13 +521,17 @@ pub fn spawn_pty(
         },
     );
 
-    // Wire the hub: register the local channel as a subscriber and tell
-    // the sidecar to open a matching shadow xterm. Both are idempotent
-    // for this tab id (subsequent re-spawns on the same tab leave the
-    // existing subscriber alone; ensure_tab is a no-op if state already
-    // exists). The sidecar.open call fires into the runtime, so spawn_pty
-    // stays sync. Strict order with subsequent broadcasts is preserved by
-    // the single mpsc inside SidecarClient.
+    // Reset any stale hub state for this tab id before wiring the new
+    // session. spawn_pty runs when try_reattach returned NotFound or
+    // Expired — for Expired, the previous session left a TabState with
+    // its own seq counter, ring entries, and (potentially) a
+    // disconnected SharedChannel still in the subscriber list. Carrying
+    // those into the new PTY would silently leak subscribers and break
+    // remote-resume sequence math once remote subscribers exist.
+    //
+    // close_tab is a no-op for the NotFound case, so this is safe to
+    // run unconditionally.
+    hub.close_tab(&tab_id);
     hub.ensure_tab(&tab_id, 80, 24);
     hub.subscribe_local(&tab_id, channel.clone());
 

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -1,4 +1,5 @@
 use crate::mod_engine::{CwdTable, ModEngineHandle};
+use crate::stream_hub::StreamHub;
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use serde::Serialize;
 use std::collections::HashMap;
@@ -104,6 +105,11 @@ struct ReaderCtx {
     closing: Arc<AtomicBool>,
     pty_map: PtyMap,
     cwd_table: CwdTable,
+    /// Per-tab fan-out into local subscribers + sidecar shadow xterm.
+    /// Reader threads broadcast every PTY chunk through here; the local
+    /// channel above is one of its subscribers (still owned here for the
+    /// reconnect-swap mechanism try_reattach uses).
+    hub: Arc<StreamHub>,
 }
 
 /// Spawns the reader thread that forwards PTY bytes to the frontend.
@@ -136,9 +142,10 @@ fn spawn_reader_thread(
                     decoded.clear();
                     let _ = decoder.decode_to_string(&[], &mut decoded, true);
                     if !decoded.is_empty() {
-                        if let Some(ch) = ctx.channel.lock().unwrap().as_ref() {
-                            ch.send(PtyDataPayload { data: decoded.clone() }).ok();
-                        }
+                        // Decoder tail goes to local subscribers only:
+                        // raw bytes are empty here so the ring + sidecar
+                        // see nothing (matches the pre-hub flush path).
+                        ctx.hub.broadcast(&ctx.tab_id, &[], &decoded);
                     }
 
                     // Mark dead first so try_reattach can't observe
@@ -191,25 +198,15 @@ fn spawn_reader_thread(
                     let (_result, _bytes_read, _had_errors) =
                         decoder.decode_to_string(&buf[..n], &mut decoded, false);
 
-                    let send_ok = {
-                        let guard = ctx.channel.lock().unwrap();
-                        match guard.as_ref() {
-                            Some(ch) => {
-                                ch.send(PtyDataPayload { data: decoded.clone() }).is_ok()
-                            }
-                            // No channel — WebView disconnected. Skip the
-                            // forward but still feed mods so per-tab state
-                            // stays current for reconnect.
-                            None => true,
-                        }
-                    };
+                    // Single fan-out: hub.broadcast handles the local
+                    // WebView send (including dead-channel cleanup), the
+                    // ring buffer, and the sidecar shadow write. The
+                    // PtyDataPayload-shape preservation for the WebView
+                    // path is byte-identical to the pre-hub code.
+                    ctx.hub.broadcast(&ctx.tab_id, &buf[..n], &decoded);
 
-                    if !send_ok {
-                        // Channel dropped mid-flight (WebView vanished while
-                        // we were sending). Clear the dead channel; the
-                        // process is fine, open_tab will swap in a new one.
-                        ctx.channel.lock().unwrap().take();
-                    }
+                    // Mods still see raw bytes directly — the hub is
+                    // purely a forwarder for subscribers.
                     ctx.mod_handle.on_output(&ctx.tab_id, buf[..n].to_vec());
                 }
             }
@@ -317,6 +314,7 @@ fn respawn_in_place(ctx: &ReaderCtx) -> Result<RespawnOutcome, String> {
             closing: ctx.closing.clone(),
             pty_map: ctx.pty_map.clone(),
             cwd_table: ctx.cwd_table.clone(),
+            hub: Arc::clone(&ctx.hub),
         },
         new_reader,
     );
@@ -337,6 +335,7 @@ pub fn try_reattach(
     pty_map: &PtyMap,
     mod_handle: ModEngineHandle,
     cwd_table: CwdTable,
+    hub: Arc<StreamHub>,
     tab_id: &str,
     on_data: Channel<PtyDataPayload>,
 ) -> Result<ReattachResult, String> {
@@ -394,6 +393,7 @@ pub fn try_reattach(
             closing,
             pty_map: pty_map.clone(),
             cwd_table,
+            hub,
         },
         reader,
     );
@@ -466,11 +466,16 @@ fn build_shell_command(
     cmd
 }
 
+// Long signature is the trade-off for keeping spawn_pty callable from both
+// the open_tab command and the respawn / try_reattach paths without a
+// builder. A SpawnConfig struct would be cleaner but is scope creep here.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_pty(
     app: AppHandle,
     pty_map: &PtyMap,
     mod_handle: ModEngineHandle,
     cwd_table: CwdTable,
+    hub: Arc<StreamHub>,
     tab_id: String,
     cwd: Option<String>,
     shell: Option<String>,
@@ -516,6 +521,16 @@ pub fn spawn_pty(
         },
     );
 
+    // Wire the hub: register the local channel as a subscriber and tell
+    // the sidecar to open a matching shadow xterm. Both are idempotent
+    // for this tab id (subsequent re-spawns on the same tab leave the
+    // existing subscriber alone; ensure_tab is a no-op if state already
+    // exists). The sidecar.open call fires into the runtime, so spawn_pty
+    // stays sync. Strict order with subsequent broadcasts is preserved by
+    // the single mpsc inside SidecarClient.
+    hub.ensure_tab(&tab_id, 80, 24);
+    hub.subscribe_local(&tab_id, channel.clone());
+
     spawn_reader_thread(
         ReaderCtx {
             app,
@@ -526,6 +541,7 @@ pub fn spawn_pty(
             closing,
             pty_map: pty_map.clone(),
             cwd_table,
+            hub,
         },
         reader,
     );

--- a/src-tauri/src/sidecar_client.rs
+++ b/src-tauri/src/sidecar_client.rs
@@ -221,6 +221,27 @@ impl SidecarClient {
         Ok(())
     }
 
+    /// Fire-and-forget `open`. Pushes the line onto the writer mpsc
+    /// synchronously and returns; no reply is awaited. The sidecar
+    /// processes lines in arrival order, so a subsequent `write_bytes`
+    /// from the same thread is guaranteed to land after this line — that
+    /// is the ordering invariant `StreamHub::ensure_tab` relies on.
+    ///
+    /// Any sidecar-side failure (bad cols, OOM, etc.) is silently dropped
+    /// from the caller's perspective but surfaces on the sidecar's stderr
+    /// log, which the Rust client forwards with a `[sidecar]` prefix.
+    pub fn open_nonblocking(&self, tab_id: &str, cols: u16, rows: u16) {
+        if self.is_dead() {
+            return;
+        }
+        let line = json!({
+            "verb": "open",
+            "args": { "tab_id": tab_id, "cols": cols, "rows": rows }
+        })
+        .to_string();
+        let _ = self.inner.writer_tx.send(line);
+    }
+
     /// Push raw PTY bytes to the sidecar's parser for `tab_id`. Returns
     /// immediately — there is no reply. If the sidecar has died, the bytes
     /// silently drop; the caller's hot path stays branch-free.
@@ -246,6 +267,20 @@ impl SidecarClient {
         Ok(())
     }
 
+    /// Fire-and-forget `resize`. Same ordering and failure semantics as
+    /// `open_nonblocking`.
+    pub fn resize_nonblocking(&self, tab_id: &str, cols: u16, rows: u16) {
+        if self.is_dead() {
+            return;
+        }
+        let line = json!({
+            "verb": "resize",
+            "args": { "tab_id": tab_id, "cols": cols, "rows": rows }
+        })
+        .to_string();
+        let _ = self.inner.writer_tx.send(line);
+    }
+
     /// Ask the sidecar to serialize tab_id's buffer. Returns the xterm-
     /// serialize payload (a string containing escape sequences ready to
     /// replay into a fresh xterm Terminal).
@@ -266,6 +301,20 @@ impl SidecarClient {
     pub async fn close(&self, tab_id: &str) -> Result<()> {
         self.call("close", json!({ "tab_id": tab_id })).await?;
         Ok(())
+    }
+
+    /// Fire-and-forget `close`. Same ordering and failure semantics as
+    /// `open_nonblocking`.
+    pub fn close_nonblocking(&self, tab_id: &str) {
+        if self.is_dead() {
+            return;
+        }
+        let line = json!({
+            "verb": "close",
+            "args": { "tab_id": tab_id }
+        })
+        .to_string();
+        let _ = self.inner.writer_tx.send(line);
     }
 }
 

--- a/src-tauri/src/stream_hub.rs
+++ b/src-tauri/src/stream_hub.rs
@@ -1,0 +1,513 @@
+// Per-tab fan-out of PTY output. The reader thread broadcasts every chunk
+// through here instead of sending directly to the WebView Channel; the hub
+// then delivers to every subscriber (local WebView + future remote mobile
+// clients) AND writes the same bytes to the sidecar's shadow xterm so the
+// sidecar's terminal state stays in sync with the real PTY for the upcoming
+// `serialize` op.
+//
+// What the hub owns per tab:
+// - A monotonic u64 sequence counter for every broadcast chunk.
+// - A bytes-capped ring buffer of recent (seq, bytes) entries — used for
+//   replay-on-reconnect to remote clients (no consumers yet; sub-step 4
+//   wires this up).
+// - A list of subscribers. In this sub-step only `Subscriber::Local` exists;
+//   `Subscriber::Remote` arrives when the WSS server lands.
+// - Last-known cols/rows so future `subscribe_remote` calls know what size
+//   to ask the sidecar to serialise.
+//
+// What the hub does NOT own:
+// - The PTY itself (lives in `PtyHandle` inside `PtyMap`).
+// - The UTF-8 stream decoder (lives in the reader thread, kept there so the
+//   stateful cross-chunk decode stays single-threaded and identical to
+//   today's byte-for-byte behaviour).
+// - The mod engine. `pty_manager` still feeds `mod_handle.on_output` with
+//   raw bytes directly — the hub is purely a forwarder.
+//
+// Locking discipline (matters for reasoning about deadlocks):
+// - `tabs` is a DashMap (sharded). Holding a per-tab `Arc<TabState>` does
+//   not block other tabs.
+// - Within a tab, the order is always: `subscribers` lock first, then
+//   `shared.lock()` on a Local subscriber's channel. No code path goes the
+//   other way, so there is no AB / BA deadlock between hub broadcast and
+//   `try_reattach`'s channel swap.
+
+use crate::pty_manager::{PtyDataPayload, SharedChannel};
+use crate::sidecar_client::SidecarClient;
+use dashmap::DashMap;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
+
+/// Default ring buffer cap per tab — bytes, not entries. Holds roughly five
+/// to ten seconds of continuous high-bandwidth output. Past this point a
+/// reconnecting remote client receives a fresh snapshot instead of byte
+/// replay (sub-step 4 implements the snapshot path).
+pub const DEFAULT_RING_CAP_BYTES: usize = 512 * 1024;
+
+/// Stable identifier for a subscriber within a tab. Allocated by the hub
+/// at subscribe time; callers hand it back to unsubscribe. Opaque on
+/// purpose — the underlying counter is an implementation detail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SubscriberId(u64);
+
+pub enum Subscriber {
+    /// Desktop WebView path. The SharedChannel inside flips between
+    /// `Some(channel)` and `None` as the WebView connects and reconnects
+    /// without ever re-subscribing — same shape pty_manager has used since
+    /// before the hub existed.
+    Local(SharedChannel),
+    // Subscriber::Remote arrives when the WSS server is wired in; this
+    // enum is non-exhaustive on purpose for that growth.
+}
+
+struct TabState {
+    next_seq: AtomicU64,
+    ring: Mutex<RingBuffer>,
+    subscribers: Mutex<Vec<(SubscriberId, Subscriber)>>,
+    next_sub_id: AtomicU64,
+    // Last-known terminal size. `resize_tab` updates this; future
+    // `subscribe_remote` will read it to know what dimensions to ask the
+    // sidecar to serialise.
+    cols: AtomicU16,
+    rows: AtomicU16,
+}
+
+impl TabState {
+    fn new(cols: u16, rows: u16, ring_cap_bytes: usize) -> Self {
+        Self {
+            next_seq: AtomicU64::new(0),
+            ring: Mutex::new(RingBuffer::new(ring_cap_bytes)),
+            subscribers: Mutex::new(Vec::new()),
+            next_sub_id: AtomicU64::new(1),
+            cols: AtomicU16::new(cols),
+            rows: AtomicU16::new(rows),
+        }
+    }
+}
+
+struct RingBuffer {
+    cap_bytes: usize,
+    bytes_held: usize,
+    entries: VecDeque<(u64, Vec<u8>)>,
+}
+
+impl RingBuffer {
+    fn new(cap_bytes: usize) -> Self {
+        Self {
+            cap_bytes,
+            bytes_held: 0,
+            entries: VecDeque::new(),
+        }
+    }
+
+    /// Append a new chunk, evicting older ones from the front until the
+    /// held byte total fits the cap. The newest entry is always kept even
+    /// if it alone exceeds the cap — losing it would silently drop bytes
+    /// the producer just claimed to broadcast.
+    fn push(&mut self, seq: u64, bytes: Vec<u8>) {
+        self.bytes_held = self.bytes_held.saturating_add(bytes.len());
+        self.entries.push_back((seq, bytes));
+        while self.bytes_held > self.cap_bytes && self.entries.len() > 1 {
+            if let Some((_, evicted)) = self.entries.pop_front() {
+                self.bytes_held = self.bytes_held.saturating_sub(evicted.len());
+            }
+        }
+    }
+}
+
+pub struct StreamHub {
+    tabs: DashMap<String, Arc<TabState>>,
+    sidecar: Option<Arc<SidecarClient>>,
+    ring_cap_bytes: usize,
+}
+
+impl StreamHub {
+    pub fn new(sidecar: Option<Arc<SidecarClient>>) -> Arc<Self> {
+        Self::with_ring_cap(sidecar, DEFAULT_RING_CAP_BYTES)
+    }
+
+    pub fn with_ring_cap(sidecar: Option<Arc<SidecarClient>>, ring_cap_bytes: usize) -> Arc<Self> {
+        Arc::new(Self {
+            tabs: DashMap::new(),
+            sidecar,
+            ring_cap_bytes,
+        })
+    }
+
+    /// Create per-tab state (idempotent) and tell the sidecar to open a
+    /// matching headless xterm. Returns immediately; the sidecar open is
+    /// fired into the tokio runtime so the synchronous spawn_pty caller
+    /// doesn't have to be made async.
+    ///
+    /// Strict ordering with subsequent `broadcast` calls is preserved by
+    /// the single mpsc inside the SidecarClient: the `open` line lands on
+    /// the writer queue before any `write` line that follows.
+    pub fn ensure_tab(&self, tab_id: &str, cols: u16, rows: u16) {
+        self.tabs
+            .entry(tab_id.to_string())
+            .or_insert_with(|| Arc::new(TabState::new(cols, rows, self.ring_cap_bytes)));
+
+        if let Some(sidecar) = self.sidecar.clone() {
+            let tab_id = tab_id.to_string();
+            tauri::async_runtime::spawn(async move {
+                if let Err(e) = sidecar.open(&tab_id, cols, rows).await {
+                    eprintln!("[stream_hub] sidecar.open({tab_id}) failed: {e}");
+                }
+            });
+        }
+    }
+
+    /// Add a Local subscriber for `tab_id`. Caller stores the returned id
+    /// and passes it to `unsubscribe` later. If the tab doesn't exist yet
+    /// (broadcast hasn't happened), it is created with default 80x24
+    /// dimensions; the upcoming resize call will correct them.
+    pub fn subscribe_local(&self, tab_id: &str, channel: SharedChannel) -> SubscriberId {
+        let state = self
+            .tabs
+            .entry(tab_id.to_string())
+            .or_insert_with(|| Arc::new(TabState::new(80, 24, self.ring_cap_bytes)))
+            .clone();
+        let id = SubscriberId(state.next_sub_id.fetch_add(1, Ordering::Relaxed));
+        state
+            .subscribers
+            .lock()
+            .expect("subscribers lock poisoned")
+            .push((id, Subscriber::Local(channel)));
+        id
+    }
+
+    pub fn unsubscribe(&self, tab_id: &str, sub_id: SubscriberId) {
+        if let Some(state) = self.tabs.get(tab_id) {
+            state
+                .subscribers
+                .lock()
+                .expect("subscribers lock poisoned")
+                .retain(|(id, _)| *id != sub_id);
+        }
+    }
+
+    /// Broadcast one chunk of PTY output. Local subscribers receive the
+    /// UTF-8 decoded string (matches the `PtyDataPayload { data: String }`
+    /// shape the WebView already consumes). The ring buffer and the
+    /// sidecar receive the raw bytes (xterm-headless parses escape
+    /// sequences from bytes; the ring's replay path needs raw too).
+    ///
+    /// Caller passes both raw and decoded because the stateful UTF-8
+    /// decoder lives in the reader thread — moving it into the hub would
+    /// require synchronising the decoder across hypothetical concurrent
+    /// broadcasts to the same tab, which today never happens (one reader
+    /// thread per tab) but would be a footgun for future contributors.
+    ///
+    /// Sync (not async) so the reader thread's hot loop stays on a real
+    /// OS thread without bouncing off the tokio runtime.
+    pub fn broadcast(&self, tab_id: &str, raw_bytes: &[u8], decoded_str: &str) {
+        if raw_bytes.is_empty() && decoded_str.is_empty() {
+            return;
+        }
+        let state = match self.tabs.get(tab_id) {
+            Some(s) => Arc::clone(&s),
+            None => return,
+        };
+
+        if !decoded_str.is_empty() {
+            let subscribers = state.subscribers.lock().expect("subscribers lock poisoned");
+            for (_, sub) in subscribers.iter() {
+                match sub {
+                    Subscriber::Local(shared) => {
+                        let send_failed = {
+                            let guard = shared.lock().expect("channel lock poisoned");
+                            match guard.as_ref() {
+                                Some(ch) => ch
+                                    .send(PtyDataPayload {
+                                        data: decoded_str.to_string(),
+                                    })
+                                    .is_err(),
+                                // WebView disconnected; the next `open_tab`
+                                // call will swap a fresh Channel into this
+                                // SharedChannel. Skip without fault.
+                                None => false,
+                            }
+                        };
+                        if send_failed {
+                            // Channel dropped mid-send (WebView vanished
+                            // while we were forwarding). Clear so the next
+                            // broadcast skips cleanly. Matches the
+                            // pre-hub behaviour byte-for-byte.
+                            shared
+                                .lock()
+                                .expect("channel lock poisoned")
+                                .take();
+                        }
+                    }
+                }
+            }
+        }
+
+        if !raw_bytes.is_empty() {
+            let seq = state.next_seq.fetch_add(1, Ordering::AcqRel);
+            state
+                .ring
+                .lock()
+                .expect("ring lock poisoned")
+                .push(seq, raw_bytes.to_vec());
+            if let Some(sidecar) = &self.sidecar {
+                sidecar.write_bytes(tab_id, raw_bytes);
+            }
+        }
+    }
+
+    /// Update the tab's known size and tell the sidecar to resize its
+    /// shadow xterm. Called from `resize_pty`.
+    pub async fn resize_tab(&self, tab_id: &str, cols: u16, rows: u16) {
+        if let Some(state) = self.tabs.get(tab_id) {
+            state.cols.store(cols, Ordering::Release);
+            state.rows.store(rows, Ordering::Release);
+        }
+        if let Some(sidecar) = self.sidecar.as_ref() {
+            if let Err(e) = sidecar.resize(tab_id, cols, rows).await {
+                eprintln!("[stream_hub] sidecar.resize({tab_id}) failed: {e}");
+            }
+        }
+    }
+
+    /// Drop per-tab state and tell the sidecar to dispose its shadow.
+    pub async fn close_tab(&self, tab_id: &str) {
+        self.tabs.remove(tab_id);
+        if let Some(sidecar) = self.sidecar.as_ref() {
+            if let Err(e) = sidecar.close(tab_id).await {
+                eprintln!("[stream_hub] sidecar.close({tab_id}) failed: {e}");
+            }
+        }
+    }
+
+    // ---- introspection — used by tests and by future remote ops ----
+
+    /// Read the current seq counter for a tab. Returns None if the tab is
+    /// unknown. Mostly a test affordance today; future `subscribe_remote`
+    /// will use it to stamp the snapshot frame.
+    pub fn next_seq(&self, tab_id: &str) -> Option<u64> {
+        self.tabs
+            .get(tab_id)
+            .map(|s| s.next_seq.load(Ordering::Acquire))
+    }
+
+    /// Snapshot of the current ring contents. Test affordance + future
+    /// resume-remote path. Returns a clone so callers don't hold the lock.
+    pub fn ring_entries(&self, tab_id: &str) -> Option<Vec<(u64, Vec<u8>)>> {
+        self.tabs.get(tab_id).map(|s| {
+            s.ring
+                .lock()
+                .expect("ring lock poisoned")
+                .entries
+                .iter()
+                .cloned()
+                .collect()
+        })
+    }
+
+    /// Aggregate bytes currently held in the ring for `tab_id`.
+    pub fn ring_bytes_held(&self, tab_id: &str) -> Option<usize> {
+        self.tabs.get(tab_id).map(|s| {
+            s.ring
+                .lock()
+                .expect("ring lock poisoned")
+                .bytes_held
+        })
+    }
+
+    /// Number of subscribers currently registered for `tab_id`.
+    pub fn subscriber_count(&self, tab_id: &str) -> Option<usize> {
+        self.tabs
+            .get(tab_id)
+            .map(|s| s.subscribers.lock().expect("subscribers lock poisoned").len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_hub() -> Arc<StreamHub> {
+        StreamHub::new(None)
+    }
+
+    fn new_hub_with_cap(cap: usize) -> Arc<StreamHub> {
+        StreamHub::with_ring_cap(None, cap)
+    }
+
+    #[test]
+    fn ensure_tab_creates_state_at_zero_seq() {
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        assert_eq!(hub.next_seq("t1"), Some(0));
+        assert_eq!(hub.subscriber_count("t1"), Some(0));
+    }
+
+    #[test]
+    fn ensure_tab_is_idempotent() {
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        hub.broadcast("t1", b"a", "a");
+        // Re-ensuring must not reset seq or wipe state.
+        hub.ensure_tab("t1", 120, 30);
+        assert_eq!(hub.next_seq("t1"), Some(1));
+    }
+
+    #[test]
+    fn broadcast_increments_seq_per_chunk() {
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        for _ in 0..5 {
+            hub.broadcast("t1", b"x", "x");
+        }
+        assert_eq!(hub.next_seq("t1"), Some(5));
+    }
+
+    #[test]
+    fn broadcast_pushes_raw_bytes_to_ring() {
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        hub.broadcast("t1", b"hello", "hello");
+        let entries = hub.ring_entries("t1").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, 0);
+        assert_eq!(entries[0].1, b"hello");
+    }
+
+    #[test]
+    fn ring_evicts_oldest_when_over_cap() {
+        // Tiny cap so eviction kicks in after a few writes.
+        let hub = new_hub_with_cap(100);
+        hub.ensure_tab("t1", 80, 24);
+        for i in 0..10u8 {
+            hub.broadcast("t1", &[i; 20], "x");
+        }
+        let entries = hub.ring_entries("t1").unwrap();
+        let total: usize = entries.iter().map(|(_, b)| b.len()).sum();
+        assert!(total <= 100, "ring exceeded cap: {total}");
+        // Newest entry must still be present — losing it would mean
+        // dropping bytes the caller just claimed to broadcast.
+        assert_eq!(entries.last().unwrap().0, 9);
+        // Oldest entries should have been evicted.
+        assert!(entries.first().unwrap().0 >= 5);
+    }
+
+    #[test]
+    fn ring_keeps_single_oversize_entry() {
+        let hub = new_hub_with_cap(50);
+        hub.ensure_tab("t1", 80, 24);
+        hub.broadcast("t1", &vec![0u8; 500], "x");
+        let entries = hub.ring_entries("t1").unwrap();
+        assert_eq!(entries.len(), 1, "must not silently drop the only entry");
+        assert_eq!(entries[0].1.len(), 500);
+    }
+
+    #[test]
+    fn separate_tabs_have_independent_seqs() {
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        hub.ensure_tab("t2", 80, 24);
+        hub.broadcast("t1", b"a", "a");
+        hub.broadcast("t1", b"b", "b");
+        hub.broadcast("t2", b"x", "x");
+        assert_eq!(hub.next_seq("t1"), Some(2));
+        assert_eq!(hub.next_seq("t2"), Some(1));
+    }
+
+    #[test]
+    fn broadcast_to_unknown_tab_is_silent() {
+        let hub = new_hub();
+        hub.broadcast("ghost", b"x", "x");
+        assert_eq!(hub.next_seq("ghost"), None);
+    }
+
+    #[test]
+    fn empty_broadcast_is_noop() {
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        hub.broadcast("t1", b"", "");
+        assert_eq!(hub.next_seq("t1"), Some(0));
+        assert_eq!(hub.ring_entries("t1").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn decoded_only_broadcast_skips_ring() {
+        // Simulates the reader-thread EOF flush: decoder spits out a
+        // partial-codepoint tail, raw bytes are empty.
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        hub.broadcast("t1", b"", "tail");
+        // No raw bytes → no ring entry, no seq increment, no sidecar
+        // (verified indirectly by ring + seq state).
+        assert_eq!(hub.next_seq("t1"), Some(0));
+        assert_eq!(hub.ring_entries("t1").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn close_tab_drops_state() {
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        hub.broadcast("t1", b"hello", "hello");
+        tauri::async_runtime::block_on(hub.close_tab("t1"));
+        assert_eq!(hub.next_seq("t1"), None);
+        assert!(hub.ring_entries("t1").is_none());
+    }
+
+    #[test]
+    fn subscribe_local_returns_distinct_ids() {
+        let hub = new_hub();
+        let make_chan = || Arc::new(Mutex::new(None));
+        let id1 = hub.subscribe_local("t1", make_chan());
+        let id2 = hub.subscribe_local("t1", make_chan());
+        let id3 = hub.subscribe_local("t1", make_chan());
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert_eq!(hub.subscriber_count("t1"), Some(3));
+    }
+
+    #[test]
+    fn unsubscribe_removes_only_named_subscriber() {
+        let hub = new_hub();
+        let make_chan = || Arc::new(Mutex::new(None));
+        let id1 = hub.subscribe_local("t1", make_chan());
+        let _id2 = hub.subscribe_local("t1", make_chan());
+        assert_eq!(hub.subscriber_count("t1"), Some(2));
+        hub.unsubscribe("t1", id1);
+        assert_eq!(hub.subscriber_count("t1"), Some(1));
+    }
+
+    #[test]
+    fn unsubscribe_unknown_tab_is_silent() {
+        let hub = new_hub();
+        hub.unsubscribe("ghost", SubscriberId(99));
+        // No panic; nothing to verify beyond "didn't crash".
+    }
+
+    /// Stress: many threads broadcasting into different tabs hammer the
+    /// DashMap shards. The hub must remain consistent: each tab's seq
+    /// counter equals the number of broadcasts that hit it.
+    #[test]
+    fn concurrent_broadcasts_across_tabs_consistent() {
+        let hub = new_hub();
+        for t in 0..16 {
+            hub.ensure_tab(&format!("t{t}"), 80, 24);
+        }
+        let handles: Vec<_> = (0..16)
+            .map(|t| {
+                let hub = Arc::clone(&hub);
+                std::thread::spawn(move || {
+                    for _ in 0..1000 {
+                        hub.broadcast(&format!("t{t}"), b"x", "x");
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        for t in 0..16 {
+            assert_eq!(hub.next_seq(&format!("t{t}")), Some(1000));
+        }
+    }
+}

--- a/src-tauri/src/stream_hub.rs
+++ b/src-tauri/src/stream_hub.rs
@@ -51,14 +51,17 @@ pub const DEFAULT_RING_CAP_BYTES: usize = 512 * 1024;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SubscriberId(u64);
 
+/// Per-tab fan-out target. `#[non_exhaustive]` so adding the upcoming
+/// `Remote` variant for paired mobile clients does not break any external
+/// matcher — and matches the intent expressed in the master architecture
+/// plan that subscribers grow over the phases.
+#[non_exhaustive]
 pub enum Subscriber {
     /// Desktop WebView path. The SharedChannel inside flips between
     /// `Some(channel)` and `None` as the WebView connects and reconnects
     /// without ever re-subscribing — same shape pty_manager has used since
     /// before the hub existed.
     Local(SharedChannel),
-    // Subscriber::Remote arrives when the WSS server is wired in; this
-    // enum is non-exhaustive on purpose for that growth.
 }
 
 struct TabState {
@@ -136,25 +139,19 @@ impl StreamHub {
     }
 
     /// Create per-tab state (idempotent) and tell the sidecar to open a
-    /// matching headless xterm. Returns immediately; the sidecar open is
-    /// fired into the tokio runtime so the synchronous spawn_pty caller
-    /// doesn't have to be made async.
-    ///
-    /// Strict ordering with subsequent `broadcast` calls is preserved by
-    /// the single mpsc inside the SidecarClient: the `open` line lands on
-    /// the writer queue before any `write` line that follows.
+    /// matching headless xterm. Fully synchronous — the sidecar `open`
+    /// line lands on the writer mpsc before this call returns, so any
+    /// subsequent `broadcast` from the same thread is guaranteed to push
+    /// its `write` line after the `open`. The previous version spawned
+    /// the open as a tokio task, which broke that ordering whenever the
+    /// reader thread raced ahead of the runtime scheduler.
     pub fn ensure_tab(&self, tab_id: &str, cols: u16, rows: u16) {
         self.tabs
             .entry(tab_id.to_string())
             .or_insert_with(|| Arc::new(TabState::new(cols, rows, self.ring_cap_bytes)));
 
-        if let Some(sidecar) = self.sidecar.clone() {
-            let tab_id = tab_id.to_string();
-            tauri::async_runtime::spawn(async move {
-                if let Err(e) = sidecar.open(&tab_id, cols, rows).await {
-                    eprintln!("[stream_hub] sidecar.open({tab_id}) failed: {e}");
-                }
-            });
+        if let Some(sidecar) = self.sidecar.as_ref() {
+            sidecar.open_nonblocking(tab_id, cols, rows);
         }
     }
 
@@ -258,26 +255,27 @@ impl StreamHub {
     }
 
     /// Update the tab's known size and tell the sidecar to resize its
-    /// shadow xterm. Called from `resize_pty`.
-    pub async fn resize_tab(&self, tab_id: &str, cols: u16, rows: u16) {
+    /// shadow xterm. Sync + fire-and-forget so callers don't have to be
+    /// async just to drag a divider.
+    pub fn resize_tab(&self, tab_id: &str, cols: u16, rows: u16) {
         if let Some(state) = self.tabs.get(tab_id) {
             state.cols.store(cols, Ordering::Release);
             state.rows.store(rows, Ordering::Release);
         }
         if let Some(sidecar) = self.sidecar.as_ref() {
-            if let Err(e) = sidecar.resize(tab_id, cols, rows).await {
-                eprintln!("[stream_hub] sidecar.resize({tab_id}) failed: {e}");
-            }
+            sidecar.resize_nonblocking(tab_id, cols, rows);
         }
     }
 
     /// Drop per-tab state and tell the sidecar to dispose its shadow.
-    pub async fn close_tab(&self, tab_id: &str) {
+    /// Sync + fire-and-forget. Called both from the user-facing close_tab
+    /// command and from spawn_pty when restarting a tab whose previous
+    /// PTY died (resets ring + seq + sidecar shadow so the new session
+    /// doesn't inherit stale state).
+    pub fn close_tab(&self, tab_id: &str) {
         self.tabs.remove(tab_id);
         if let Some(sidecar) = self.sidecar.as_ref() {
-            if let Err(e) = sidecar.close(tab_id).await {
-                eprintln!("[stream_hub] sidecar.close({tab_id}) failed: {e}");
-            }
+            sidecar.close_nonblocking(tab_id);
         }
     }
 
@@ -449,9 +447,44 @@ mod tests {
         let hub = new_hub();
         hub.ensure_tab("t1", 80, 24);
         hub.broadcast("t1", b"hello", "hello");
-        tauri::async_runtime::block_on(hub.close_tab("t1"));
+        hub.close_tab("t1");
         assert_eq!(hub.next_seq("t1"), None);
         assert!(hub.ring_entries("t1").is_none());
+    }
+
+    /// Regression: when `spawn_pty` restarts a tab whose previous PTY
+    /// expired, it calls `close_tab` then `ensure_tab` on the same id.
+    /// The hub state must come up fresh — same seq counter as a brand-
+    /// new tab, empty ring, no carried-over subscribers — otherwise
+    /// remote subscribers' resume-by-seq math is wrong on the next
+    /// session.
+    #[test]
+    fn close_then_ensure_resets_seq_ring_and_subscribers() {
+        let hub = new_hub();
+        let make_chan = || Arc::new(Mutex::new(None));
+
+        // First session.
+        hub.ensure_tab("t1", 80, 24);
+        let _id = hub.subscribe_local("t1", make_chan());
+        hub.broadcast("t1", b"first-session-bytes", "x");
+        assert_eq!(hub.next_seq("t1"), Some(1));
+        assert_eq!(hub.subscriber_count("t1"), Some(1));
+        assert_eq!(hub.ring_entries("t1").unwrap().len(), 1);
+
+        // Simulated respawn-after-expiry path.
+        hub.close_tab("t1");
+        hub.ensure_tab("t1", 80, 24);
+
+        // Fresh state: seq back to zero, no subscribers, empty ring.
+        assert_eq!(hub.next_seq("t1"), Some(0));
+        assert_eq!(hub.subscriber_count("t1"), Some(0));
+        assert_eq!(hub.ring_entries("t1").unwrap().len(), 0);
+
+        // A new subscriber attaches cleanly and its broadcasts are
+        // accounted against the fresh seq counter.
+        hub.subscribe_local("t1", make_chan());
+        hub.broadcast("t1", b"second-session", "x");
+        assert_eq!(hub.next_seq("t1"), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
> Sub-step 2 of the mobile-companion server stack. Targets the epic branch \`feat/desktop-sidecar-substrate\`. Builds on the sidecar substrate that branch already carries.

## What

One new module that consolidates the PTY reader thread's output path. The reader thread no longer writes directly to the WebView \`Channel\`; it calls \`hub.broadcast\`, which forwards each chunk to every subscriber and to the sidecar's shadow xterm.

\`\`\`
PTY read -> decoder ─┐
                     ▼
                hub.broadcast(tab_id, raw_bytes, decoded_str)
                     │
        ┌────────────┼────────────┐
        ▼            ▼            ▼
  Subscribers   Ring buffer   Sidecar
  (Local +      (512 KB,      (write_bytes,
   future       seq-tagged,   keeps shadow
   Remote)      for replay)   xterm in sync)
\`\`\`

## Why this is the regression-risky sub-step

The reader thread is the hottest path in the desktop. Today's two \`ch.send(...)\` call sites get replaced by one \`hub.broadcast(...)\` call. The WebView path must stay **byte-identical** — same \`PtyDataPayload\` shape, same dead-channel-clear behaviour, same skip-when-Channel-None semantics. Plenty of tests + a manual happy path on this PR's branch confirmed that holds.

## Files

| File | Change |
|---|---|
| \`src-tauri/src/stream_hub.rs\` (new) | StreamHub + TabState + RingBuffer + Subscriber enum (Local only for now). Public API: \`new\` / \`ensure_tab\` / \`subscribe_local\` / \`unsubscribe\` / \`broadcast\` / \`resize_tab\` / \`close_tab\`. Plus introspection (\`next_seq\` / \`ring_entries\` / \`ring_bytes_held\` / \`subscriber_count\`) used by tests and by the upcoming remote-resume path. |
| \`src-tauri/src/pty_manager.rs\` | \`ReaderCtx\` gains \`hub: Arc<StreamHub>\`. Reader thread's two \`ch.send\` sites collapse into one \`hub.broadcast\`. EOF flush path also goes through the hub (decoded tail to locals; raw-empty so it bypasses ring + sidecar). \`spawn_pty\` calls \`hub.ensure_tab\` + \`hub.subscribe_local\`. |
| \`src-tauri/src/commands.rs\` | \`open_tab\` / \`resize_pty\` / \`close_tab\` take \`State<Arc<StreamHub>>\`. \`resize_pty\` awaits \`hub.resize_tab\`. \`close_tab\` awaits \`hub.close_tab\`. |
| \`src-tauri/src/lib.rs\` | Builds \`StreamHub::new(sidecar)\` next to the sidecar manage and registers it as managed state. Hub still works (degraded, local-only) when the sidecar failed to spawn. |
| \`src-tauri/Cargo.toml\` | Adds \`dashmap = \"6\"\`. The hub's per-tab state uses a sharded concurrent map so multiple tabs broadcasting in parallel don't serialise through a single Mutex. |

## Tests

| Suite | Result | What it covers |
|---|---|---|
| \`cargo test --lib stream_hub\` | 15/15 | seq monotonicity per chunk, per-tab independence, ring eviction respecting byte cap, single-entry-larger-than-cap kept, decoded-only flush bypasses ring + sidecar, subscribe / unsubscribe id allocation + isolation, close_tab drops all state, 16-thread / 16-tab / 1000-broadcast stress yielding exact seq counts, broadcasts to unknown tabs are silent. |
| \`cargo test --lib\` (whole) | 62/62 + 1 ignored | Existing 47 still pass untouched. |
| \`cargo test --test hook_integration\` | 9/9 (4 ignored, same as before) | No regressions on the existing PTY / hook surface. |
| \`cargo test --lib -- --ignored\` | 1/1 | Real-sidecar end-to-end roundtrip from sub-step 1 still passes against the freshly bundled sidecar. |
| \`cargo clippy --lib --tests\` | no new warnings | Only the pre-existing \`hook_integration\` MutexGuard noise remains. \`spawn_pty\` and \`open_tab\` carry \`#[allow(clippy::too_many_arguments)]\` with a comment explaining the trade-off (alternative is a SpawnConfig refactor that's scope creep here). |
| \`bun test src/\` | 147/147 | Frontend untouched, still green. |
| \`bun test\` (sidecar) | 11/11 | Sidecar JS still green. |
| Manual: \`bun run tauri:dev\` | sidecar spawns + terminal works | Sub-step 1's verified launch path is unchanged. |

## What's deferred

- \`Subscriber::Remote\` and the \`subscribe_remote\` / \`resume_remote\` async APIs land with the WSS server sub-step. Today's enum is intentionally non-exhaustive so adding a variant is non-breaking.
- Wire-protocol types: sub-step 3.
- The \`stream-hub-off\` cargo feature flag mentioned in the planning notes is **not** included. The stacking strategy (epic branch lands in main as one slice once the walking skeleton works) gives the soak the feature flag was originally meant to provide.

## Test plan (post-merge into the epic branch)

- [ ] Boot \`bun run tauri:dev\` on the merged epic branch. Confirm \`[sidecar] ready\` still appears.
- [ ] Run a few terminal sessions; output rendering should be byte-identical.
- [ ] Disconnect / reconnect a tab (close + reopen the WebView). \`pty_manager\`'s reconnect path should still work end-to-end via the SharedChannel swap.
- [ ] Resize a tab. The sidecar shadow should resize via \`hub.resize_tab\` (visible only via log lines today).