### PR TITLE
feat(desktop): WSS server — the mobile companion's network surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "dashmap",
  "dirs 5.0.1",
  "encoding_rs",
+ "futures-util",
  "portable-pty",
  "serde",
  "serde_json",
@@ -33,6 +34,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "typeshare",
  "user-notify",
  "uuid",
@@ -419,7 +421,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5617,6 +5619,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -5624,7 +5638,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -5850,6 +5864,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.1.5"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "constant_time_eq",
  "dashmap",
  "dirs 5.0.1",
  "encoding_rs",
@@ -29,10 +30,12 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "typeshare",
  "user-notify",
+ "uuid",
  "which",
 ]
 
@@ -783,6 +786,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite 0.26.2",
  "typeshare",
  "user-notify",
  "uuid",
@@ -5619,14 +5619,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.24.0",
+ "tungstenite 0.26.2",
 ]
 
 [[package]]
@@ -5867,19 +5867,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.9.4",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -415,8 +416,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1020,6 +1023,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
@@ -4680,6 +4689,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5596,6 +5616,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5818,6 +5850,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typeid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,4 +88,11 @@ uuid = { version = "1", features = ["v4"] }
 [dev-dependencies]
 # Isolated temp directories for auth_stub round-trip tests.
 tempfile = "3"
+# WebSocket client for the wss_server integration tests. Spins up an in-
+# process WS client bound to a randomly-assigned port so tests never
+# collide with a real WSS server the dev has running.
+tokio-tungstenite = "0.24"
+# Stream/Sink extension traits needed for tokio-tungstenite's split
+# WebSocket handles.
+futures-util = "0.3"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,7 +51,11 @@ portable-pty = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-axum = "0.8"
+# `ws` feature is needed for the WSS server's `/stream` endpoint. axum-ws
+# is a thin wrapper over tokio-tungstenite (which axum-ws pulls in for us)
+# — same underlying implementation the master plan sketched, with axum's
+# routing / middleware / graceful-shutdown machinery bolted on top.
+axum = { version = "0.8", features = ["ws"] }
 dirs = "5"
 encoding_rs = "0.8"
 sysinfo = "0.33"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,10 +88,10 @@ uuid = { version = "1", features = ["v4"] }
 [dev-dependencies]
 # Isolated temp directories for auth_stub round-trip tests.
 tempfile = "3"
-# WebSocket client for the wss_server integration tests. Spins up an in-
-# process WS client bound to a randomly-assigned port so tests never
-# collide with a real WSS server the dev has running.
-tokio-tungstenite = "0.24"
+# WebSocket client for the wss_server integration tests. Version pinned
+# to match what axum 0.8's `ws` feature pulls in transitively — avoids
+# two tungstenite stacks in the build.
+tokio-tungstenite = "0.26"
 # Stream/Sink extension traits needed for tokio-tungstenite's split
 # WebSocket handles.
 futures-util = "0.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,4 +74,14 @@ dashmap = "6"
 # picks up every `#[typeshare]`-annotated type and emits the matching TS
 # discriminated-union file under `companion/src/modules/wss/protocol.gen.ts`.
 typeshare = "1"
+# Constant-time token comparison for the WSS auth stub. Prevents timing
+# attacks even in dev mode — cheap defence-in-depth over `==` on bytes.
+constant_time_eq = "0.3"
+# Random token generation for the initial dev config file. v4 UUIDs give
+# ~122 bits of entropy which is plenty for a Phase-1 bearer token.
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+# Isolated temp directories for auth_stub round-trip tests.
+tempfile = "3"
 

--- a/src-tauri/sidecar/index.js
+++ b/src-tauri/sidecar/index.js
@@ -51,11 +51,13 @@ function openTab({ tab_id, cols, rows }) {
   })
   const serializer = new SerializeAddon()
   term.loadAddon(serializer)
-  // last_seq: highest seq the Rust hub has enqueued for this tab. Updated by
-  // writeBytes; returned by serializeTab so subscribe_remote can tag its
-  // snapshot with the exact seq whose bytes are reflected in the payload.
-  // 0 means "no writes seen yet".
-  terminals.set(tab_id, { term, serializer, last_seq: 0 })
+  // last_seq: highest seq the Rust hub has enqueued for this tab. Updated
+  // by writeBytes; returned by serializeTab so subscribe_remote can tag
+  // its snapshot with the exact seq whose bytes are reflected in the
+  // payload. `null` is the "no writes seen yet" sentinel — distinct from
+  // 0, which is a legitimate first-broadcast seq. The Rust side reads
+  // this as `Option<u64>` and initialises new subscribers accordingly.
+  terminals.set(tab_id, { term, serializer, last_seq: null })
 }
 
 function writeBytes({ tab_id, bytes_b64, seq }) {

--- a/src-tauri/sidecar/index.js
+++ b/src-tauri/sidecar/index.js
@@ -51,16 +51,24 @@ function openTab({ tab_id, cols, rows }) {
   })
   const serializer = new SerializeAddon()
   term.loadAddon(serializer)
-  terminals.set(tab_id, { term, serializer })
+  // last_seq: highest seq the Rust hub has enqueued for this tab. Updated by
+  // writeBytes; returned by serializeTab so subscribe_remote can tag its
+  // snapshot with the exact seq whose bytes are reflected in the payload.
+  // 0 means "no writes seen yet".
+  terminals.set(tab_id, { term, serializer, last_seq: 0 })
 }
 
-function writeBytes({ tab_id, bytes_b64 }) {
+function writeBytes({ tab_id, bytes_b64, seq }) {
   const entry = terminals.get(tab_id)
   if (!entry) return
   // term.write is async-internal — the data joins a parser queue and the
   // visible buffer updates later. Fire-and-forget at this layer is fine
   // because `serialize` flushes the queue before reading.
   entry.term.write(Buffer.from(bytes_b64, 'base64'))
+  // Track the seq the Rust hub assigned to this chunk so a subsequent
+  // serialize can return it verbatim. Writes without a seq (historic
+  // callers, tests) leave the counter untouched.
+  if (typeof seq === 'number') entry.last_seq = seq
 }
 
 function resizeTab({ tab_id, cols, rows }) {
@@ -82,7 +90,13 @@ async function serializeTab({ tab_id, scrollback }) {
   const payload = entry.serializer.serialize({
     scrollback: typeof scrollback === 'number' ? scrollback : 1000,
   })
-  return { ok: true, payload }
+  // last_seq is the highest seq whose bytes have been fully parsed into the
+  // terminal buffer (flushWrites above waits for the parser to drain, so
+  // every write recorded before flush-callback has been applied). The Rust
+  // hub uses this exact value to tag ServerFrame::Snapshot.seq, eliminating
+  // the drift-window race between "which write did the payload include" and
+  // "which seq will the next Bytes broadcast target".
+  return { ok: true, payload, last_seq: entry.last_seq }
 }
 
 function closeTab({ tab_id }) {

--- a/src-tauri/sidecar/test/dispatch.test.ts
+++ b/src-tauri/sidecar/test/dispatch.test.ts
@@ -95,10 +95,11 @@ describe('dispatch — happy path', () => {
     expect(r.ok).toBe(true)
     expect(typeof r.payload).toBe('string')
     expect(r.payload as string).toContain('hello world')
-    // last_seq defaults to 0 when write was called without a seq (this
-    // test's write above does not pass one). See dedicated seq-threading
-    // test below for the non-zero path.
-    expect(r.last_seq).toBe(0)
+    // last_seq is null when writeBytes was called without a seq (this
+    // test's write above does not pass one). The Rust side reads this
+    // as Option::None which subscribe_remote treats as "no writes seen
+    // yet." See the dedicated seq-threading test below for Some(N).
+    expect(r.last_seq).toBeNull()
   })
 
   test('serialize returns last_seq threaded through writeBytes', async () => {

--- a/src-tauri/sidecar/test/dispatch.test.ts
+++ b/src-tauri/sidecar/test/dispatch.test.ts
@@ -95,6 +95,41 @@ describe('dispatch — happy path', () => {
     expect(r.ok).toBe(true)
     expect(typeof r.payload).toBe('string')
     expect(r.payload as string).toContain('hello world')
+    // last_seq defaults to 0 when write was called without a seq (this
+    // test's write above does not pass one). See dedicated seq-threading
+    // test below for the non-zero path.
+    expect(r.last_seq).toBe(0)
+  })
+
+  test('serialize returns last_seq threaded through writeBytes', async () => {
+    await sidecar.dispatch({
+      id: 1,
+      verb: 'open',
+      args: { tab_id: 't1', cols: 80, rows: 24 },
+    })
+    // Three writes with increasing seqs. Sidecar tracks the highest
+    // seq per tab; serialize echoes it back.
+    await sidecar.dispatch({
+      verb: 'write',
+      args: { tab_id: 't1', bytes_b64: b64('one\r\n'), seq: 100 },
+    })
+    await sidecar.dispatch({
+      verb: 'write',
+      args: { tab_id: 't1', bytes_b64: b64('two\r\n'), seq: 101 },
+    })
+    await sidecar.dispatch({
+      verb: 'write',
+      args: { tab_id: 't1', bytes_b64: b64('three\r\n'), seq: 102 },
+    })
+    captured.length = 0
+    await sidecar.dispatch({
+      id: 5,
+      verb: 'serialize',
+      args: { tab_id: 't1', scrollback: 100 },
+    })
+    const r = lastReply()
+    expect(r.ok).toBe(true)
+    expect(r.last_seq).toBe(102)
   })
 
   test('resize replies ok and is reflected on subsequent serialize', async () => {

--- a/src-tauri/src/auth_stub.rs
+++ b/src-tauri/src/auth_stub.rs
@@ -52,6 +52,18 @@ pub struct AuthStub {
 }
 
 impl AuthStub {
+    /// Test-only direct constructor. Skips the config file so integration
+    /// tests can pick a known token + ephemeral bind port. `#[doc(hidden)]`
+    /// keeps it out of the rustdoc surface.
+    #[doc(hidden)]
+    pub fn new_for_tests(token: String, device_name: String, bind_addr: SocketAddr) -> Self {
+        Self {
+            token,
+            device_name,
+            bind_addr,
+        }
+    }
+
     /// Load the config from `<config_dir>/companion-dev.json`, generating
     /// the file with a fresh random token if it does not exist. Returns
     /// the parsed state plus a path suitable for logging.

--- a/src-tauri/src/auth_stub.rs
+++ b/src-tauri/src/auth_stub.rs
@@ -1,0 +1,190 @@
+// Dev-only bearer-token auth for the WSS server.
+//
+// Reads a JSON config from `~/.config/agent-terminal/companion-dev.json` (or
+// the dev-namespaced variant when built with feature = "dev-instance"). On
+// first launch the file is written with a fresh random token so the user
+// never has to hand-generate credentials. The token path is logged loudly
+// at startup so the user can grep it and paste the token into the mobile
+// client's connect screen.
+//
+// Phase 1 only. Phase 2 introduces the QR-code pairing flow and stores
+// per-device tokens in the macOS Keychain; this module goes away.
+//
+// Not TLS. Not integrity-protected on disk. Every note in the log line
+// says "dev only" for a reason.
+
+use constant_time_eq::constant_time_eq;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// Filename inside the config directory. Kept as a constant so the loud
+/// startup log line and the test path can share it.
+const CONFIG_FILENAME: &str = "companion-dev.json";
+
+/// Default bind address for the WSS server: LAN-accessible so a phone on
+/// the same Wi-Fi can reach it. Users can override via the config file if
+/// this port collides with something else on their machine.
+const DEFAULT_BIND_ADDR: &str = "0.0.0.0:47823";
+
+/// Human-facing name reported to the client on successful auth. Users
+/// override via the config file if they want their phone to identify the
+/// desktop as something friendlier.
+const DEFAULT_DEVICE_NAME: &str = "agent-terminal (dev)";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ConfigFile {
+    token: String,
+    device_name: String,
+    bind_addr: String,
+}
+
+/// Loaded, ready-to-use auth state. Held as `Arc<AuthStub>` by the WSS
+/// server; cheap to clone into per-connection tasks.
+#[derive(Debug)]
+pub struct AuthStub {
+    token: String,
+    pub device_name: String,
+    pub bind_addr: SocketAddr,
+}
+
+impl AuthStub {
+    /// Load the config from `<config_dir>/companion-dev.json`, generating
+    /// the file with a fresh random token if it does not exist. Returns
+    /// the parsed state plus a path suitable for logging.
+    pub fn load_or_init(config_dir: &Path) -> io::Result<(Self, PathBuf)> {
+        fs::create_dir_all(config_dir)?;
+        let path = config_dir.join(CONFIG_FILENAME);
+
+        if !path.exists() {
+            let fresh = ConfigFile {
+                token: Uuid::new_v4().to_string(),
+                device_name: DEFAULT_DEVICE_NAME.to_string(),
+                bind_addr: DEFAULT_BIND_ADDR.to_string(),
+            };
+            let body = serde_json::to_string_pretty(&fresh)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            fs::write(&path, body)?;
+        }
+
+        let raw = fs::read_to_string(&path)?;
+        let parsed: ConfigFile = serde_json::from_str(&raw)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let bind_addr: SocketAddr = parsed.bind_addr.parse().map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("bind_addr '{}' is not a valid SocketAddr: {e}", parsed.bind_addr),
+            )
+        })?;
+
+        Ok((
+            Self {
+                token: parsed.token,
+                device_name: parsed.device_name,
+                bind_addr,
+            },
+            path,
+        ))
+    }
+
+    /// Constant-time comparison of `supplied` against the configured
+    /// token. Timing attacks on a dev token are unrealistic, but the
+    /// primitive is cheap and the WSS server calls it once per
+    /// connection — no reason not to use it.
+    pub fn check(&self, supplied: &str) -> bool {
+        constant_time_eq(self.token.as_bytes(), supplied.as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir() -> tempfile::TempDir {
+        tempfile::TempDir::new().expect("mkdtemp")
+    }
+
+    #[test]
+    fn load_or_init_creates_config_when_missing() {
+        let dir = tmp_dir();
+        let (auth, path) = AuthStub::load_or_init(dir.path()).expect("init");
+        assert!(path.exists(), "config file must be created");
+        assert!(!auth.token.is_empty(), "token must be non-empty");
+        assert_eq!(auth.device_name, DEFAULT_DEVICE_NAME);
+        assert_eq!(
+            auth.bind_addr.to_string(),
+            DEFAULT_BIND_ADDR,
+            "default bind is LAN-accessible dev port 47823"
+        );
+    }
+
+    #[test]
+    fn load_or_init_preserves_existing_config() {
+        let dir = tmp_dir();
+        // Write a config with a known token so we can verify round-trip.
+        let path = dir.path().join(CONFIG_FILENAME);
+        fs::write(
+            &path,
+            r#"{
+                "token": "known-token-value",
+                "device_name": "Alice's laptop",
+                "bind_addr": "127.0.0.1:12345"
+            }"#,
+        )
+        .unwrap();
+
+        let (auth, _) = AuthStub::load_or_init(dir.path()).expect("load");
+        assert_eq!(auth.device_name, "Alice's laptop");
+        assert_eq!(auth.bind_addr.to_string(), "127.0.0.1:12345");
+        assert!(auth.check("known-token-value"));
+    }
+
+    #[test]
+    fn check_rejects_wrong_token() {
+        let dir = tmp_dir();
+        let (auth, _) = AuthStub::load_or_init(dir.path()).expect("init");
+        assert!(!auth.check(""));
+        assert!(!auth.check("obviously-wrong"));
+        // Rejects a token of the same length as the real one (guards
+        // against a length-only compare regression).
+        let same_length_wrong = "0".repeat(auth.token.len());
+        assert!(!auth.check(&same_length_wrong));
+        // Positive path — pass the real token, expect true.
+        let real = auth.token.clone();
+        assert!(auth.check(&real));
+    }
+
+    #[test]
+    fn generated_tokens_are_unique_across_inits() {
+        let dir1 = tmp_dir();
+        let dir2 = tmp_dir();
+        let (a, _) = AuthStub::load_or_init(dir1.path()).expect("a");
+        let (b, _) = AuthStub::load_or_init(dir2.path()).expect("b");
+        assert_ne!(a.token, b.token, "each fresh init must roll a new token");
+    }
+
+    #[test]
+    fn malformed_config_returns_error() {
+        let dir = tmp_dir();
+        let path = dir.path().join(CONFIG_FILENAME);
+        fs::write(&path, "{ not json").unwrap();
+        let err = AuthStub::load_or_init(dir.path()).expect_err("must fail");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn malformed_bind_addr_returns_error() {
+        let dir = tmp_dir();
+        let path = dir.path().join(CONFIG_FILENAME);
+        fs::write(
+            &path,
+            r#"{"token":"x","device_name":"y","bind_addr":"nope"}"#,
+        )
+        .unwrap();
+        let err = AuthStub::load_or_init(dir.path()).expect_err("must fail");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 use crate::mod_engine::ModEngine;
+use crate::project_registry::ProjectRegistry;
 use crate::pty_manager::{spawn_pty, try_reattach, PtyDataPayload, PtyMap, ReattachResult};
 use crate::stream_hub::StreamHub;
 use portable_pty::PtySize;
@@ -17,6 +18,7 @@ pub async fn open_tab(
     pty_map: State<'_, PtyMap>,
     mod_engine: State<'_, ModEngine>,
     hub: State<'_, Arc<StreamHub>>,
+    registry: State<'_, Arc<ProjectRegistry>>,
     tab_id: String,
     cwd: Option<String>,
     shell: Option<String>,
@@ -67,11 +69,15 @@ pub async fn open_tab(
         mod_engine.handle(),
         mod_engine.cwd_table(),
         Arc::clone(&hub),
+        Some(Arc::clone(&registry)),
         tab_id,
         cwd,
         shell,
         on_data,
     )?;
+    // Notify any WSS subscribers that the tab inventory changed so
+    // they push a fresh Projects frame to their mobile clients.
+    registry.notify_change();
     Ok(true)
 }
 
@@ -126,6 +132,7 @@ pub async fn resize_pty(
 pub async fn close_tab(
     pty_map: State<'_, PtyMap>,
     hub: State<'_, Arc<StreamHub>>,
+    registry: State<'_, Arc<ProjectRegistry>>,
     tab_id: String,
 ) -> Result<(), String> {
     // The reader thread reads `closing` on EOF to decide between emitting
@@ -146,6 +153,8 @@ pub async fn close_tab(
     // Done after the PtyMap mutation so the reader thread's `closing`
     // check sees the same ordering it always did. Fire-and-forget.
     hub.close_tab(&tab_id);
+    // Notify WSS subscribers so mobile clients see the tab disappear.
+    registry.notify_change();
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,8 +7,16 @@ pub mod hook_server;
 // `pub` so integration tests can read NAMESPACE/HOOK_PORT.
 pub mod identity;
 mod mod_engine;
+// Narrow re-export for integration tests that need to build a
+// ModEngineHandle::noop() or read the CwdTable type. Keeps the rest of
+// the mod_engine tree private (clippy has opinions on those internal
+// mod-specific types).
+#[doc(hidden)]
+pub use mod_engine::{CwdTable, ModEngineHandle};
 mod notifications;
-mod pty_manager;
+// pub so integration tests can construct a bare PtyMap without a full
+// PtyHandle harness (tests only need the map's shape for ServerState).
+pub mod pty_manager;
 mod shell_integration;
 // pub so integration tests can drive a SidecarClient instance directly
 // without going through the full Tauri startup path.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,9 @@ pub mod auth_stub;
 // pub for direct test coverage. The WSS server (next commit) constructs
 // one at startup and hands it to per-connection tasks.
 pub mod project_registry;
+// pub so integration tests can drive the server directly (spin up on
+// 127.0.0.1:0 with an in-process client).
+pub mod wss_server;
 
 use hook_config::ensure_hooks_installed;
 use hook_server::start_hook_server;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,9 @@ pub mod stream_hub;
 // root so `cargo xtask regen-protocol` (which shells out to typeshare)
 // can find the #[typeshare]-annotated types by scanning src-tauri/src/.
 pub mod protocol;
+// pub for direct test coverage (config file round-trip, constant-time
+// compare, error paths).
+pub mod auth_stub;
 
 use hook_config::ensure_hooks_installed;
 use hook_server::start_hook_server;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,9 @@ pub mod protocol;
 // pub for direct test coverage (config file round-trip, constant-time
 // compare, error paths).
 pub mod auth_stub;
+// pub for direct test coverage. The WSS server (next commit) constructs
+// one at startup and hands it to per-connection tasks.
+pub mod project_registry;
 
 use hook_config::ensure_hooks_installed;
 use hook_server::start_hook_server;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,6 +53,8 @@ use tauri::Emitter;
 use tauri::menu::{MenuBuilder, SubmenuBuilder};
 #[cfg(all(target_os = "macos", not(feature = "dev-instance")))]
 use tauri::menu::MenuItemBuilder;
+use auth_stub::AuthStub;
+use project_registry::ProjectRegistry;
 use pty_manager::PtyMap;
 use sidecar_client::SidecarClient;
 use std::collections::HashMap;
@@ -60,6 +62,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use stream_hub::StreamHub;
 use tokio::process::Command;
+use wss_server::ServerState;
 
 /// Locate the runtime binary + sidecar entry script. Dev launches read from
 /// the source tree via CARGO_MANIFEST_DIR; production bundling is a separate
@@ -145,8 +148,12 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init());
 
+    // Cheap Arc clones the setup closure needs before the outer scope
+    // hands ownership to `.manage(pty_map)` at the end of the builder.
+    let pty_map_for_setup = Arc::clone(&pty_map);
+
     builder
-        .setup(|app| {
+        .setup(move |app| {
             // Custom macOS menu — omits the default items whose shortcuts
             // conflict with our keyboard handlers:
             //   View → Actual Size / Zoom In / Zoom Out  (⌘0 / ⌘+ / ⌘-)
@@ -210,6 +217,11 @@ pub fn run() {
             start_hook_server(hook_tx);
 
             let mod_engine = engine_builder.build(app.handle().clone());
+            // Take handles the WSS server needs BEFORE we hand mod_engine
+            // over to Tauri's managed-state store — after `app.manage`
+            // moves it, direct access goes away.
+            let mod_engine_handle = mod_engine.handle();
+            let cwd_table = mod_engine.cwd_table();
             app.manage(mod_engine);
 
             // Headless-xterm sidecar. Spawned as best-effort so a missing
@@ -227,7 +239,59 @@ pub fn run() {
             // is the optional bit. State<'_, Arc<StreamHub>> is the handle
             // Tauri commands grab.
             let hub = StreamHub::new(sidecar);
+            let hub_for_wss = Arc::clone(&hub);
             app.manage(hub);
+
+            // Project registry: read view over PtyMap + CwdTable for the
+            // WSS server's Projects push. Fires notify_change from
+            // open_tab / close_tab / respawn_in_place so mobile clients
+            // stay live-synced with the desktop's tab inventory.
+            let pty_map_for_registry = Arc::clone(&pty_map_for_setup);
+            let registry = Arc::new(ProjectRegistry::new(
+                Arc::clone(&pty_map_for_registry),
+                cwd_table,
+            ));
+            let registry_for_wss = Arc::clone(&registry);
+            app.manage(registry);
+
+            // WSS server. AuthStub reads (or auto-generates) the dev
+            // config file — its bind_addr comes from there. Spawn as a
+            // tokio task; bind failure logs but doesn't block startup so
+            // a broken WSS never keeps the desktop from launching.
+            let config_dir = dirs::home_dir()
+                .map(|h| h.join(".config").join(identity::NAMESPACE));
+            if let Some(dir) = config_dir {
+                match AuthStub::load_or_init(&dir) {
+                    Ok((auth, path)) => {
+                        let auth = Arc::new(auth);
+                        eprintln!(
+                            "[wss] dev config: {} (token inside — copy into companion client)",
+                            path.display()
+                        );
+                        let server_state = Arc::new(ServerState {
+                            hub: hub_for_wss,
+                            auth: Arc::clone(&auth),
+                            registry: registry_for_wss,
+                            pty_map: Arc::clone(&pty_map_for_registry),
+                            mod_engine_handle,
+                        });
+                        let bind_addr = auth.bind_addr;
+                        app.manage(auth);
+                        tauri::async_runtime::spawn(async move {
+                            if let Err(e) =
+                                wss_server::run(bind_addr, server_state).await
+                            {
+                                eprintln!("[wss] server crashed: {e}");
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        eprintln!("[wss] disabled: dev config load failed: {e}");
+                    }
+                }
+            } else {
+                eprintln!("[wss] disabled: no home directory");
+            }
 
             // Window focus → suppression signal only.
             // (The previous focus-event-based click heuristic is gone — it

--- a/src-tauri/src/mod_engine/engine.rs
+++ b/src-tauri/src/mod_engine/engine.rs
@@ -53,6 +53,18 @@ pub struct ModEngineHandle {
 }
 
 impl ModEngineHandle {
+    /// Test-only constructor. Every method drops its message on the
+    /// floor (the receivers are dropped immediately) so callers can
+    /// exercise code paths that need a `ModEngineHandle` field without
+    /// standing up a full mod engine. Not for production code —
+    /// `#[doc(hidden)]` keeps it out of the rustdoc surface.
+    #[doc(hidden)]
+    pub fn noop() -> Self {
+        let (tx, _rx) = mpsc::channel(1);
+        let (lifecycle_tx, _lifecycle_rx) = mpsc::unbounded_channel();
+        Self { tx, lifecycle_tx }
+    }
+
     pub fn on_tab_open(&self, tab_id: &str, shell_pid: u32) {
         let _ = self.lifecycle_tx.send(ModMessage::Open { tab_id: tab_id.to_string(), shell_pid });
     }

--- a/src-tauri/src/project_registry.rs
+++ b/src-tauri/src/project_registry.rs
@@ -1,0 +1,213 @@
+// Read view over the desktop's tab inventory, packaged as
+// `ServerFrame::Projects.data`.
+//
+// The WSS server pushes a full Projects frame to each client on auth-ok
+// and again on every notify_change() fire. Change events come from the
+// existing tab-lifecycle sites (`commands::open_tab`, `commands::close_
+// tab`, `pty_manager::respawn_in_place`) once they're wired up in a
+// later commit.
+//
+// Grouping: tab ids follow the convention `<project>:<suffix>` (used
+// throughout the desktop UI). Ids without a colon land under a synthetic
+// "Ungrouped" project so mobile clients always see everything.
+//
+// Metadata (agent name, git branch, ports) stays intentionally sparse for
+// Phase 1 — the wire types carry the fields but Phase 3's status-pill
+// work populates them. cwd is available now via mod_engine's CwdTable.
+
+use crate::mod_engine::CwdTable;
+use crate::protocol::{ProjectSummary, TabSummary};
+use crate::pty_manager::PtyMap;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+/// Bundle of read handles + a change-notification watch. The registry
+/// itself owns nothing PTY-side; every call goes back to the source of
+/// truth (`PtyMap`, `CwdTable`).
+pub struct ProjectRegistry {
+    pty_map: PtyMap,
+    cwd_table: CwdTable,
+    change_tx: watch::Sender<u64>,
+    change_rx: watch::Receiver<u64>,
+}
+
+impl ProjectRegistry {
+    pub fn new(pty_map: PtyMap, cwd_table: CwdTable) -> Self {
+        // Initial "version" of 0. Every notify_change bumps it so the
+        // watch fires even if consumers get spurious wakeups.
+        let (tx, rx) = watch::channel(0u64);
+        Self {
+            pty_map,
+            cwd_table,
+            change_tx: tx,
+            change_rx: rx,
+        }
+    }
+
+    /// Build the current project + tab tree. Fresh Vec on every call —
+    /// the caller sends it as `ServerFrame::Projects { data }`.
+    pub fn projects(&self) -> Vec<ProjectSummary> {
+        let cwds = self
+            .cwd_table
+            .lock()
+            .expect("cwd_table lock poisoned")
+            .clone();
+        let map = self.pty_map.lock().expect("pty_map lock poisoned");
+
+        // Group tabs by project prefix. Order matters for the mobile UI —
+        // preserve insertion order (BTreeMap gives alphabetical which is
+        // arguably better than the HashMap random order the PtyMap gives).
+        let mut groups: std::collections::BTreeMap<String, Vec<TabSummary>> =
+            std::collections::BTreeMap::new();
+
+        for tab_id in map.keys() {
+            let (project_id, label) = split_tab_id(tab_id);
+            let cwd = cwds.get(tab_id).cloned();
+            groups.entry(project_id).or_default().push(TabSummary {
+                tab_id: tab_id.clone(),
+                label,
+                cwd,
+                // Populated in Phase 3 when the mod engine grows a
+                // per-tab agent-summary accessor.
+                agent: None,
+            });
+        }
+
+        groups
+            .into_iter()
+            .map(|(project_id, tabs)| ProjectSummary {
+                name: project_id.clone(),
+                project_id,
+                tabs,
+            })
+            .collect()
+    }
+
+    /// Signal that the tab inventory has changed. Wakes every watcher
+    /// bound via `subscribe_changes`.
+    pub fn notify_change(&self) {
+        // send_modify updates the value and fires the watch even if the
+        // new value equals the old — we increment monotonically so
+        // consumers see distinct versions.
+        self.change_tx.send_modify(|v| *v = v.saturating_add(1));
+    }
+
+    /// Return a fresh watch::Receiver. Each WSS connection holds one and
+    /// pushes a Projects frame whenever it fires.
+    pub fn subscribe_changes(&self) -> watch::Receiver<u64> {
+        self.change_rx.clone()
+    }
+}
+
+/// Split a tab id into `(project_id, label)`. `foo:bar` becomes
+/// `("foo", "bar")`; a plain `foo` becomes `("Ungrouped", "foo")`. The
+/// "Ungrouped" fallback matches the master plan's guidance for loose tabs
+/// that aren't associated with a workspace.
+fn split_tab_id(tab_id: &str) -> (String, String) {
+    match tab_id.split_once(':') {
+        Some((project, suffix)) => (project.to_string(), suffix.to_string()),
+        None => ("Ungrouped".to_string(), tab_id.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty_manager::PtyHandle;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn empty_pty_map() -> PtyMap {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    fn empty_cwd_table() -> CwdTable {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    /// Insert a synthetic tab id into the PtyMap. Uses a null PtyHandle
+    /// via `unsafe {}` transmute? No — simpler: skip actually
+    /// constructing PtyHandle (it holds trait objects that need a real
+    /// PTY). Test via ProjectRegistry::projects reading from a map
+    /// populated *around* PtyHandle: we assert only on keys/CwdTable.
+    ///
+    /// The `pty_map.lock().keys()` iteration in `projects()` is the only
+    /// thing under test — populate a real map with real handles when
+    /// pty_manager gains a mockable constructor, or cover via the
+    /// wss_integration test at the top of the stack.
+
+    #[test]
+    fn empty_map_yields_empty_projects() {
+        let reg = ProjectRegistry::new(empty_pty_map(), empty_cwd_table());
+        assert!(reg.projects().is_empty());
+    }
+
+    #[test]
+    fn notify_change_bumps_watch_version() {
+        let reg = ProjectRegistry::new(empty_pty_map(), empty_cwd_table());
+        let mut rx = reg.subscribe_changes();
+        // Baseline value before any notification.
+        assert_eq!(*rx.borrow(), 0);
+        reg.notify_change();
+        // borrow_and_update marks the current value as seen so the next
+        // `changed().await` waits for a real update.
+        assert_eq!(*rx.borrow_and_update(), 1);
+        reg.notify_change();
+        reg.notify_change();
+        assert_eq!(*rx.borrow(), 3);
+    }
+
+    #[test]
+    fn multiple_subscribers_all_see_changes() {
+        let reg = ProjectRegistry::new(empty_pty_map(), empty_cwd_table());
+        let a = reg.subscribe_changes();
+        let b = reg.subscribe_changes();
+        reg.notify_change();
+        assert_eq!(*a.borrow(), 1);
+        assert_eq!(*b.borrow(), 1);
+    }
+
+    // ---- split_tab_id ----
+
+    #[test]
+    fn split_tab_id_colon_form() {
+        assert_eq!(
+            split_tab_id("claude-ui:dev"),
+            ("claude-ui".to_string(), "dev".to_string())
+        );
+    }
+
+    #[test]
+    fn split_tab_id_no_colon_lands_in_ungrouped() {
+        assert_eq!(
+            split_tab_id("loose-tab"),
+            ("Ungrouped".to_string(), "loose-tab".to_string())
+        );
+    }
+
+    #[test]
+    fn split_tab_id_empty_project_side() {
+        // ":foo" splits with an empty project. Not a shape we'd expect
+        // in practice but the parser handles it gracefully.
+        assert_eq!(
+            split_tab_id(":foo"),
+            ("".to_string(), "foo".to_string())
+        );
+    }
+
+    // ---- projects() with a populated map ----
+    //
+    // PtyHandle can't be trivially constructed in a unit test (it holds
+    // portable-pty trait objects that need a real openpty). The
+    // `projects()` grouping / cwd merge / TabSummary shape are covered
+    // end-to-end by the WSS integration test in a later commit. Here we
+    // pin the pure-function behaviour (`split_tab_id`) + the change
+    // notification mechanism directly.
+
+    // Suppress the unused imports lint for symbols that are only present
+    // for the not-yet-wired PtyHandle tests.
+    #[allow(dead_code)]
+    fn _pty_handle_stub_note() -> PtyHandle {
+        unimplemented!("PtyHandle needs a real PTY — covered in integration tests")
+    }
+}

--- a/src-tauri/src/project_registry.rs
+++ b/src-tauri/src/project_registry.rs
@@ -18,7 +18,6 @@
 use crate::mod_engine::CwdTable;
 use crate::protocol::{ProjectSummary, TabSummary};
 use crate::pty_manager::PtyMap;
-use std::sync::Arc;
 use tokio::sync::watch;
 
 /// Bundle of read handles + a change-notification watch. The registry
@@ -115,7 +114,7 @@ mod tests {
     use super::*;
     use crate::pty_manager::PtyHandle;
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     fn empty_pty_map() -> PtyMap {
         Arc::new(Mutex::new(HashMap::new()))

--- a/src-tauri/src/protocol.rs
+++ b/src-tauri/src/protocol.rs
@@ -197,7 +197,7 @@ pub struct TabStateSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::{json, Value};
+    use serde_json::json;
 
     /// Every ClientFrame variant round-trips through JSON unchanged.
     /// Catches derive-macro mistakes (forgotten Serialize/Deserialize,

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -1,4 +1,5 @@
 use crate::mod_engine::{CwdTable, ModEngineHandle};
+use crate::project_registry::ProjectRegistry;
 use crate::stream_hub::StreamHub;
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use serde::Serialize;
@@ -110,6 +111,11 @@ struct ReaderCtx {
     /// channel above is one of its subscribers (still owned here for the
     /// reconnect-swap mechanism try_reattach uses).
     hub: Arc<StreamHub>,
+    /// Fired on respawn_in_place so paired WSS clients push a fresh
+    /// Projects frame reflecting the new PtyHandle's state. Optional so
+    /// spawn_pty callers that don't yet have a registry (existing tests,
+    /// pre-integration paths) can still work.
+    registry: Option<Arc<ProjectRegistry>>,
 }
 
 /// Spawns the reader thread that forwards PTY bytes to the frontend.
@@ -315,6 +321,7 @@ fn respawn_in_place(ctx: &ReaderCtx) -> Result<RespawnOutcome, String> {
             pty_map: ctx.pty_map.clone(),
             cwd_table: ctx.cwd_table.clone(),
             hub: Arc::clone(&ctx.hub),
+            registry: ctx.registry.clone(),
         },
         new_reader,
     );
@@ -326,6 +333,13 @@ fn respawn_in_place(ctx: &ReaderCtx) -> Result<RespawnOutcome, String> {
             cwd,
         },
     ).ok();
+
+    // Notify WSS clients so mobile UI's TabState / project tree
+    // reflects the new PtyHandle. No-op when the registry hasn't been
+    // wired (tests, legacy callers).
+    if let Some(registry) = ctx.registry.as_ref() {
+        registry.notify_change();
+    }
 
     Ok(RespawnOutcome::Respawned)
 }
@@ -394,6 +408,7 @@ pub fn try_reattach(
             pty_map: pty_map.clone(),
             cwd_table,
             hub,
+            registry: None,
         },
         reader,
     );
@@ -476,6 +491,7 @@ pub fn spawn_pty(
     mod_handle: ModEngineHandle,
     cwd_table: CwdTable,
     hub: Arc<StreamHub>,
+    registry: Option<Arc<ProjectRegistry>>,
     tab_id: String,
     cwd: Option<String>,
     shell: Option<String>,
@@ -546,6 +562,7 @@ pub fn spawn_pty(
             pty_map: pty_map.clone(),
             cwd_table,
             hub,
+            registry,
         },
         reader,
     );

--- a/src-tauri/src/sidecar_client.rs
+++ b/src-tauri/src/sidecar_client.rs
@@ -293,11 +293,18 @@ impl SidecarClient {
     ///
     /// - `payload` is the xterm-serialize output (escape sequences ready to
     ///   replay into a fresh xterm Terminal).
-    /// - `last_seq` is the highest seq the sidecar had fully parsed at the
-    ///   moment the payload was captured. Callers use this to tag
-    ///   `ServerFrame::Snapshot.seq` so subsequent broadcast fan-out can
-    ///   deduplicate with `if seq <= last_acked { skip }`.
-    pub async fn serialize(&self, tab_id: &str, scrollback: u32) -> Result<(String, u64)> {
+    /// - `last_seq` is `Some(N)` where N is the highest seq the sidecar had
+    ///   fully parsed at the moment the payload was captured, or `None`
+    ///   when no writes have been observed yet (freshly-opened tab). The
+    ///   `None` case is distinct from `Some(0)`: seq 0 is a legitimate
+    ///   first-broadcast value, and subscribe_remote uses this distinction
+    ///   to decide whether to send the first broadcast (`None` → always
+    ///   send it; `Some(N)` → dedupe with `if seq <= N { skip }`).
+    pub async fn serialize(
+        &self,
+        tab_id: &str,
+        scrollback: u32,
+    ) -> Result<(String, Option<u64>)> {
         let reply = self
             .call(
                 "serialize",
@@ -309,11 +316,7 @@ impl SidecarClient {
             .and_then(Value::as_str)
             .map(String::from)
             .ok_or_else(|| SidecarError::InvalidReply("missing payload field".to_string()))?;
-        // last_seq is 0 for a freshly-opened tab that hasn't received any
-        // writes yet. Missing from older sidecar builds also reads as 0 —
-        // safe default; the drift race we're closing here has no bearing
-        // on an empty terminal.
-        let last_seq = reply.get("last_seq").and_then(Value::as_u64).unwrap_or(0);
+        let last_seq = reply.get("last_seq").and_then(Value::as_u64);
         Ok((payload, last_seq))
     }
 
@@ -470,8 +473,10 @@ mod tests {
             "serialize payload did not contain written text. payload: {payload}"
         );
         // Threading check: the sidecar echoes back the highest seq it saw
-        // via `writeBytes.seq`. Our write above tagged seq 42.
-        assert_eq!(last_seq, 42, "last_seq must round-trip through the sidecar");
+        // via `writeBytes.seq`. Our write above tagged seq 42, so
+        // last_seq must round-trip as Some(42). None would indicate the
+        // sidecar treated the write as seqless (path regression).
+        assert_eq!(last_seq, Some(42));
 
         client.close("tab-1").await.expect("close");
     }

--- a/src-tauri/src/sidecar_client.rs
+++ b/src-tauri/src/sidecar_client.rs
@@ -245,14 +245,20 @@ impl SidecarClient {
     /// Push raw PTY bytes to the sidecar's parser for `tab_id`. Returns
     /// immediately — there is no reply. If the sidecar has died, the bytes
     /// silently drop; the caller's hot path stays branch-free.
-    pub fn write_bytes(&self, tab_id: &str, bytes: &[u8]) {
+    ///
+    /// `seq` is the sequence number the StreamHub assigned to this chunk.
+    /// The sidecar records the highest seq it has seen per tab and returns
+    /// it from `serialize`, so subscribe_remote can tag its snapshot with
+    /// the exact seq whose bytes are reflected in the payload (no drift
+    /// window between "state in snapshot" and "next Bytes broadcast seq").
+    pub fn write_bytes(&self, tab_id: &str, bytes: &[u8], seq: u64) {
         if self.is_dead() {
             return;
         }
         let bytes_b64 = B64.encode(bytes);
         let line = json!({
             "verb": "write",
-            "args": { "tab_id": tab_id, "bytes_b64": bytes_b64 }
+            "args": { "tab_id": tab_id, "bytes_b64": bytes_b64, "seq": seq }
         })
         .to_string();
         let _ = self.inner.writer_tx.send(line);
@@ -281,21 +287,34 @@ impl SidecarClient {
         let _ = self.inner.writer_tx.send(line);
     }
 
-    /// Ask the sidecar to serialize tab_id's buffer. Returns the xterm-
-    /// serialize payload (a string containing escape sequences ready to
-    /// replay into a fresh xterm Terminal).
-    pub async fn serialize(&self, tab_id: &str, scrollback: u32) -> Result<String> {
+    /// Ask the sidecar to serialize tab_id's buffer.
+    ///
+    /// Returns `(payload, last_seq)`:
+    ///
+    /// - `payload` is the xterm-serialize output (escape sequences ready to
+    ///   replay into a fresh xterm Terminal).
+    /// - `last_seq` is the highest seq the sidecar had fully parsed at the
+    ///   moment the payload was captured. Callers use this to tag
+    ///   `ServerFrame::Snapshot.seq` so subsequent broadcast fan-out can
+    ///   deduplicate with `if seq <= last_acked { skip }`.
+    pub async fn serialize(&self, tab_id: &str, scrollback: u32) -> Result<(String, u64)> {
         let reply = self
             .call(
                 "serialize",
                 json!({ "tab_id": tab_id, "scrollback": scrollback }),
             )
             .await?;
-        reply
+        let payload = reply
             .get("payload")
             .and_then(Value::as_str)
             .map(String::from)
-            .ok_or_else(|| SidecarError::InvalidReply("missing payload field".to_string()))
+            .ok_or_else(|| SidecarError::InvalidReply("missing payload field".to_string()))?;
+        // last_seq is 0 for a freshly-opened tab that hasn't received any
+        // writes yet. Missing from older sidecar builds also reads as 0 —
+        // safe default; the drift race we're closing here has no bearing
+        // on an empty terminal.
+        let last_seq = reply.get("last_seq").and_then(Value::as_u64).unwrap_or(0);
+        Ok((payload, last_seq))
     }
 
     pub async fn close(&self, tab_id: &str) -> Result<()> {
@@ -385,8 +404,8 @@ mod tests {
         // Spam writes; the call returns immediately even if the sidecar is
         // slow to process. Mostly a sanity check that the API does not
         // accidentally become blocking.
-        for _ in 0..1000 {
-            client.write_bytes("t1", b"hello");
+        for i in 0..1000 {
+            client.write_bytes("t1", b"hello", i);
         }
         // The echo sidecar emits no reply for `write`. Sleep briefly to
         // confirm no spurious reply arrives that would corrupt later state.
@@ -436,9 +455,9 @@ mod tests {
         let client = SidecarClient::spawn(cmd).await.expect("spawn");
 
         client.open("tab-1", 80, 24).await.expect("open");
-        client.write_bytes("tab-1", b"hello world\r\n");
+        client.write_bytes("tab-1", b"hello world\r\n", 42);
 
-        let payload = timeout(
+        let (payload, last_seq) = timeout(
             Duration::from_secs(10),
             client.serialize("tab-1", 1000),
         )
@@ -450,6 +469,9 @@ mod tests {
             payload.contains("hello world"),
             "serialize payload did not contain written text. payload: {payload}"
         );
+        // Threading check: the sidecar echoes back the highest seq it saw
+        // via `writeBytes.seq`. Our write above tagged seq 42.
+        assert_eq!(last_seq, 42, "last_seq must round-trip through the sidecar");
 
         client.close("tab-1").await.expect("close");
     }

--- a/src-tauri/src/stream_hub.rs
+++ b/src-tauri/src/stream_hub.rs
@@ -248,8 +248,12 @@ impl StreamHub {
                 .lock()
                 .expect("ring lock poisoned")
                 .push(seq, raw_bytes.to_vec());
+            // Threaded to the sidecar so `serialize` can return the exact
+            // seq whose bytes are in the payload — closes the drift window
+            // between "which write was in the snapshot" and "next Bytes
+            // broadcast seq" that a remote subscribe would otherwise hit.
             if let Some(sidecar) = &self.sidecar {
-                sidecar.write_bytes(tab_id, raw_bytes);
+                sidecar.write_bytes(tab_id, raw_bytes, seq);
             }
         }
     }

--- a/src-tauri/src/stream_hub.rs
+++ b/src-tauri/src/stream_hub.rs
@@ -336,14 +336,17 @@ impl StreamHub {
     /// snapshot's `last_seq`, catching up bytes that landed between the
     /// serialize call and the subscribers-lock acquisition.
     ///
-    /// Returns the SubscriberId the caller passes back to `unsubscribe`.
-    /// Async because sidecar.serialize awaits a reply.
+    /// Returns `Some(SubscriberId)` on success. Returns `None` when the
+    /// receiver is already dropped and initial delivery fails — no
+    /// subscriber is registered in that case (would otherwise sit dead
+    /// in the list until a broadcast triggers reap). Async because
+    /// sidecar.serialize awaits a reply.
     pub async fn subscribe_remote(
         &self,
         tab_id: &str,
         outbox: mpsc::UnboundedSender<ServerFrame>,
         scrollback: u32,
-    ) -> SubscriberId {
+    ) -> Option<SubscriberId> {
         let state = self
             .tabs
             .entry(tab_id.to_string())
@@ -370,7 +373,7 @@ impl StreamHub {
         outbox: mpsc::UnboundedSender<ServerFrame>,
         last_seq: u64,
         scrollback: u32,
-    ) -> SubscriberId {
+    ) -> Option<SubscriberId> {
         let state = self
             .tabs
             .entry(tab_id.to_string())
@@ -388,17 +391,35 @@ impl StreamHub {
             let mut subs = state.subscribers.lock().expect("subscribers lock poisoned");
             let ring = state.ring.lock().expect("ring lock poisoned");
             let mut highest_delivered = last_seq;
+            // Track outbox health across every ring-replay send. If the
+            // receiver dropped mid-delivery, don't register a dead
+            // subscriber that would sit in the list until a later
+            // broadcast triggers the reap.
+            let mut delivery_ok = true;
             for (seq, bytes) in ring.entries.iter() {
                 if *seq > last_seq {
-                    let _ = outbox.send(ServerFrame::Bytes {
-                        tab_id: tab_id.to_string(),
-                        seq: *seq,
-                        data: B64.encode(bytes),
-                    });
+                    if outbox
+                        .send(ServerFrame::Bytes {
+                            tab_id: tab_id.to_string(),
+                            seq: *seq,
+                            data: B64.encode(bytes),
+                        })
+                        .is_err()
+                    {
+                        delivery_ok = false;
+                        break;
+                    }
                     highest_delivered = *seq;
                 }
             }
             drop(ring);
+            if !delivery_ok {
+                eprintln!(
+                    "[stream_hub] resume_remote({tab_id}): outbox closed \
+                     mid-replay; skipping subscriber registration"
+                );
+                return None;
+            }
             let id = SubscriberId(state.next_sub_id.fetch_add(1, Ordering::Relaxed));
             subs.push((
                 id,
@@ -407,7 +428,7 @@ impl StreamHub {
                     outbox,
                 },
             ));
-            id
+            Some(id)
         } else {
             let (payload, sidecar_seq) = self.fetch_snapshot(tab_id, scrollback).await;
             self.attach_remote_and_catch_up(&state, tab_id, outbox, payload, sidecar_seq)
@@ -426,18 +447,27 @@ impl StreamHub {
         outbox: mpsc::UnboundedSender<ServerFrame>,
         payload: String,
         sidecar_seq: Option<u64>,
-    ) -> SubscriberId {
+    ) -> Option<SubscriberId> {
         let mut subs = state.subscribers.lock().expect("subscribers lock poisoned");
         let ring = state.ring.lock().expect("ring lock poisoned");
 
         // Snapshot's seq on the wire: sidecar_seq if known, else 0 with an
         // empty payload. Client stores this for future resume requests.
         let snapshot_seq_on_wire = sidecar_seq.unwrap_or(0);
-        let _ = outbox.send(ServerFrame::Snapshot {
-            tab_id: tab_id.to_string(),
-            seq: snapshot_seq_on_wire,
-            payload,
-        });
+        if outbox
+            .send(ServerFrame::Snapshot {
+                tab_id: tab_id.to_string(),
+                seq: snapshot_seq_on_wire,
+                payload,
+            })
+            .is_err()
+        {
+            eprintln!(
+                "[stream_hub] subscribe_remote({tab_id}): outbox closed \
+                 before Snapshot delivery; skipping subscriber registration"
+            );
+            return None;
+        }
 
         // Replay ring entries newer than the snapshot's coverage. Closes
         // the race where a broadcast landed between subscribe's serialize
@@ -449,11 +479,20 @@ impl StreamHub {
                 None => true,
             };
             if should_replay {
-                let _ = outbox.send(ServerFrame::Bytes {
-                    tab_id: tab_id.to_string(),
-                    seq: *seq,
-                    data: B64.encode(bytes),
-                });
+                if outbox
+                    .send(ServerFrame::Bytes {
+                        tab_id: tab_id.to_string(),
+                        seq: *seq,
+                        data: B64.encode(bytes),
+                    })
+                    .is_err()
+                {
+                    eprintln!(
+                        "[stream_hub] subscribe_remote({tab_id}): outbox closed \
+                         mid-replay; skipping subscriber registration"
+                    );
+                    return None;
+                }
                 highest_delivered = Some(*seq);
             }
         }
@@ -472,7 +511,7 @@ impl StreamHub {
                 outbox,
             },
         ));
-        id
+        Some(id)
     }
 
     /// Ask the sidecar for a serialize snapshot; degrade to empty payload
@@ -932,6 +971,37 @@ mod tests {
                 .any(|f| matches!(f, ServerFrame::Snapshot { .. })),
             "gap-too-wide resume must send a fresh Snapshot"
         );
+    }
+
+    #[tokio::test]
+    async fn subscribe_remote_returns_none_when_outbox_already_closed() {
+        // Regression pin: if the outbox receiver is already dropped
+        // by the time subscribe_remote runs, the function must NOT
+        // register a dead subscriber (which would sit in the list
+        // until a future broadcast triggers the reap). It returns
+        // None and subscriber_count stays at zero.
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        let (tx, rx) = mpsc::unbounded_channel::<ServerFrame>();
+        drop(rx);
+        let id = hub.subscribe_remote("t1", tx, 500).await;
+        assert!(id.is_none(), "closed outbox must not produce a SubscriberId");
+        assert_eq!(hub.subscriber_count("t1"), Some(0));
+    }
+
+    #[tokio::test]
+    async fn resume_remote_returns_none_when_outbox_closed_mid_replay() {
+        // Same regression pin for the resume-within-ring fast path.
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        for i in 0..3u8 {
+            hub.broadcast("t1", &[i], "x");
+        }
+        let (tx, rx) = mpsc::unbounded_channel::<ServerFrame>();
+        drop(rx);
+        let id = hub.resume_remote("t1", tx, 0, 500).await;
+        assert!(id.is_none(), "closed outbox must not produce a SubscriberId");
+        assert_eq!(hub.subscriber_count("t1"), Some(0));
     }
 
     #[tokio::test]

--- a/src-tauri/src/stream_hub.rs
+++ b/src-tauri/src/stream_hub.rs
@@ -31,13 +31,17 @@
 //   other way, so there is no AB / BA deadlock between hub broadcast and
 //   `try_reattach`'s channel swap.
 
+use crate::protocol::ServerFrame;
 use crate::pty_manager::{PtyDataPayload, SharedChannel};
 use crate::sidecar_client::SidecarClient;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
 use dashmap::DashMap;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
+use tokio::sync::mpsc;
 
 /// Default ring buffer cap per tab — bytes, not entries. Holds roughly five
 /// to ten seconds of continuous high-bandwidth output. Past this point a
@@ -51,10 +55,18 @@ pub const DEFAULT_RING_CAP_BYTES: usize = 512 * 1024;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SubscriberId(u64);
 
-/// Per-tab fan-out target. `#[non_exhaustive]` so adding the upcoming
-/// `Remote` variant for paired mobile clients does not break any external
-/// matcher — and matches the intent expressed in the master architecture
-/// plan that subscribers grow over the phases.
+/// Sentinel for `Subscriber::Remote::last_acked_seq` meaning "no bytes have
+/// been delivered to this subscriber yet." Distinct from `Some(0)` (which
+/// means the subscriber has been sent seq 0 already). Broadcast dedup:
+/// `if acked != REMOTE_ACK_UNSET && seq <= acked { skip }`.
+///
+/// `u64::MAX` is safe as a sentinel because a real broadcast seq would take
+/// ~285 years to reach it at 1 GB/s continuous output — the practical
+/// upper bound is far below.
+const REMOTE_ACK_UNSET: u64 = u64::MAX;
+
+/// Per-tab fan-out target. `#[non_exhaustive]` so adding future variants
+/// (relay backends, notification sinks, etc.) stays non-breaking.
 #[non_exhaustive]
 pub enum Subscriber {
     /// Desktop WebView path. The SharedChannel inside flips between
@@ -62,6 +74,20 @@ pub enum Subscriber {
     /// without ever re-subscribing — same shape pty_manager has used since
     /// before the hub existed.
     Local(SharedChannel),
+
+    /// Paired mobile / remote client. Each connection owns its own
+    /// `mpsc::UnboundedSender<ServerFrame>`; the WSS server's writer task
+    /// drains it into the WebSocket. Two atomics track per-subscriber
+    /// delivery state so `broadcast` can dedupe against subscribe-time
+    /// ring replay and reap dead subscribers on send failure.
+    Remote {
+        /// Highest seq delivered to this subscriber (via Snapshot or a
+        /// Bytes frame). Starts as `REMOTE_ACK_UNSET`; updates on every
+        /// successful delivery. Broadcast fan-out uses it to skip re-
+        /// sending bytes the subscribe path already replayed from ring.
+        last_acked_seq: Arc<AtomicU64>,
+        outbox: mpsc::UnboundedSender<ServerFrame>,
+    },
 }
 
 struct TabState {
@@ -207,54 +233,264 @@ impl StreamHub {
             None => return,
         };
 
-        if !decoded_str.is_empty() {
-            let subscribers = state.subscribers.lock().expect("subscribers lock poisoned");
-            for (_, sub) in subscribers.iter() {
-                match sub {
-                    Subscriber::Local(shared) => {
-                        let send_failed = {
-                            let guard = shared.lock().expect("channel lock poisoned");
-                            match guard.as_ref() {
-                                Some(ch) => ch
-                                    .send(PtyDataPayload {
-                                        data: decoded_str.to_string(),
-                                    })
-                                    .is_err(),
-                                // WebView disconnected; the next `open_tab`
-                                // call will swap a fresh Channel into this
-                                // SharedChannel. Skip without fault.
-                                None => false,
-                            }
-                        };
-                        if send_failed {
-                            // Channel dropped mid-send (WebView vanished
-                            // while we were forwarding). Clear so the next
-                            // broadcast skips cleanly. Matches the
-                            // pre-hub behaviour byte-for-byte.
-                            shared
-                                .lock()
-                                .expect("channel lock poisoned")
-                                .take();
-                        }
-                    }
-                }
-            }
-        }
-
-        if !raw_bytes.is_empty() {
+        // Assign seq + push to ring + write to sidecar shadow FIRST, before
+        // any subscriber fan-out. This ordering matters for two reasons:
+        //   1. If a Remote subscriber is added between now and the
+        //      subs.lock() below, its subscribe-time ring replay will
+        //      include this chunk — no gap.
+        //   2. `sidecar.write_bytes(seq)` and the ring push must happen
+        //      atomically relative to `state.next_seq`, otherwise the
+        //      ordering guarantee subscribe_remote relies on for snapshot
+        //      alignment breaks. Nothing awaits between them.
+        let assigned_seq: Option<u64> = if !raw_bytes.is_empty() {
             let seq = state.next_seq.fetch_add(1, Ordering::AcqRel);
             state
                 .ring
                 .lock()
                 .expect("ring lock poisoned")
                 .push(seq, raw_bytes.to_vec());
-            // Threaded to the sidecar so `serialize` can return the exact
-            // seq whose bytes are in the payload — closes the drift window
-            // between "which write was in the snapshot" and "next Bytes
-            // broadcast seq" that a remote subscribe would otherwise hit.
             if let Some(sidecar) = &self.sidecar {
                 sidecar.write_bytes(tab_id, raw_bytes, seq);
             }
+            Some(seq)
+        } else {
+            None
+        };
+
+        // Single fan-out pass. Local subscribers get the decoded string;
+        // Remote subscribers get base64-encoded raw bytes wrapped in a
+        // ServerFrame::Bytes. Encoding is lazy so tabs with no remote
+        // subscribers pay zero base64 cost.
+        let mut subs = state.subscribers.lock().expect("subscribers lock poisoned");
+        let mut dead: Vec<SubscriberId> = Vec::new();
+        let mut encoded: Option<String> = None;
+
+        for (sid, sub) in subs.iter() {
+            match sub {
+                Subscriber::Local(shared) => {
+                    if decoded_str.is_empty() {
+                        continue;
+                    }
+                    let send_failed = {
+                        let guard = shared.lock().expect("channel lock poisoned");
+                        match guard.as_ref() {
+                            Some(ch) => ch
+                                .send(PtyDataPayload {
+                                    data: decoded_str.to_string(),
+                                })
+                                .is_err(),
+                            // WebView disconnected; the next `open_tab`
+                            // call will swap a fresh Channel into this
+                            // SharedChannel. Skip without fault.
+                            None => false,
+                        }
+                    };
+                    if send_failed {
+                        // Channel dropped mid-send (WebView vanished
+                        // while we were forwarding). Clear so the next
+                        // broadcast skips cleanly. Matches the pre-hub
+                        // behaviour byte-for-byte.
+                        shared
+                            .lock()
+                            .expect("channel lock poisoned")
+                            .take();
+                    }
+                }
+                Subscriber::Remote {
+                    last_acked_seq,
+                    outbox,
+                } => {
+                    // Remotes only get non-empty raw bytes; a decoded-only
+                    // broadcast (EOF flush case) isn't representable on the
+                    // wire protocol yet and gets dropped for Remotes.
+                    let Some(seq) = assigned_seq else { continue };
+                    // Dedup: skip if we've already sent (or the subscribe
+                    // path replayed) this seq via the ring.
+                    let acked = last_acked_seq.load(Ordering::Acquire);
+                    if acked != REMOTE_ACK_UNSET && seq <= acked {
+                        continue;
+                    }
+                    let data = encoded
+                        .get_or_insert_with(|| B64.encode(raw_bytes))
+                        .clone();
+                    match outbox.send(ServerFrame::Bytes {
+                        tab_id: tab_id.to_string(),
+                        seq,
+                        data,
+                    }) {
+                        Ok(()) => last_acked_seq.store(seq, Ordering::Release),
+                        Err(_) => dead.push(*sid),
+                    }
+                }
+            }
+        }
+        if !dead.is_empty() {
+            subs.retain(|(id, _)| !dead.contains(id));
+        }
+    }
+
+    /// Register a Remote subscriber for `tab_id`. Fetches the sidecar's
+    /// current serialize payload (which includes state through the highest
+    /// seq the sidecar has parsed so far) and delivers it as a Snapshot
+    /// frame; then replays any ring entries with seqs newer than that
+    /// snapshot's `last_seq`, catching up bytes that landed between the
+    /// serialize call and the subscribers-lock acquisition.
+    ///
+    /// Returns the SubscriberId the caller passes back to `unsubscribe`.
+    /// Async because sidecar.serialize awaits a reply.
+    pub async fn subscribe_remote(
+        &self,
+        tab_id: &str,
+        outbox: mpsc::UnboundedSender<ServerFrame>,
+        scrollback: u32,
+    ) -> SubscriberId {
+        let state = self
+            .tabs
+            .entry(tab_id.to_string())
+            .or_insert_with(|| Arc::new(TabState::new(80, 24, self.ring_cap_bytes)))
+            .clone();
+
+        let (payload, sidecar_seq) = self.fetch_snapshot(tab_id, scrollback).await;
+        self.attach_remote_and_catch_up(&state, tab_id, outbox, payload, sidecar_seq)
+    }
+
+    /// Reconnect path: client's last-known seq is `last_seq`. If the ring
+    /// still has the byte immediately after that seq, replay from there —
+    /// no snapshot needed, cheap. Otherwise fall through to a fresh
+    /// snapshot (same shape as `subscribe_remote`), including the client's
+    /// implicit re-init of state from the snapshot payload.
+    ///
+    /// The "can replay" cut-off is `ring.front.seq <= last_seq + 1`. If the
+    /// oldest ring entry is exactly the byte the client needs next, replay
+    /// works; anything older has been evicted and the gap is unrecoverable
+    /// without a fresh snapshot.
+    pub async fn resume_remote(
+        &self,
+        tab_id: &str,
+        outbox: mpsc::UnboundedSender<ServerFrame>,
+        last_seq: u64,
+        scrollback: u32,
+    ) -> SubscriberId {
+        let state = self
+            .tabs
+            .entry(tab_id.to_string())
+            .or_insert_with(|| Arc::new(TabState::new(80, 24, self.ring_cap_bytes)))
+            .clone();
+
+        let can_replay = {
+            let ring = state.ring.lock().expect("ring lock poisoned");
+            !ring.entries.is_empty()
+                && ring.entries.front().expect("checked non-empty above").0
+                    <= last_seq.saturating_add(1)
+        };
+
+        if can_replay {
+            let mut subs = state.subscribers.lock().expect("subscribers lock poisoned");
+            let ring = state.ring.lock().expect("ring lock poisoned");
+            let mut highest_delivered = last_seq;
+            for (seq, bytes) in ring.entries.iter() {
+                if *seq > last_seq {
+                    let _ = outbox.send(ServerFrame::Bytes {
+                        tab_id: tab_id.to_string(),
+                        seq: *seq,
+                        data: B64.encode(bytes),
+                    });
+                    highest_delivered = *seq;
+                }
+            }
+            drop(ring);
+            let id = SubscriberId(state.next_sub_id.fetch_add(1, Ordering::Relaxed));
+            subs.push((
+                id,
+                Subscriber::Remote {
+                    last_acked_seq: Arc::new(AtomicU64::new(highest_delivered)),
+                    outbox,
+                },
+            ));
+            id
+        } else {
+            let (payload, sidecar_seq) = self.fetch_snapshot(tab_id, scrollback).await;
+            self.attach_remote_and_catch_up(&state, tab_id, outbox, payload, sidecar_seq)
+        }
+    }
+
+    /// Sync helper shared by `subscribe_remote` and `resume_remote`'s
+    /// gap-too-wide fallback. Holds `subscribers` + `ring` locks during the
+    /// snapshot send + ring replay so no concurrent broadcast can slip in
+    /// with a seq that would land between the snapshot's tail and the
+    /// subscriber's registration.
+    fn attach_remote_and_catch_up(
+        &self,
+        state: &Arc<TabState>,
+        tab_id: &str,
+        outbox: mpsc::UnboundedSender<ServerFrame>,
+        payload: String,
+        sidecar_seq: Option<u64>,
+    ) -> SubscriberId {
+        let mut subs = state.subscribers.lock().expect("subscribers lock poisoned");
+        let ring = state.ring.lock().expect("ring lock poisoned");
+
+        // Snapshot's seq on the wire: sidecar_seq if known, else 0 with an
+        // empty payload. Client stores this for future resume requests.
+        let snapshot_seq_on_wire = sidecar_seq.unwrap_or(0);
+        let _ = outbox.send(ServerFrame::Snapshot {
+            tab_id: tab_id.to_string(),
+            seq: snapshot_seq_on_wire,
+            payload,
+        });
+
+        // Replay ring entries newer than the snapshot's coverage. Closes
+        // the race where a broadcast landed between subscribe's serialize
+        // call and this lock acquisition.
+        let mut highest_delivered = sidecar_seq;
+        for (seq, bytes) in ring.entries.iter() {
+            let should_replay = match sidecar_seq {
+                Some(t) => *seq > t,
+                None => true,
+            };
+            if should_replay {
+                let _ = outbox.send(ServerFrame::Bytes {
+                    tab_id: tab_id.to_string(),
+                    seq: *seq,
+                    data: B64.encode(bytes),
+                });
+                highest_delivered = Some(*seq);
+            }
+        }
+        drop(ring);
+
+        // Initial ack: highest seq we actually delivered, or the "unset"
+        // sentinel when nothing concrete has gone out yet (empty snapshot,
+        // empty ring — first broadcast will pass the dedup gate).
+        let initial_ack = highest_delivered.unwrap_or(REMOTE_ACK_UNSET);
+
+        let id = SubscriberId(state.next_sub_id.fetch_add(1, Ordering::Relaxed));
+        subs.push((
+            id,
+            Subscriber::Remote {
+                last_acked_seq: Arc::new(AtomicU64::new(initial_ack)),
+                outbox,
+            },
+        ));
+        id
+    }
+
+    /// Ask the sidecar for a serialize snapshot; degrade to empty payload
+    /// when the sidecar is absent or errors.
+    async fn fetch_snapshot(
+        &self,
+        tab_id: &str,
+        scrollback: u32,
+    ) -> (String, Option<u64>) {
+        match self.sidecar.as_ref() {
+            Some(sc) => match sc.serialize(tab_id, scrollback).await {
+                Ok(x) => x,
+                Err(e) => {
+                    eprintln!("[stream_hub] sidecar.serialize({tab_id}) failed: {e}");
+                    (String::new(), None)
+                }
+            },
+            None => (String::new(), None),
         }
     }
 
@@ -546,5 +782,207 @@ mod tests {
         for t in 0..16 {
             assert_eq!(hub.next_seq(&format!("t{t}")), Some(1000));
         }
+    }
+
+    // ---- Remote subscriber coverage ----
+    //
+    // These tests exercise the WSS-facing path. `StreamHub::new(None)` means
+    // no sidecar, so `subscribe_remote` sends an empty-payload Snapshot at
+    // seq 0 and initialises `last_acked_seq = REMOTE_ACK_UNSET`. That's
+    // enough to lock in the wire-level behaviour; real-sidecar coverage
+    // lives in the integration tests.
+
+    /// Drain everything currently in an unbounded receiver into a Vec.
+    /// Small helper to keep the test bodies focused on the assertions.
+    fn drain(rx: &mut mpsc::UnboundedReceiver<ServerFrame>) -> Vec<ServerFrame> {
+        let mut out = Vec::new();
+        while let Ok(f) = rx.try_recv() {
+            out.push(f);
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn remote_subscribe_receives_snapshot_frame() {
+        let hub = new_hub();
+        let (tx, mut rx) = mpsc::unbounded_channel::<ServerFrame>();
+        let _id = hub.subscribe_remote("t1", tx, 500).await;
+        let frames = drain(&mut rx);
+        assert_eq!(frames.len(), 1, "exactly one Snapshot frame on subscribe");
+        match &frames[0] {
+            ServerFrame::Snapshot {
+                tab_id,
+                seq,
+                payload,
+            } => {
+                assert_eq!(tab_id, "t1");
+                // No sidecar → empty payload, seq 0 (client's local
+                // last_seq starts there for future resume).
+                assert_eq!(*seq, 0);
+                assert_eq!(payload, "");
+            }
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn remote_subscribe_first_broadcast_delivered_despite_seq_zero() {
+        // Regression pin for the sentinel-init dedup. Without
+        // REMOTE_ACK_UNSET, initial last_acked would be 0 and the
+        // dedup check `seq <= 0` would drop the first broadcast.
+        let hub = new_hub();
+        let (tx, mut rx) = mpsc::unbounded_channel::<ServerFrame>();
+        let _id = hub.subscribe_remote("t1", tx, 500).await;
+        // Drop the snapshot frame — we care about what happens next.
+        let _ = drain(&mut rx);
+        hub.broadcast("t1", b"first", "first");
+        let frames = drain(&mut rx);
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            ServerFrame::Bytes { seq, data, .. } => {
+                assert_eq!(*seq, 0);
+                assert_eq!(data, &B64.encode(b"first"));
+            }
+            other => panic!("expected Bytes, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn remote_subscribe_replays_ring_entries_and_dedupes() {
+        // Broadcasts land in the ring before the subscribe; the
+        // subscribe path replays them as Bytes frames. Subsequent
+        // broadcasts continue via the normal fan-out without duplicating
+        // any of the replayed seqs.
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        for i in 0..3u8 {
+            hub.broadcast("t1", &[i], "x");
+        }
+        let (tx, mut rx) = mpsc::unbounded_channel::<ServerFrame>();
+        let _id = hub.subscribe_remote("t1", tx, 500).await;
+        // Expect: Snapshot(seq=0, empty) + Bytes(seq=0,1,2) replayed from
+        // ring (no sidecar → replay everything).
+        let subscribe_frames = drain(&mut rx);
+        assert!(matches!(subscribe_frames[0], ServerFrame::Snapshot { .. }));
+        let byte_seqs: Vec<u64> = subscribe_frames[1..]
+            .iter()
+            .filter_map(|f| match f {
+                ServerFrame::Bytes { seq, .. } => Some(*seq),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(byte_seqs, vec![0, 1, 2]);
+
+        // Next broadcast advances the seq — should arrive as Bytes(3),
+        // NOT as a repeat of any replayed seq.
+        hub.broadcast("t1", b"next", "next");
+        let live_frames = drain(&mut rx);
+        assert_eq!(live_frames.len(), 1);
+        match &live_frames[0] {
+            ServerFrame::Bytes { seq, .. } => assert_eq!(*seq, 3),
+            other => panic!("expected Bytes, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn remote_resume_within_ring_replays_only_newer_bytes() {
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        for i in 0..5u8 {
+            hub.broadcast("t1", &[i], "x");
+        }
+        // Client claims to have seen through seq 2 → server should
+        // replay 3, 4 only. No Snapshot on the resume-within-ring path.
+        let (tx, mut rx) = mpsc::unbounded_channel::<ServerFrame>();
+        let _id = hub.resume_remote("t1", tx, 2, 500).await;
+        let frames = drain(&mut rx);
+        let byte_seqs: Vec<u64> = frames
+            .iter()
+            .filter_map(|f| match f {
+                ServerFrame::Bytes { seq, .. } => Some(*seq),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(byte_seqs, vec![3, 4]);
+        assert!(
+            !frames
+                .iter()
+                .any(|f| matches!(f, ServerFrame::Snapshot { .. })),
+            "no Snapshot on the in-ring resume path"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_resume_beyond_ring_falls_through_to_snapshot() {
+        // Tiny ring so eviction bites after a few writes.
+        let hub = new_hub_with_cap(20);
+        hub.ensure_tab("t1", 80, 24);
+        for i in 0..50u8 {
+            hub.broadcast("t1", &[i; 10], "x");
+        }
+        // Ring now holds only the tail (single ~10-byte entry). Client's
+        // last_seq=0 is way outside the ring's coverage → fall through
+        // to Snapshot.
+        let (tx, mut rx) = mpsc::unbounded_channel::<ServerFrame>();
+        let _id = hub.resume_remote("t1", tx, 0, 500).await;
+        let frames = drain(&mut rx);
+        assert!(
+            frames
+                .iter()
+                .any(|f| matches!(f, ServerFrame::Snapshot { .. })),
+            "gap-too-wide resume must send a fresh Snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_disconnect_reaps_on_next_broadcast() {
+        let hub = new_hub();
+        let (tx, rx) = mpsc::unbounded_channel::<ServerFrame>();
+        let _id = hub.subscribe_remote("t1", tx, 500).await;
+        assert_eq!(hub.subscriber_count("t1"), Some(1));
+        // Drop the receiver; the outbox now returns Err on send.
+        drop(rx);
+        // First broadcast attempts to send, gets Err, marks dead, retains
+        // trimmed list.
+        hub.broadcast("t1", b"post-drop", "x");
+        assert_eq!(
+            hub.subscriber_count("t1"),
+            Some(0),
+            "dead remote must be reaped on the next broadcast"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_and_remote_subscribers_coexist() {
+        // Regression pin for the master invariant: the desktop path must
+        // stay byte-identical while a phone is also attached. This test
+        // asserts that broadcasts reach BOTH a local subscriber and a
+        // remote subscriber without cross-interference.
+        let hub = new_hub();
+        hub.ensure_tab("t1", 80, 24);
+        let local_ch: SharedChannel = Arc::new(Mutex::new(None));
+        let _local_id = hub.subscribe_local("t1", Arc::clone(&local_ch));
+        let (tx, mut rx) = mpsc::unbounded_channel::<ServerFrame>();
+        let _remote_id = hub.subscribe_remote("t1", tx, 500).await;
+        assert_eq!(hub.subscriber_count("t1"), Some(2));
+
+        // Skip the Snapshot the subscribe just emitted.
+        let _ = drain(&mut rx);
+
+        hub.broadcast("t1", b"shared", "shared-decoded");
+
+        // Remote received bytes.
+        let remote_frames = drain(&mut rx);
+        assert_eq!(remote_frames.len(), 1);
+        match &remote_frames[0] {
+            ServerFrame::Bytes { data, .. } => {
+                assert_eq!(data, &B64.encode(b"shared"));
+            }
+            other => panic!("expected Bytes, got {other:?}"),
+        }
+        // Local subscriber is on a Tauri Channel which we can't easily
+        // observe in-process. Its presence (subscriber_count=2 after
+        // subscribe and no reaping) plus the "no panic / no lock
+        // contention" success of the broadcast is the regression pin.
     }
 }

--- a/src-tauri/src/wss_server.rs
+++ b/src-tauri/src/wss_server.rs
@@ -75,6 +75,20 @@ pub async fn run(addr: SocketAddr, state: Arc<ServerState>) -> Result<(), WssErr
     let listener = TcpListener::bind(addr)
         .await
         .map_err(|source| WssError::Bind { addr, source })?;
+    run_with_listener(listener, state).await
+}
+
+/// Serve on an already-bound listener. Public so integration tests can
+/// hold the port from allocation through serving — no drop-then-rebind
+/// race, no sleep waiting for the server to come up. Production callers
+/// go through `run(addr, state)` which binds first, then delegates here.
+pub async fn run_with_listener(
+    listener: TcpListener,
+    state: Arc<ServerState>,
+) -> Result<(), WssError> {
+    let addr = listener
+        .local_addr()
+        .unwrap_or_else(|_| SocketAddr::from(([0, 0, 0, 0], 0)));
     // Loud dev-only warning so anyone reading the terminal knows this
     // server is exposed to the LAN with no TLS. Phase 2 introduces the
     // TOFU-pinned self-signed cert.
@@ -262,11 +276,16 @@ async fn dispatch_client_frame(
             if let Some(prev) = subscriptions.remove(&tab_id) {
                 state.hub.unsubscribe(&tab_id, prev);
             }
-            let id = state
+            // subscribe_remote returns None if the outbox closed during
+            // initial Snapshot / ring replay. Nothing to track; the
+            // connection is about to unwind on its own.
+            if let Some(id) = state
                 .hub
                 .subscribe_remote(&tab_id, outbox_tx.clone(), scrollback)
-                .await;
-            subscriptions.insert(tab_id, id);
+                .await
+            {
+                subscriptions.insert(tab_id, id);
+            }
         }
 
         ClientFrame::Resume {
@@ -277,11 +296,13 @@ async fn dispatch_client_frame(
             if let Some(prev) = subscriptions.remove(&tab_id) {
                 state.hub.unsubscribe(&tab_id, prev);
             }
-            let id = state
+            if let Some(id) = state
                 .hub
                 .resume_remote(&tab_id, outbox_tx.clone(), last_seq, scrollback)
-                .await;
-            subscriptions.insert(tab_id, id);
+                .await
+            {
+                subscriptions.insert(tab_id, id);
+            }
         }
 
         ClientFrame::Unsubscribe { tab_id } => {

--- a/src-tauri/src/wss_server.rs
+++ b/src-tauri/src/wss_server.rs
@@ -17,9 +17,11 @@
 // handshake per-device tokens stored in the macOS Keychain.
 
 use crate::auth_stub::AuthStub;
+use crate::mod_engine::ModEngine;
 use crate::project_registry::ProjectRegistry;
 use crate::protocol::{ClientFrame, ServerFrame};
-use crate::stream_hub::StreamHub;
+use crate::pty_manager::PtyMap;
+use crate::stream_hub::{StreamHub, SubscriberId};
 use axum::{
     Router,
     extract::{
@@ -29,11 +31,14 @@ use axum::{
     response::Response,
     routing::get,
 };
-use std::io;
+use portable_pty::PtySize;
+use std::collections::HashMap;
+use std::io::{self, Write};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::net::TcpListener;
+use tokio::sync::mpsc;
 
 #[derive(Debug, Error)]
 pub enum WssError {
@@ -53,6 +58,13 @@ pub struct ServerState {
     pub hub: Arc<StreamHub>,
     pub auth: Arc<AuthStub>,
     pub registry: Arc<ProjectRegistry>,
+    /// Shared with the Tauri app so a Write / Resize frame from a
+    /// remote client writes to the same PtyHandle the desktop
+    /// frontend does. Concurrent access under the existing
+    /// `Mutex<HashMap>` is fine at Phase 1 keystroke rates; if
+    /// contention shows in profiling we split the lock.
+    pub pty_map: PtyMap,
+    pub mod_engine: Arc<ModEngine>,
 }
 
 /// Bind the WSS server to `addr` and serve until the listener closes.
@@ -154,20 +166,153 @@ async fn connection_task(mut socket: WebSocket, state: Arc<ServerState>) {
         return;
     }
 
-    // Step 4: dispatch loop lands in the next commit. For now, just
-    // drain any subsequent frames so a wscat probe doesn't see the
-    // connection close immediately after Projects — the client observes
-    // "connected + authed" until it disconnects on its own.
+    // Step 4: enter the frame dispatch loop.
+    //
+    // Per-connection state:
+    // - `outbox_tx` / `outbox_rx` is the mpsc the StreamHub pushes
+    //   Bytes/Snapshot frames onto (Remote subscribers each own an
+    //   outbox clone). The main select! below drains outbox_rx onto
+    //   the WebSocket alongside handling client frames.
+    // - `subscriptions` tracks the SubscriberId per tab_id so
+    //   Unsubscribe / disconnect can clean up hub state.
+    let (outbox_tx, mut outbox_rx) = mpsc::unbounded_channel::<ServerFrame>();
+    let mut subscriptions: HashMap<String, SubscriberId> = HashMap::new();
+
     loop {
-        match socket.recv().await {
-            Some(Ok(Message::Close(_))) | None => break,
-            Some(Ok(_)) => {
-                // Silently drop until the dispatcher lands.
+        tokio::select! {
+            // Client → server: read a frame, dispatch.
+            incoming = read_frame(&mut socket) => {
+                let frame = match incoming {
+                    Ok(Some(f)) => f,
+                    Ok(None) => break,
+                    Err(e) => {
+                        eprintln!("[wss] read error: {e}");
+                        break;
+                    }
+                };
+                dispatch_client_frame(
+                    frame,
+                    &state,
+                    &outbox_tx,
+                    &mut subscriptions,
+                )
+                .await;
             }
-            Some(Err(e)) => {
-                eprintln!("[wss] recv error: {e}");
-                break;
+
+            // Server → client: outbox drained onto the WebSocket. The
+            // outbox_tx clone in `subscriptions` keeps this alive; when
+            // all clones drop (i.e. connection torn down), this branch
+            // returns None and the select! moves on. We break in that
+            // case so the connection cleanly closes.
+            frame = outbox_rx.recv() => {
+                let Some(frame) = frame else { break };
+                if send_frame(&mut socket, &frame).await.is_err() {
+                    break;
+                }
             }
+        }
+    }
+
+    // Cleanup: drop every remaining subscription so the hub reclaims
+    // its per-tab bookkeeping. Runs on any exit from the loop (client
+    // close, read error, outbox drained).
+    for (tab_id, sub_id) in subscriptions {
+        state.hub.unsubscribe(&tab_id, sub_id);
+    }
+}
+
+/// Route a single ClientFrame to its handler. Kept as a standalone
+/// function so the main connection_task select! stays legible.
+async fn dispatch_client_frame(
+    frame: ClientFrame,
+    state: &Arc<ServerState>,
+    outbox_tx: &mpsc::UnboundedSender<ServerFrame>,
+    subscriptions: &mut HashMap<String, SubscriberId>,
+) {
+    match frame {
+        // The main auth path already handled the first Auth frame. A
+        // second one is a protocol error but not worth tearing down for
+        // — silently ignore.
+        ClientFrame::Auth { .. } => {}
+
+        ClientFrame::Subscribe { tab_id, scrollback } => {
+            // Drop any prior subscription on the same tab first so we
+            // don't leak SubscriberIds if a client re-subscribes.
+            if let Some(prev) = subscriptions.remove(&tab_id) {
+                state.hub.unsubscribe(&tab_id, prev);
+            }
+            let id = state
+                .hub
+                .subscribe_remote(&tab_id, outbox_tx.clone(), scrollback)
+                .await;
+            subscriptions.insert(tab_id, id);
+        }
+
+        ClientFrame::Resume {
+            tab_id,
+            scrollback,
+            last_seq,
+        } => {
+            if let Some(prev) = subscriptions.remove(&tab_id) {
+                state.hub.unsubscribe(&tab_id, prev);
+            }
+            let id = state
+                .hub
+                .resume_remote(&tab_id, outbox_tx.clone(), last_seq, scrollback)
+                .await;
+            subscriptions.insert(tab_id, id);
+        }
+
+        ClientFrame::Unsubscribe { tab_id } => {
+            if let Some(id) = subscriptions.remove(&tab_id) {
+                state.hub.unsubscribe(&tab_id, id);
+            }
+        }
+
+        ClientFrame::Write { tab_id, data } => {
+            // Look up the PtyHandle and write bytes to its master.
+            // Matches `commands::write_pty` behaviour byte-for-byte:
+            // silently no-op if the tab is already closed, then feed
+            // the mod engine.
+            let bytes = data.into_bytes();
+            {
+                let mut map = state.pty_map.lock().expect("pty_map lock poisoned");
+                if let Some(handle) = map.get_mut(&tab_id) {
+                    if let Err(e) = handle.writer.write_all(&bytes) {
+                        eprintln!("[wss] write to {tab_id} failed: {e}");
+                    }
+                }
+            }
+            state.mod_engine.handle().on_input(&tab_id, bytes);
+        }
+
+        ClientFrame::Resize {
+            tab_id,
+            cols,
+            rows,
+        } => {
+            {
+                let map = state.pty_map.lock().expect("pty_map lock poisoned");
+                if let Some(handle) = map.get(&tab_id) {
+                    if let Err(e) = handle.master.resize(PtySize {
+                        rows,
+                        cols,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    }) {
+                        eprintln!("[wss] resize {tab_id} failed: {e}");
+                    }
+                }
+            }
+            state.mod_engine.handle().on_resize(&tab_id, cols, rows);
+            // Keep the sidecar's shadow xterm in step so a subsequent
+            // Snapshot from a re-subscribing client sees the right
+            // dimensions.
+            state.hub.resize_tab(&tab_id, cols, rows);
+        }
+
+        ClientFrame::Ping => {
+            let _ = outbox_tx.send(ServerFrame::Pong);
         }
     }
 }

--- a/src-tauri/src/wss_server.rs
+++ b/src-tauri/src/wss_server.rs
@@ -175,8 +175,17 @@ async fn connection_task(mut socket: WebSocket, state: Arc<ServerState>) {
     //   the WebSocket alongside handling client frames.
     // - `subscriptions` tracks the SubscriberId per tab_id so
     //   Unsubscribe / disconnect can clean up hub state.
+    // - `changes` fires whenever the tab inventory mutates
+    //   (open_tab, close_tab, respawn_in_place). We push a fresh
+    //   Projects frame to the outbox in response so the mobile UI's
+    //   tab tree stays live-synced with the desktop's.
     let (outbox_tx, mut outbox_rx) = mpsc::unbounded_channel::<ServerFrame>();
     let mut subscriptions: HashMap<String, SubscriberId> = HashMap::new();
+    let mut changes = state.registry.subscribe_changes();
+    // Consume the current value so `changed().await` blocks until the
+    // NEXT notify — otherwise the first iteration would fire
+    // immediately and re-send the projects we just pushed above.
+    changes.mark_unchanged();
 
     loop {
         tokio::select! {
@@ -209,6 +218,18 @@ async fn connection_task(mut socket: WebSocket, state: Arc<ServerState>) {
                 if send_frame(&mut socket, &frame).await.is_err() {
                     break;
                 }
+            }
+
+            // ProjectRegistry fired notify_change. Re-read the tab
+            // tree and enqueue a fresh Projects frame; the outbox
+            // branch above will send it on the next iteration. Any
+            // send error on `changed().await` means the sender has
+            // been dropped — impossible in practice (registry is
+            // long-lived) but treat as a clean exit anyway.
+            change = changes.changed() => {
+                if change.is_err() { break; }
+                let projects = state.registry.projects();
+                let _ = outbox_tx.send(ServerFrame::Projects { data: projects });
             }
         }
     }

--- a/src-tauri/src/wss_server.rs
+++ b/src-tauri/src/wss_server.rs
@@ -17,7 +17,7 @@
 // handshake per-device tokens stored in the macOS Keychain.
 
 use crate::auth_stub::AuthStub;
-use crate::mod_engine::ModEngine;
+use crate::mod_engine::ModEngineHandle;
 use crate::project_registry::ProjectRegistry;
 use crate::protocol::{ClientFrame, ServerFrame};
 use crate::pty_manager::PtyMap;
@@ -64,7 +64,7 @@ pub struct ServerState {
     /// `Mutex<HashMap>` is fine at Phase 1 keystroke rates; if
     /// contention shows in profiling we split the lock.
     pub pty_map: PtyMap,
-    pub mod_engine: Arc<ModEngine>,
+    pub mod_engine_handle: ModEngineHandle,
 }
 
 /// Bind the WSS server to `addr` and serve until the listener closes.
@@ -304,7 +304,7 @@ async fn dispatch_client_frame(
                     }
                 }
             }
-            state.mod_engine.handle().on_input(&tab_id, bytes);
+            state.mod_engine_handle.on_input(&tab_id, bytes);
         }
 
         ClientFrame::Resize {
@@ -325,7 +325,7 @@ async fn dispatch_client_frame(
                     }
                 }
             }
-            state.mod_engine.handle().on_resize(&tab_id, cols, rows);
+            state.mod_engine_handle.on_resize(&tab_id, cols, rows);
             // Keep the sidecar's shadow xterm in step so a subsequent
             // Snapshot from a re-subscribing client sees the right
             // dimensions.

--- a/src-tauri/src/wss_server.rs
+++ b/src-tauri/src/wss_server.rs
@@ -1,0 +1,223 @@
+// WSS server for the mobile companion. Bound to the dev-config's
+// bind_addr (defaults to 0.0.0.0:47823 — LAN-accessible so a phone on
+// the same Wi-Fi can reach it). One route in Phase 1: `/stream`.
+//
+// Connection lifecycle:
+//   1. WebSocket upgrade on `/stream`.
+//   2. Client sends `ClientFrame::Auth`. Server validates against the
+//      AuthStub's bearer token via constant-time compare.
+//   3. Server replies `ServerFrame::AuthOk` + immediately pushes a
+//      `ServerFrame::Projects` frame with the current tab tree.
+//   4. Server enters the frame-dispatch loop (lands in the next
+//      commit — this initial commit closes the connection right after
+//      the AuthOk + Projects push).
+//
+// Auth is intentionally minimal — a single bearer token from the dev
+// config file. Phase 2 replaces the whole flow with the QR-code pairing
+// handshake per-device tokens stored in the macOS Keychain.
+
+use crate::auth_stub::AuthStub;
+use crate::project_registry::ProjectRegistry;
+use crate::protocol::{ClientFrame, ServerFrame};
+use crate::stream_hub::StreamHub;
+use axum::{
+    Router,
+    extract::{
+        State, WebSocketUpgrade,
+        ws::{Message, WebSocket},
+    },
+    response::Response,
+    routing::get,
+};
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::net::TcpListener;
+
+#[derive(Debug, Error)]
+pub enum WssError {
+    #[error("bind {addr}: {source}")]
+    Bind {
+        addr: SocketAddr,
+        #[source]
+        source: io::Error,
+    },
+    #[error("serve: {0}")]
+    Serve(#[from] io::Error),
+}
+
+/// Handles passed to each connection task. Cloneable via `Arc`; per-
+/// connection state lives inside the task itself.
+pub struct ServerState {
+    pub hub: Arc<StreamHub>,
+    pub auth: Arc<AuthStub>,
+    pub registry: Arc<ProjectRegistry>,
+}
+
+/// Bind the WSS server to `addr` and serve until the listener closes.
+/// `lib.rs` spawns this as a tokio task and doesn't await its
+/// completion; a bind failure logs and returns without blocking desktop
+/// startup.
+pub async fn run(addr: SocketAddr, state: Arc<ServerState>) -> Result<(), WssError> {
+    let listener = TcpListener::bind(addr)
+        .await
+        .map_err(|source| WssError::Bind { addr, source })?;
+    // Loud dev-only warning so anyone reading the terminal knows this
+    // server is exposed to the LAN with no TLS. Phase 2 introduces the
+    // TOFU-pinned self-signed cert.
+    eprintln!(
+        "[wss] listening on {addr} — LAN-exposed, dev only, no TLS. \
+         Token in the companion-dev.json config file"
+    );
+
+    let app = Router::new()
+        .route("/stream", get(handle_stream_upgrade))
+        .with_state(state);
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// axum handler for `/stream`. Just performs the WebSocket upgrade and
+/// hands off to `connection_task`; all the interesting logic lives there.
+async fn handle_stream_upgrade(
+    State(state): State<Arc<ServerState>>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    ws.on_upgrade(move |socket| connection_task(socket, state))
+}
+
+/// Per-connection lifecycle. Reads frames, dispatches them, pushes
+/// replies. This initial commit only handles auth + the initial Projects
+/// push. The next commit wires the full ClientFrame dispatch loop.
+async fn connection_task(mut socket: WebSocket, state: Arc<ServerState>) {
+    // Step 1: read the auth frame.
+    let auth_frame = match read_frame(&mut socket).await {
+        Ok(Some(f)) => f,
+        Ok(None) => {
+            // Client closed before sending auth. Nothing to do.
+            return;
+        }
+        Err(e) => {
+            eprintln!("[wss] read auth frame failed: {e}");
+            return;
+        }
+    };
+
+    let token = match auth_frame {
+        ClientFrame::Auth { token } => token,
+        other => {
+            // Any non-Auth first frame is a protocol error.
+            let _ = send_frame(
+                &mut socket,
+                &ServerFrame::AuthFail {
+                    reason: format!(
+                        "expected Auth as first frame, got {}",
+                        first_op_name(&other)
+                    ),
+                },
+            )
+            .await;
+            return;
+        }
+    };
+
+    // Step 2: validate.
+    if !state.auth.check(&token) {
+        let _ = send_frame(
+            &mut socket,
+            &ServerFrame::AuthFail {
+                reason: "bad token".to_string(),
+            },
+        )
+        .await;
+        return;
+    }
+
+    // Step 3: auth-ok + immediate Projects push.
+    if send_frame(
+        &mut socket,
+        &ServerFrame::AuthOk {
+            device_name: state.auth.device_name.clone(),
+        },
+    )
+    .await
+    .is_err()
+    {
+        return;
+    }
+    let projects = state.registry.projects();
+    if send_frame(&mut socket, &ServerFrame::Projects { data: projects })
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    // Step 4: dispatch loop lands in the next commit. For now, just
+    // drain any subsequent frames so a wscat probe doesn't see the
+    // connection close immediately after Projects — the client observes
+    // "connected + authed" until it disconnects on its own.
+    loop {
+        match socket.recv().await {
+            Some(Ok(Message::Close(_))) | None => break,
+            Some(Ok(_)) => {
+                // Silently drop until the dispatcher lands.
+            }
+            Some(Err(e)) => {
+                eprintln!("[wss] recv error: {e}");
+                break;
+            }
+        }
+    }
+}
+
+/// Read the next text/binary frame as a ClientFrame. Returns `Ok(None)`
+/// on a clean close. Ignores WebSocket Ping/Pong control frames (axum
+/// handles those transparently but the loop still sees them).
+async fn read_frame(socket: &mut WebSocket) -> Result<Option<ClientFrame>, ReadFrameError> {
+    loop {
+        match socket.recv().await {
+            Some(Ok(Message::Text(text))) => {
+                let frame: ClientFrame = serde_json::from_str(text.as_str())
+                    .map_err(ReadFrameError::BadJson)?;
+                return Ok(Some(frame));
+            }
+            Some(Ok(Message::Binary(bytes))) => {
+                let frame: ClientFrame = serde_json::from_slice(&bytes)
+                    .map_err(ReadFrameError::BadJson)?;
+                return Ok(Some(frame));
+            }
+            Some(Ok(Message::Ping(_) | Message::Pong(_))) => continue,
+            Some(Ok(Message::Close(_))) | None => return Ok(None),
+            Some(Err(e)) => return Err(ReadFrameError::Socket(e.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+enum ReadFrameError {
+    #[error("bad json: {0}")]
+    BadJson(#[from] serde_json::Error),
+    #[error("socket: {0}")]
+    Socket(String),
+}
+
+/// Serialise and send a ServerFrame as a text WebSocket message.
+async fn send_frame(socket: &mut WebSocket, frame: &ServerFrame) -> Result<(), axum::Error> {
+    let json = serde_json::to_string(frame).expect("ServerFrame must always serialise");
+    socket.send(Message::Text(json.into())).await
+}
+
+/// Human-readable variant name for the "expected Auth" error message.
+fn first_op_name(frame: &ClientFrame) -> &'static str {
+    match frame {
+        ClientFrame::Auth { .. } => "auth",
+        ClientFrame::Subscribe { .. } => "subscribe",
+        ClientFrame::Resume { .. } => "resume",
+        ClientFrame::Unsubscribe { .. } => "unsubscribe",
+        ClientFrame::Write { .. } => "write",
+        ClientFrame::Resize { .. } => "resize",
+        ClientFrame::Ping => "ping",
+    }
+}

--- a/src-tauri/tests/wss_integration.rs
+++ b/src-tauri/tests/wss_integration.rs
@@ -32,10 +32,11 @@ use tokio_tungstenite::tungstenite::Message;
 /// Build a fully-wired ServerState with a known token. Sidecar is None
 /// (no headless xterm), so Snapshots come back with empty payload and
 /// broadcasts show up as base64-encoded Bytes frames only.
+///
+/// Uses `wss_server::run_with_listener` — the test binds the listener
+/// itself and hands it to the server task. No drop-then-rebind race, no
+/// sleep-and-hope wait for the server to come up.
 async fn spawn_server(token: &str) -> (SocketAddr, Arc<ServerState>) {
-    // Bind first to a kernel-assigned port so we can hand it back for
-    // the client to connect to. Then hand ownership of the listener
-    // over to the server task.
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind ephemeral");
@@ -66,16 +67,25 @@ async fn spawn_server(token: &str) -> (SocketAddr, Arc<ServerState>) {
         mod_engine_handle: ModEngineHandle::noop(),
     });
 
-    // Release the listener so `run()` can rebind the same addr. Ports
-    // are TIME_WAIT-safe within the ~50ms this test needs.
-    drop(listener);
     let state_for_task = Arc::clone(&state);
     tokio::spawn(async move {
-        let _ = wss_server::run(addr, state_for_task).await;
+        let _ = wss_server::run_with_listener(listener, state_for_task).await;
     });
 
-    // Give the server a beat to bind.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Poll for readiness instead of guessing with a fixed sleep. The
+    // listener is already bound (we did it above); this loop just
+    // waits until axum's serve loop has begun accepting connections.
+    // Deterministic on slow CI, fast on a healthy dev box.
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("wss server never came up at {addr}");
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
     (addr, state)
 }
 
@@ -106,7 +116,8 @@ where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     let json = serde_json::to_string(frame).expect("serialise");
-    ws.send(Message::Text(json)).await.expect("send");
+    // `.into()` converts String → Utf8Bytes (tungstenite 0.26 Text variant).
+    ws.send(Message::Text(json.into())).await.expect("send");
 }
 
 async fn recv_frame<S>(

--- a/src-tauri/tests/wss_integration.rs
+++ b/src-tauri/tests/wss_integration.rs
@@ -1,0 +1,319 @@
+// End-to-end integration tests for the WSS server.
+//
+// Each test binds an ephemeral port (0.0.0.0:0 lets the OS pick), spins
+// the server up in a tokio task, and drives it with an in-process
+// tokio-tungstenite client. Covers the auth handshake, the initial
+// Projects push, per-frame dispatch (Ping/Pong, Subscribe → Snapshot,
+// broadcast → Bytes, resume flows), and disconnect cleanup.
+//
+// PtyHandle construction requires a real openpty which is impractical in
+// a hermetic test — the Write/Resize dispatch paths are covered by the
+// existing sync unit tests + manual smoke (`wscat` against a running dev
+// app).
+
+use agent_terminal_lib::auth_stub::AuthStub;
+use agent_terminal_lib::{CwdTable, ModEngineHandle};
+use agent_terminal_lib::project_registry::ProjectRegistry;
+use agent_terminal_lib::protocol::{ClientFrame, ServerFrame};
+use agent_terminal_lib::pty_manager::PtyMap;
+use agent_terminal_lib::stream_hub::StreamHub;
+use agent_terminal_lib::wss_server::{self, ServerState};
+
+use futures_util::{SinkExt, StreamExt};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+
+// ---- Test scaffolding ----
+
+/// Build a fully-wired ServerState with a known token. Sidecar is None
+/// (no headless xterm), so Snapshots come back with empty payload and
+/// broadcasts show up as base64-encoded Bytes frames only.
+async fn spawn_server(token: &str) -> (SocketAddr, Arc<ServerState>) {
+    // Bind first to a kernel-assigned port so we can hand it back for
+    // the client to connect to. Then hand ownership of the listener
+    // over to the server task.
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral");
+    let addr = listener.local_addr().expect("local_addr");
+
+    let auth = Arc::new(AuthStub::new_for_tests(
+        token.to_string(),
+        "test-device".to_string(),
+        addr,
+    ));
+
+    let hub = StreamHub::new(None);
+    let pty_map: PtyMap = Arc::new(Mutex::new(HashMap::new()));
+    let cwd_table: CwdTable = Arc::new(Mutex::new(HashMap::new()));
+    let registry = Arc::new(ProjectRegistry::new(
+        Arc::clone(&pty_map),
+        Arc::clone(&cwd_table),
+    ));
+
+    let state = Arc::new(ServerState {
+        hub: Arc::clone(&hub),
+        auth,
+        registry,
+        pty_map,
+        // Test-only noop handle — the tests below don't exercise Write
+        // or Resize dispatch (they need a real PtyHandle), so the mod
+        // engine channels this drops onto never matter.
+        mod_engine_handle: ModEngineHandle::noop(),
+    });
+
+    // Release the listener so `run()` can rebind the same addr. Ports
+    // are TIME_WAIT-safe within the ~50ms this test needs.
+    drop(listener);
+    let state_for_task = Arc::clone(&state);
+    tokio::spawn(async move {
+        let _ = wss_server::run(addr, state_for_task).await;
+    });
+
+    // Give the server a beat to bind.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, state)
+}
+
+/// Connect a client to the server and drive it through the auth
+/// handshake. Returns the still-live WebSocket for further test steps.
+async fn auth_ok_client(
+    addr: SocketAddr,
+    token: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>
+{
+    let url = format!("ws://{addr}/stream");
+    let (mut ws, _) = tokio_tungstenite::connect_async(url).await.expect("connect");
+    send_frame(&mut ws, &ClientFrame::Auth { token: token.to_string() }).await;
+    // Consume AuthOk + Projects. Tests care about frames AFTER these.
+    match recv_frame(&mut ws).await {
+        ServerFrame::AuthOk { .. } => {}
+        other => panic!("expected AuthOk, got {other:?}"),
+    }
+    match recv_frame(&mut ws).await {
+        ServerFrame::Projects { .. } => {}
+        other => panic!("expected Projects, got {other:?}"),
+    }
+    ws
+}
+
+async fn send_frame<S>(ws: &mut tokio_tungstenite::WebSocketStream<S>, frame: &ClientFrame)
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let json = serde_json::to_string(frame).expect("serialise");
+    ws.send(Message::Text(json)).await.expect("send");
+}
+
+async fn recv_frame<S>(
+    ws: &mut tokio_tungstenite::WebSocketStream<S>,
+) -> ServerFrame
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let msg = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("recv timeout")
+        .expect("stream closed")
+        .expect("ws error");
+    let text = match msg {
+        Message::Text(t) => t.to_string(),
+        Message::Binary(b) => String::from_utf8(b.to_vec()).expect("utf8"),
+        other => panic!("unexpected non-frame message: {other:?}"),
+    };
+    serde_json::from_str(&text).expect("parse ServerFrame")
+}
+
+// ---- Tests ----
+
+#[tokio::test]
+async fn auth_bad_token_yields_authfail_and_closes() {
+    let (addr, _state) = spawn_server("known-token").await;
+    let url = format!("ws://{addr}/stream");
+    let (mut ws, _) = tokio_tungstenite::connect_async(url).await.expect("connect");
+    send_frame(&mut ws, &ClientFrame::Auth { token: "wrong".to_string() }).await;
+    match recv_frame(&mut ws).await {
+        ServerFrame::AuthFail { reason } => {
+            assert!(!reason.is_empty(), "AuthFail must include a reason");
+        }
+        other => panic!("expected AuthFail, got {other:?}"),
+    }
+    // Next recv should observe the server-side close. axum doesn't
+    // always emit a graceful Close frame before dropping the socket —
+    // any of {None, Ok(Close), Err(ResetWithoutClosingHandshake)}
+    // means "connection is over," which is the invariant this test
+    // pins down.
+    let closed = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("timeout waiting for close");
+    let connection_ended = matches!(closed, None | Some(Ok(Message::Close(_))) | Some(Err(_)));
+    assert!(
+        connection_ended,
+        "expected connection to end after AuthFail; got {closed:?}"
+    );
+}
+
+#[tokio::test]
+async fn auth_ok_yields_authok_and_initial_projects_push() {
+    let (addr, _state) = spawn_server("secret").await;
+    let mut ws = auth_ok_client(addr, "secret").await;
+    // `auth_ok_client` already consumed AuthOk + Projects. As a
+    // secondary sanity check, drive a Ping/Pong to prove the socket is
+    // still healthy after the handshake.
+    send_frame(&mut ws, &ClientFrame::Ping).await;
+    match recv_frame(&mut ws).await {
+        ServerFrame::Pong => {}
+        other => panic!("expected Pong, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn subscribe_receives_snapshot_and_live_bytes() {
+    let (addr, state) = spawn_server("secret").await;
+    // Pre-populate the hub with some ring entries so the subscribe path
+    // replays them as Bytes right after the Snapshot.
+    state.hub.ensure_tab("workspace-a:tab-1", 80, 24);
+    state
+        .hub
+        .broadcast("workspace-a:tab-1", b"hello ", "hello ");
+    state
+        .hub
+        .broadcast("workspace-a:tab-1", b"world\n", "world\n");
+
+    let mut ws = auth_ok_client(addr, "secret").await;
+    send_frame(
+        &mut ws,
+        &ClientFrame::Subscribe {
+            tab_id: "workspace-a:tab-1".to_string(),
+            scrollback: 500,
+        },
+    )
+    .await;
+
+    // Snapshot + 2 replayed Bytes frames (no sidecar → replay all
+    // ring entries).
+    let snap = recv_frame(&mut ws).await;
+    assert!(matches!(snap, ServerFrame::Snapshot { .. }));
+    let b1 = recv_frame(&mut ws).await;
+    let b2 = recv_frame(&mut ws).await;
+    match (b1, b2) {
+        (
+            ServerFrame::Bytes { seq: 0, .. },
+            ServerFrame::Bytes { seq: 1, .. },
+        ) => {}
+        other => panic!("expected Bytes(seq=0), Bytes(seq=1), got {other:?}"),
+    }
+
+    // Now emit a live broadcast — should arrive as Bytes(seq=2).
+    state.hub.broadcast("workspace-a:tab-1", b"live", "live");
+    let live = recv_frame(&mut ws).await;
+    match live {
+        ServerFrame::Bytes { seq: 2, .. } => {}
+        other => panic!("expected Bytes(seq=2), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resume_within_ring_replays_only_missing_bytes() {
+    let (addr, state) = spawn_server("secret").await;
+    state.hub.ensure_tab("t:1", 80, 24);
+    for i in 0..5u8 {
+        state.hub.broadcast("t:1", &[i], "x");
+    }
+
+    let mut ws = auth_ok_client(addr, "secret").await;
+    send_frame(
+        &mut ws,
+        &ClientFrame::Resume {
+            tab_id: "t:1".to_string(),
+            scrollback: 500,
+            last_seq: 2,
+        },
+    )
+    .await;
+    let f1 = recv_frame(&mut ws).await;
+    let f2 = recv_frame(&mut ws).await;
+    match (f1, f2) {
+        (
+            ServerFrame::Bytes { seq: 3, .. },
+            ServerFrame::Bytes { seq: 4, .. },
+        ) => {}
+        other => panic!("expected Bytes(3), Bytes(4); got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unsubscribe_removes_hub_state_and_stops_bytes() {
+    let (addr, state) = spawn_server("secret").await;
+    state.hub.ensure_tab("t:1", 80, 24);
+    let mut ws = auth_ok_client(addr, "secret").await;
+    send_frame(
+        &mut ws,
+        &ClientFrame::Subscribe {
+            tab_id: "t:1".to_string(),
+            scrollback: 500,
+        },
+    )
+    .await;
+    // Consume the Snapshot.
+    let _ = recv_frame(&mut ws).await;
+
+    send_frame(
+        &mut ws,
+        &ClientFrame::Unsubscribe {
+            tab_id: "t:1".to_string(),
+        },
+    )
+    .await;
+
+    // Give the server a moment to process. subscriber_count should now
+    // be zero.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(state.hub.subscriber_count("t:1"), Some(0));
+
+    // Post-unsubscribe broadcasts must NOT arrive on the WebSocket.
+    state.hub.broadcast("t:1", b"unheard", "x");
+    let sees_a_byte = tokio::time::timeout(Duration::from_millis(200), ws.next())
+        .await
+        .is_ok();
+    assert!(!sees_a_byte, "unsubscribed client must not receive Bytes");
+}
+
+#[tokio::test]
+async fn client_disconnect_reaps_all_subscriptions() {
+    let (addr, state) = spawn_server("secret").await;
+    state.hub.ensure_tab("t:1", 80, 24);
+    state.hub.ensure_tab("t:2", 80, 24);
+    let mut ws = auth_ok_client(addr, "secret").await;
+    send_frame(
+        &mut ws,
+        &ClientFrame::Subscribe {
+            tab_id: "t:1".to_string(),
+            scrollback: 500,
+        },
+    )
+    .await;
+    let _ = recv_frame(&mut ws).await;
+    send_frame(
+        &mut ws,
+        &ClientFrame::Subscribe {
+            tab_id: "t:2".to_string(),
+            scrollback: 500,
+        },
+    )
+    .await;
+    let _ = recv_frame(&mut ws).await;
+    assert_eq!(state.hub.subscriber_count("t:1"), Some(1));
+    assert_eq!(state.hub.subscriber_count("t:2"), Some(1));
+
+    // Drop the client without unsubscribing. Cleanup happens when the
+    // connection_task's read loop returns.
+    drop(ws);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(state.hub.subscriber_count("t:1"), Some(0));
+    assert_eq!(state.hub.subscriber_count("t:2"), Some(0));
+}


### PR DESCRIPTION
> Targets the epic branch \`feat/desktop-sidecar-substrate\`. Sub-step 4 of the mobile-companion server stack.

## What

Turns everything below the WSS boundary (StreamHub, protocol frames, sidecar) into a network endpoint a mobile client can drive.

axum server on \`0.0.0.0:47823\` with one route (\`/stream\`), auth-stub via config-file bearer token, per-connection frame dispatch, live \`Projects\` push on tab-inventory changes.

**Success criterion:** \`wscat -c ws://<desktop-ip>:47823/stream\` can auth, subscribe to a tab, see snapshot + live bytes, send input, resume after disconnect, and watch the tab tree update in real time.

## Nine commits, review-friendly

| # | Commit | What |
|---|---|---|
| 1 | \`feat(sidecar): thread seq through write → serialize round-trip\` | Substrate. \`sidecar.write_bytes(tab_id, bytes, seq)\` + \`serialize\` returns \`(payload, last_seq)\` so subscribe_remote's snapshot has a deterministic seq. |
| 2 | \`fix(sidecar): distinguish \"no writes yet\" from \"seq 0 processed\"\` | Small tightening — \`sidecar.serialize\` returns \`Option<u64>\`, \`null\` on the wire = "no writes." |
| 3 | \`feat(hub): Subscriber::Remote + subscribe_remote / resume_remote\` | The biggest single commit. Enum variant + async subscribe / resume APIs + ring-replay math + broadcast fan-out. Dedup via \`REMOTE_ACK_UNSET\` sentinel. +8 stream_hub tests. |
| 4 | \`feat(auth_stub): dev-only bearer-token config with auto-init\` | JSON config at \`~/.config/agent-terminal/companion-dev.json\`. UUID token, constant-time compare. +6 tests. |
| 5 | \`feat(project_registry): read view + change-notification watch channel\` | Reads the desktop tab inventory, packages as \`ProjectSummary[]\`. Grouping via \`<project>:<suffix>\` convention. +6 tests. |
| 6 | \`feat(wss_server): axum server + /stream route + auth handshake\` | Skeleton with auth handshake + initial Projects push. Keep-alive loop drains subsequent frames. |
| 7 | \`feat(wss_server): frame dispatcher for every ClientFrame variant\` | Full Subscribe / Resume / Unsubscribe / Write / Resize / Ping dispatch. \`tokio::select!\` between client-read and outbox-drain. |
| 8 | \`feat(wss_server): live projects push via registry watch channel\` | Adds the change-notification branch to the select! + wires \`notify_change()\` into open_tab / close_tab / respawn_in_place. |
| 9 | \`feat(lib): spawn WSS server on startup\` + \`test(wss_server): 6 in-process integration tests\` | Wiring + integration coverage. |

## Two design decisions worth flagging

### \`REMOTE_ACK_UNSET\` sentinel

\`Subscriber::Remote::last_acked_seq\` is \`Arc<AtomicU64>\` where \`u64::MAX\` = "no bytes delivered yet." Broadcast dedup: \`if acked != REMOTE_ACK_UNSET && seq <= acked { skip }\`. This exists to distinguish "subscribed with an empty snapshot, waiting for first byte" from "already got seq 0" — the sidecar's \`Option<u64>\` return type (commit 2) propagates all the way down.

### Adjacently-tagged frames

The wire protocol from the previous sub-step (protocol-types) uses adjacent tagging (\`{\"op\": \"…\", \"body\": {…}}\`). Every dispatch site in \`wss_server.rs\` uses the generated enum variants; no hand-rolled JSON parsing.

## Files

\`\`\`
src-tauri/
├── sidecar/
│   ├── index.js                     seq-tagged writes, Option<u64> serialize
│   └── test/dispatch.test.ts        +1 seq-threading case
└── src/
    ├── auth_stub.rs                 NEW: 176 LOC + 6 tests
    ├── project_registry.rs          NEW: 137 LOC + 6 tests
    ├── wss_server.rs                NEW: 348 LOC (dispatcher + Registry watch)
    ├── stream_hub.rs                +240 LOC (Remote variant + subscribe /
                                     resume / broadcast fan-out) + 8 tests
    ├── sidecar_client.rs            +26 LOC (seq param, Option<u64> return)
    ├── commands.rs                  Registry.notify_change wired
    ├── pty_manager.rs               Registry.notify_change on respawn
    ├── protocol.rs                  Unused-import fix
    └── lib.rs                       WSS spawn + narrow re-exports

src-tauri/tests/
└── wss_integration.rs               NEW: 6 in-process integration tests
\`\`\`

## Tests

| Suite | Result |
|---|---|
| \`cargo test --lib\` | **94/94** + 1 ignored (was 82 before this sub-step) |
| \`cargo test --test wss_integration\` | **6/6** — auth good/bad, subscribe snapshot + live bytes, resume within ring, unsubscribe silences future broadcasts, disconnect reaps all subs |
| \`cargo test --test hook_integration\` | **9/9** + 4 ignored — no regressions |
| \`cargo test --lib -- --ignored\` | real-sidecar roundtrip still passes (seq threading verified end-to-end) |
| \`cd src-tauri/sidecar && bun test\` | **12/12** (was 11) |
| \`cargo clippy --lib --tests\` | no new warnings |

## What's deferred

Every item is called out in the plan file:

- **\`/pair\` route** — Phase 2 (QR-code handshake)
- **TLS** — Phase 2 (TOFU-pinned self-signed cert)
- **mDNS advertisement** — Phase 2
- **Rate limiting** — Phase 3 if abuse surfaces
- **Frame-size cap enforcement on the client** — Phase 3
- **WebSocket compression** — Phase 3 if bandwidth matters
- **Mobile-driven lifecycle ops** (Open/Close/Rename tabs from the phone) — captured as a future roadmap in the plan file's dedicated section

## Manual smoke test (not in CI)

- [ ] \`bun run tauri:dev\` — verify \`[wss] listening on 0.0.0.0:47823 — LAN-exposed, dev only, no TLS\` appears.
- [ ] Note the config path from the second log line; open it, copy the token.
- [ ] \`wscat -c ws://127.0.0.1:47823/stream\` from another terminal.
- [ ] Send \`{\"op\":\"auth\",\"body\":{\"token\":\"<token>\"}}\`. Expect \`auth_ok\` + \`projects\`.
- [ ] Open a tab in the desktop UI; a new \`projects\` push arrives on wscat.
- [ ] \`{\"op\":\"subscribe\",\"body\":{\"tab_id\":\"<tab>\",\"scrollback\":500}}\`. Expect \`snapshot\`.
- [ ] Run \`ls -la\` on the desktop; \`bytes\` frames stream in.
- [ ] \`{\"op\":\"write\",\"body\":{\"tab_id\":\"<tab>\",\"data\":\"echo hi\\r\"}}\`. Desktop shell prints \`hi\`.
- [ ] Kill wscat, reconnect, resume with the last seen seq — replayed bytes catch you up without gap.

## Test plan

- [ ] All test suites green
- [ ] Manual smoke path from a physical Mac + iPhone on the same LAN (I've smoke-tested via wscat locally)