### PR TITLE
fix(keyboard): match font-size zoom by produced character, not physical key

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "nanostores": "^1.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-hotkeys-hook": "^5.2.4",
+        "react-hotkeys-hook": "^5.3.3",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
@@ -882,7 +882,7 @@
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
-    "react-hotkeys-hook": ["react-hotkeys-hook@5.3.2", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-DDDy9xK6mbTQ6aPlQvIl0dA/a90T/AWml4Rm21JXFDLlRHalIg4/Rv3equUQYs5xPTWq+oEl6RD7mi/nBpU3Uw=="],
+    "react-hotkeys-hook": ["react-hotkeys-hook@5.3.3", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-aswgyWUnE25hmhzHTfKDmKzsaSE5DJ4LKaU/o6rQSXkDd/1Bh9TfAFQbHkf6fLy11HvlYkp+cDDarGdhmCDhoQ=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nanostores": "^1.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-hotkeys-hook": "^5.2.4",
+    "react-hotkeys-hook": "^5.3.3",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",

--- a/src/modules/keymap/keys.ts
+++ b/src/modules/keymap/keys.ts
@@ -122,3 +122,25 @@ export const Mod = {
 } as const
 
 export type ModName = (typeof Mod)[keyof typeof Mod]
+
+/**
+ * Produced-character tokens, for bindings that need `useKey: true` (match
+ * `KeyboardEvent.key`) instead of the `Keys` above (which match
+ * `KeyboardEvent.code`, i.e. physical position).
+ *
+ * Code-based matching assumes a US/ANSI layout for punctuation — `Cmd+=`
+ * only lives at `code: "Equal"` there. On many non-US layouts (e.g.
+ * Italian) '+' and '-' sit on entirely different physical keys, so a
+ * code-based binding silently never fires. Font-size zoom is a "the + key"
+ * concept, not a physical-position one, so it should match by character —
+ * same as how browsers bind their own Cmd+/Cmd- zoom.
+ *
+ * Requires react-hotkeys-hook >=5.3.3 (see package.json) — 5.3.2 and
+ * earlier match `useKey` combos *before* checking modifiers, so a lone
+ * '+' keypress with no Cmd held would also fire.
+ */
+export const ProducedChars = {
+  Equal: '=',
+  Plus: '+',
+  Minus: '-',
+} as const

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -8,7 +8,7 @@ import { TabSwitcher } from '@/components/TabSwitcher/TabSwitcher'
 import { TerminalSearchBar } from '@/components/TerminalSearchBar/TerminalSearchBar'
 import { UpdateBanner } from '@/components/UpdateBanner/UpdateBanner'
 import { formatDropPayload } from '@/modules/dragDrop/dropPayload'
-import { Keys, Mod } from '@/modules/keymap/keys'
+import { Keys, Mod, ProducedChars } from '@/modules/keymap/keys'
 import { $activeSearch, openSearch } from '@/modules/stores/$activeSearch'
 import { getActiveTerminalHandle } from '@/modules/stores/$activeTerminal'
 import { popClosedTab } from '@/modules/stores/$closedTabs'
@@ -187,18 +187,31 @@ export function WorkspaceLayout() {
     hotkeyOpts,
   )
 
-  // ⌘= / ⌘+ — increase font size. Bound twice: bare `Equal` for ⌘= and
-  // shifted `Equal` for ⌘+ (which is Shift+= on US keyboards). Both
-  // presses use the same physical key (event.code "Equal") and only
-  // differ by the shift modifier.
+  // ⌘= / ⌘+ — increase font size. Matched by produced character
+  // (`useKey`), not physical code — on US keyboards '+' is Shift+Equal,
+  // but on many non-US layouts (e.g. Italian) '+' is its own unshifted
+  // key entirely. Binding all four character/shift combinations covers
+  // both cases regardless of where they physically sit. See
+  // `ProducedChars` in modules/keymap/keys.ts for the rationale.
+  const fontSizeHotkeyOpts = { ...hotkeyOpts, useKey: true, splitKey: '.' }
   useHotkeys(
-    [`${Mod.Meta}+${Keys.Equal}`, `${Mod.Meta}+${Mod.Shift}+${Keys.Equal}`],
+    [
+      `${Mod.Meta}.${ProducedChars.Equal}`,
+      `${Mod.Meta}.${Mod.Shift}.${ProducedChars.Equal}`,
+      `${Mod.Meta}.${ProducedChars.Plus}`,
+      `${Mod.Meta}.${Mod.Shift}.${ProducedChars.Plus}`,
+    ],
     () => increaseFontSize(),
-    hotkeyOpts,
+    fontSizeHotkeyOpts,
   )
-  // ⌘- — decrease font size
-  useHotkeys(`${Mod.Meta}+${Keys.Minus}`, () => decreaseFontSize(), hotkeyOpts)
-  // ⌘0 — reset font size to default
+  // ⌘- — decrease font size (produced-character match, see above)
+  useHotkeys(
+    `${Mod.Meta}.${ProducedChars.Minus}`,
+    () => decreaseFontSize(),
+    fontSizeHotkeyOpts,
+  )
+  // ⌘0 — reset font size to default. Digit codes are consistent across
+  // layouts, so physical-code matching is fine here.
   useHotkeys(`${Mod.Meta}+${Keys.Digit0}`, () => resetFontSize(), hotkeyOpts)
 
   // ⌘K — clear screen + scrollback in the active terminal


### PR DESCRIPTION
## Summary

- `⌘=` / `⌘+` / `⌘-` (terminal font-size zoom) matched on `KeyboardEvent.code` (physical key position), which only lines up with `+`/`-` on a US/ANSI keyboard layout. On non-US layouts (e.g. Italian) those characters sit on entirely different physical keys, so the shortcut silently never fired there.
- Switched to react-hotkeys-hook's `useKey` mode, which matches on `KeyboardEvent.key` (the produced character) instead of physical position — same approach browsers use for their own Cmd+/Cmd- zoom. Bound all shift/character combinations (`=`, `⇧=`, `+`, `⇧+`) so it's correct regardless of whether a given layout produces `+` shifted (US) or unshifted (Italian and most European layouts).
- `⌘0` (reset) is untouched — digit codes are consistent across layouts, so it wasn't affected.
- Bumped `react-hotkeys-hook` 5.3.2 → 5.3.3 (still within the existing `^5.2.4` range in package.json). 5.3.2 has an ordering bug where a `useKey` combo with a single key matches *before* modifier checks run — so a bare `+` keystroke with no `⌘` held would also have fired the shortcut, which would be a real problem in a terminal app where `+`/`-`/`0` are typed constantly. 5.3.3 fixes the ordering (verified against the diff between the two tagged releases upstream).

## Test plan

- [x] `bun run lint` (Biome + Clippy) — clean, only pre-existing Clippy warnings
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 147 frontend tests, 43 Rust unit tests, 9 integration tests, all passing
- [x] Manually verified in `bun run tauri:dev`: font-size zoom now works correctly with an Italian keyboard layout (confirmed by the reporter, who could reproduce the original bug and confirmed the fix)