### PR TITLE
feat(settings): add Settings window with font family and size

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,11 +28,11 @@ use mod_engine::{
 use notifications::NotificationService;
 use shell_integration::setup_shell_integration;
 use tauri::Manager;
-#[cfg(all(target_os = "macos", not(feature = "dev-instance")))]
+#[cfg(target_os = "macos")]
 use tauri::Emitter;
 #[cfg(target_os = "macos")]
 use tauri::menu::{MenuBuilder, SubmenuBuilder};
-#[cfg(all(target_os = "macos", not(feature = "dev-instance")))]
+#[cfg(target_os = "macos")]
 use tauri::menu::MenuItemBuilder;
 use pty_manager::PtyMap;
 use std::collections::HashMap;
@@ -95,13 +95,16 @@ pub fn run() {
                 eprintln!("[agent-terminal] menu setup failed: {e}");
             }
 
-            // Forward the "Check for Updates…" menu click to the renderer
-            // as a `menu:check-for-updates` event. The renderer's
-            // checkForUpdate() handler drives the rest of the flow.
-            #[cfg(all(target_os = "macos", not(feature = "dev-instance")))]
+            // Forward menu clicks to the renderer as events — it owns the
+            // rest of each flow. "check-for-updates" only exists in the
+            // prod submenu (see `install_app_menu`), so it's a no-op click
+            // target in dev builds; "settings" exists in both.
+            #[cfg(target_os = "macos")]
             app.on_menu_event(|app_handle, event| {
                 if event.id() == "check-for-updates" {
                     let _ = app_handle.emit("menu:check-for-updates", ());
+                } else if event.id() == "settings" {
+                    let _ = app_handle.emit("menu:open-settings", ());
                 }
             });
 
@@ -180,6 +183,13 @@ pub fn run() {
 fn install_app_menu(
     app: &tauri::App,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // "Settings…" — unlike "Check for Updates…" below, this has no plugin
+    // dependency, so it's available in both dev and prod builds.
+    let settings_item =
+        MenuItemBuilder::with_id("settings", "Settings…")
+            .accelerator("Cmd+,")
+            .build(app)?;
+
     // "Check for Updates…" goes between About and Services in the prod
     // app menu. dev-instance builds intentionally skip it because the
     // updater plugin isn't registered in those — surfacing a menu item
@@ -191,6 +201,8 @@ fn install_app_menu(
                 .build(app)?;
         SubmenuBuilder::new(app, "Agent Terminal")
             .about(None)
+            .separator()
+            .item(&settings_item)
             .separator()
             .item(&check_for_updates)
             .separator()
@@ -207,6 +219,8 @@ fn install_app_menu(
     #[cfg(feature = "dev-instance")]
     let app_submenu = SubmenuBuilder::new(app, "Agent Terminal")
         .about(None)
+        .separator()
+        .item(&settings_item)
         .separator()
         .services()
         .separator()

--- a/src/components/SettingsDialog/FontSettingsTab.tsx
+++ b/src/components/SettingsDialog/FontSettingsTab.tsx
@@ -1,0 +1,109 @@
+import { useStore } from '@nanostores/react'
+import { ChevronDown, Minus, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+import {
+  $fontFamily,
+  FONT_FAMILY_OPTIONS,
+  setFontFamily,
+} from '@/modules/stores/$fontFamily'
+import {
+  $fontSize,
+  decreaseFontSize,
+  increaseFontSize,
+  resetFontSize,
+} from '@/modules/stores/$fontSize'
+
+export function FontSettingsTab() {
+  const fontFamily = useStore($fontFamily)
+  const fontSize = useStore($fontSize)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <Label htmlFor="settings-font-family">Font Family</Label>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={(triggerProps) => (
+              <button
+                id="settings-font-family"
+                type="button"
+                {...triggerProps}
+                className={cn(
+                  'inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-sm',
+                  triggerProps.className,
+                )}
+              >
+                {fontFamily}
+                <ChevronDown
+                  size={14}
+                  aria-hidden="true"
+                  className="shrink-0 opacity-60"
+                />
+              </button>
+            )}
+          />
+          <DropdownMenuContent align="end" className="min-w-40">
+            {FONT_FAMILY_OPTIONS.map((option) => (
+              <DropdownMenuItem
+                key={option}
+                onClick={() => setFontFamily(option)}
+                className="justify-between gap-2"
+                style={{ fontFamily: `"${option}", monospace` }}
+              >
+                {option}
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'text-foreground/70',
+                    fontFamily === option ? 'opacity-100' : 'opacity-0',
+                  )}
+                >
+                  ✓
+                </span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <Label htmlFor="settings-font-size">Font Size</Label>
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant="outline"
+            size="icon-sm"
+            aria-label="Decrease font size"
+            onClick={() => decreaseFontSize()}
+          >
+            <Minus />
+          </Button>
+          <button
+            id="settings-font-size"
+            type="button"
+            onClick={() => resetFontSize()}
+            title="Reset to default"
+            className="w-10 text-center text-muted-foreground text-sm tabular-nums hover:text-foreground"
+          >
+            {fontSize}
+          </button>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            aria-label="Increase font size"
+            onClick={() => increaseFontSize()}
+          >
+            <Plus />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SettingsDialog/SettingsDialog.tsx
+++ b/src/components/SettingsDialog/SettingsDialog.tsx
@@ -1,0 +1,42 @@
+import { useStore } from '@nanostores/react'
+import { FontSettingsTab } from '@/components/SettingsDialog/FontSettingsTab'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { $settingsOpen, closeSettings } from '@/modules/stores/$settingsOpen'
+
+/**
+ * App-wide Settings dialog. Opened via the "Settings…" app-menu item
+ * (⌘,) — see `useSettingsWiring`. Tabbed so more setting categories can
+ * be added later without restructuring; today there's only "Font".
+ */
+export function SettingsDialog() {
+  const open = useStore($settingsOpen)
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) closeSettings()
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+        </DialogHeader>
+        <Tabs defaultValue="font">
+          <TabsList>
+            <TabsTrigger value="font">Font</TabsTrigger>
+          </TabsList>
+          <TabsContent value="font">
+            <FontSettingsTab />
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/XTermTerminal/XTermTerminal.tsx
+++ b/src/components/XTermTerminal/XTermTerminal.tsx
@@ -6,11 +6,13 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { Terminal } from '@xterm/xterm'
 import React, { useEffect, useRef } from 'react'
+import { useLiveTerminalFont } from '@/components/XTermTerminal/xterm-terminal.hooks'
 import {
   createWebglLifecycle,
   type WebglLifecycle,
 } from '@/components/XTermTerminal/xterm-terminal.webgl'
 import { $activeSearch } from '@/modules/stores/$activeSearch'
+import { $fontFamily, fontFamilyStack } from '@/modules/stores/$fontFamily'
 import { $fontSize } from '@/modules/stores/$fontSize'
 
 export type XTermHandle = {
@@ -111,6 +113,7 @@ export const XTermTerminal = React.memo(function XTermTerminal({
   const searchAddonRef = useRef<SearchAddon | null>(null)
   const webglLifecycleRef = useRef<WebglLifecycle | null>(null)
   const fontSize = useStore($fontSize)
+  const fontFamily = useStore($fontFamily)
 
   // Keep callbacks + flags in refs so the mount-once effect always sees
   // the latest versions without needing to re-run when they change
@@ -145,7 +148,7 @@ export const XTermTerminal = React.memo(function XTermTerminal({
         document.documentElement.getAttribute('data-theme'),
         darkMq.matches,
       ),
-      fontFamily: '"Geist Mono", "Cascadia Code", "Fira Code", monospace',
+      fontFamily: fontFamilyStack($fontFamily.get()),
       fontSize: $fontSize.get(),
       lineHeight: 1.2,
       cursorBlink: true,
@@ -312,21 +315,14 @@ export const XTermTerminal = React.memo(function XTermTerminal({
     }
   }, [isActive])
 
-  // React to font-size changes globally. Defer fit() so the canvas
-  // re-rasterizes glyphs at the new size before recomputing cols/rows;
-  // refresh after fit because the old-size glyphs still occupy atlas
-  // slots that the visible buffer's cells point at — refresh re-resolves
-  // them at the new size.
-  useEffect(() => {
-    const term = termRef.current
-    const fit = fitAddonRef.current
-    if (!term || !fit) return
-    term.options.fontSize = fontSize
-    requestAnimationFrame(() => {
-      fit.fit()
-      if (term.rows > 0) term.refresh(0, term.rows - 1)
-    })
-  }, [fontSize])
+  // React to font-size / font-family changes globally — see
+  // `useLiveTerminalFont` for the re-rasterize rationale.
+  useLiveTerminalFont(
+    termRef.current,
+    fitAddonRef.current,
+    fontSize,
+    fontFamily,
+  )
 
   return (
     <div ref={containerRef} className={className ?? 'h-full min-h-0 w-full'} />

--- a/src/components/XTermTerminal/xterm-terminal.hooks.ts
+++ b/src/components/XTermTerminal/xterm-terminal.hooks.ts
@@ -1,0 +1,43 @@
+import type { FitAddon } from '@xterm/addon-fit'
+import type { Terminal } from '@xterm/xterm'
+import { useEffect } from 'react'
+import {
+  type FontFamilyOption,
+  fontFamilyStack,
+} from '@/modules/stores/$fontFamily'
+
+/**
+ * Applies live font-size / font-family changes to an already-mounted
+ * terminal. Defers `fit()` so the canvas re-rasterizes glyphs at the new
+ * metrics before recomputing cols/rows; `refresh()` runs after `fit()`
+ * because the old-metric glyphs still occupy atlas slots that the visible
+ * buffer's cells point at — refresh re-resolves them at the new metrics.
+ *
+ * Takes the live `term`/`fit` instances (not refs) so they're proper
+ * effect dependencies — the caller reads them from its own refs, which
+ * are already populated by the time font settings can change.
+ */
+export function useLiveTerminalFont(
+  term: Terminal | null,
+  fit: FitAddon | null,
+  fontSize: number,
+  fontFamily: FontFamilyOption,
+): void {
+  useEffect(() => {
+    if (!term || !fit) return
+    term.options.fontSize = fontSize
+    requestAnimationFrame(() => {
+      fit.fit()
+      if (term.rows > 0) term.refresh(0, term.rows - 1)
+    })
+  }, [term, fit, fontSize])
+
+  useEffect(() => {
+    if (!term || !fit) return
+    term.options.fontFamily = fontFamilyStack(fontFamily)
+    requestAnimationFrame(() => {
+      fit.fit()
+      if (term.rows > 0) term.refresh(0, term.rows - 1)
+    })
+  }, [term, fit, fontFamily])
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { Tabs as TabsPrimitive } from '@base-ui/react/tabs'
+import { cn } from '@/lib/utils'
+
+function Tabs({ className, ...props }: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn('flex flex-col gap-3', className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        'inline-flex w-fit items-center gap-1 rounded-lg bg-muted p-1 text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        'inline-flex items-center justify-center rounded-md px-2.5 py-1 font-medium text-sm outline-none transition-colors data-active:bg-background data-active:text-foreground data-active:shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn('outline-none', className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsContent, TabsList, TabsTrigger }

--- a/src/modules/settings/useSettingsWiring.ts
+++ b/src/modules/settings/useSettingsWiring.ts
@@ -1,0 +1,19 @@
+import { listen } from '@tauri-apps/api/event'
+import { useEffect } from 'react'
+import { openSettings } from '@/modules/stores/$settingsOpen'
+
+/**
+ * Wires the renderer side of the Settings flow: listens for the
+ * "Settings…" app-menu item's `menu:open-settings` event and opens the
+ * Settings dialog in response.
+ */
+export function useSettingsWiring(): void {
+  useEffect(() => {
+    const unlistenPromise = listen('menu:open-settings', () => {
+      openSettings()
+    })
+    return () => {
+      unlistenPromise.then((fn) => fn()).catch(() => {})
+    }
+  }, [])
+}

--- a/src/modules/stores/$fontFamily.test.ts
+++ b/src/modules/stores/$fontFamily.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import {
+  $fontFamily,
+  FONT_FAMILY_OPTIONS,
+  fontFamilyStack,
+  setFontFamily,
+} from '@/modules/stores/$fontFamily'
+
+function installDomStubs() {
+  const store = new Map<string, string>()
+  const localStorageStub = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => store.clear(),
+    key: () => null,
+    length: 0,
+  } as Storage
+  ;(globalThis as typeof globalThis & { localStorage: Storage }).localStorage =
+    localStorageStub
+  // `$fontFamily`'s persistence guard checks `typeof window !== 'undefined'`
+  // (matching `$fontSize.ts`) — bun:test has no `window` global by default.
+  ;(
+    globalThis as typeof globalThis & { window: { localStorage: Storage } }
+  ).window = { localStorage: localStorageStub }
+  return store
+}
+
+beforeEach(() => {
+  $fontFamily.set('Geist Mono')
+  installDomStubs()
+})
+
+describe('font family store', () => {
+  test('setFontFamily updates the store and persists to localStorage', () => {
+    setFontFamily('JetBrains Mono')
+
+    expect($fontFamily.get()).toBe('JetBrains Mono')
+    expect(localStorage.getItem('agent-terminal:font-family')).toBe(
+      'JetBrains Mono',
+    )
+  })
+
+  test('FONT_FAMILY_OPTIONS includes the bundled default font', () => {
+    expect(FONT_FAMILY_OPTIONS).toContain('Geist Mono')
+  })
+
+  test('fontFamilyStack appends a generic monospace fallback', () => {
+    expect(fontFamilyStack('Fira Code')).toBe('"Fira Code", monospace')
+  })
+})

--- a/src/modules/stores/$fontFamily.ts
+++ b/src/modules/stores/$fontFamily.ts
@@ -1,0 +1,52 @@
+import { atom } from 'nanostores'
+
+const STORAGE_KEY = 'agent-terminal:font-family'
+
+/**
+ * Curated list of well-known monospace/programming fonts. "Geist Mono" is
+ * bundled with the app (`@fontsource-variable/geist`); the rest are common
+ * system/developer fonts users are likely to already have installed —
+ * `fontFamilyStack` falls back to the browser's generic `monospace` if the
+ * chosen one isn't present.
+ */
+export const FONT_FAMILY_OPTIONS = [
+  'Geist Mono',
+  'Menlo',
+  'Monaco',
+  'SF Mono',
+  'Cascadia Code',
+  'Fira Code',
+  'JetBrains Mono',
+  'Courier New',
+] as const
+
+export type FontFamilyOption = (typeof FONT_FAMILY_OPTIONS)[number]
+
+const DEFAULT: FontFamilyOption = 'Geist Mono'
+
+function isFontFamilyOption(value: string): value is FontFamilyOption {
+  return (FONT_FAMILY_OPTIONS as readonly string[]).includes(value)
+}
+
+function readPersisted(): FontFamilyOption {
+  if (typeof window === 'undefined') return DEFAULT
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  return raw !== null && isFontFamilyOption(raw) ? raw : DEFAULT
+}
+
+export const $fontFamily = atom<FontFamilyOption>(readPersisted())
+
+$fontFamily.subscribe((value) => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, value)
+  }
+})
+
+export function setFontFamily(value: FontFamilyOption): void {
+  $fontFamily.set(value)
+}
+
+/** CSS font-family stack: chosen font first, generic monospace fallback last. */
+export function fontFamilyStack(value: FontFamilyOption): string {
+  return `"${value}", monospace`
+}

--- a/src/modules/stores/$settingsOpen.ts
+++ b/src/modules/stores/$settingsOpen.ts
@@ -1,0 +1,16 @@
+import { atom } from 'nanostores'
+
+/**
+ * Drives the Settings dialog's open/closed state. Toggled by the
+ * "Settings…" app-menu item (via `useSettingsWiring`) and by the dialog's
+ * own close affordances (Escape, backdrop click, close button).
+ */
+export const $settingsOpen = atom<boolean>(false)
+
+export function openSettings(): void {
+  $settingsOpen.set(true)
+}
+
+export function closeSettings(): void {
+  $settingsOpen.set(false)
+}

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { getCurrentWebview } from '@tauri-apps/api/webview'
 import { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
+import { SettingsDialog } from '@/components/SettingsDialog/SettingsDialog'
 import { Sidebar } from '@/components/Sidebar/Sidebar'
 import { StatusBar } from '@/components/StatusBar/StatusBar'
 import { TabSwitcher } from '@/components/TabSwitcher/TabSwitcher'
@@ -9,6 +10,7 @@ import { TerminalSearchBar } from '@/components/TerminalSearchBar/TerminalSearch
 import { UpdateBanner } from '@/components/UpdateBanner/UpdateBanner'
 import { formatDropPayload } from '@/modules/dragDrop/dropPayload'
 import { Keys, Mod } from '@/modules/keymap/keys'
+import { useSettingsWiring } from '@/modules/settings/useSettingsWiring'
 import { $activeSearch, openSearch } from '@/modules/stores/$activeSearch'
 import { getActiveTerminalHandle } from '@/modules/stores/$activeTerminal'
 import { popClosedTab } from '@/modules/stores/$closedTabs'
@@ -87,6 +89,7 @@ export function WorkspaceLayout() {
   }, [])
 
   useUpdaterWiring()
+  useSettingsWiring()
 
   // enableOnFormTags is required because xterm uses a hidden <textarea> to
   // capture keyboard input. Without it react-hotkeys-hook silently ignores
@@ -291,6 +294,8 @@ export function WorkspaceLayout() {
       <UpdateBanner />
       {/* Self-contained: owns its open state + Cmd+P hotkey. */}
       <TabSwitcher />
+      {/* Self-contained: owns its open state via $settingsOpen. */}
+      <SettingsDialog />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Adds a Settings dialog, opened via a new "Settings…" item in the "Agent Terminal" app menu (`⌘,`), with a tabbed layout so more setting categories can be added later — starting with one "Font" tab.
- Font family is now user-adjustable (was hardcoded in `XTermTerminal.tsx`) via a curated list of common monospace fonts (`Geist Mono`, `Menlo`, `Monaco`, `SF Mono`, `Cascadia Code`, `Fira Code`, `JetBrains Mono`, `Courier New`), persisted the same way font size already is.
- Font size lives in the same tab, reusing the existing `increaseFontSize`/`decreaseFontSize`/`resetFontSize` from `$fontSize.ts` — no new sizing logic.
- Both settings apply live to every open terminal tab/pane, and persist across restarts.

### Design notes

- Went with an in-app modal `Dialog` rather than a second OS window — the app is single-window end to end (no `WebviewWindowBuilder` usage anywhere, one window in `tauri.conf.json`), so a second window would mean net-new Rust window creation, a second frontend entry point, and cross-window nanostore sync for what's currently two fields. The existing `Dialog` primitive is already the established pattern for app-level overlays (`TerminalSearchBar`, `TabSwitcher`).
- The Settings menu item is wired through the same Tauri-menu-event-to-frontend bridge already used for "Check for Updates…" (`menu:open-settings` → `useSettingsWiring`), and is available in both dev and prod builds (unlike "Check for Updates…", it has no plugin dependency).
- Added a `Tabs` UI primitive (`src/components/ui/tabs.tsx`), base-ui-backed, following the same wrapping conventions as the existing `dialog.tsx`.
- Font-family picker reuses the exact `DropdownMenu`-of-options + checkmark pattern already established by `ThemeToggle`.
- Extracted the terminal's live font-size/font-family sync effects into `xterm-terminal.hooks.ts` (`useLiveTerminalFont`) to keep `XTermTerminal.tsx` under Biome's per-file line limit — same satellite-file convention as the existing `xterm-terminal.keys.ts`/`.webgl.ts`/`.themes.ts`.

## Test plan

- [x] `bun run lint` (Biome + Clippy) — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 150 frontend tests (147 existing + 3 new for `$fontFamily`), 43 Rust unit tests, 9 integration tests, all passing
- [x] `cargo check` with and without `--features dev-instance` — both compile (menu/event-bridge cfg gating touches both build variants)
- [x] Manually verified in `bun run tauri:dev`: Settings opens via the app menu and `⌘,`, font family and font size both update the active terminal live, both persist across app restart, and a font-family change applies to all open tabs/panes at once