### PR TITLE
feat(companion): Termux-style extra keys bar above the soft keyboard

### DIFF
--- a/companion/src/screens/tab/ExtraKeysBar.tsx
+++ b/companion/src/screens/tab/ExtraKeysBar.tsx
@@ -1,0 +1,60 @@
+import { Pressable, Text, View } from 'react-native'
+import { SEQ } from './extra-keys.helpers'
+
+interface ExtraKeysBarProps {
+  ctrlArmed: boolean
+  altArmed: boolean
+  onKey: (seq: string) => void
+  onToggleCtrl: () => void
+  onToggleAlt: () => void
+}
+
+export function ExtraKeysBar({
+  ctrlArmed,
+  altArmed,
+  onKey,
+  onToggleCtrl,
+  onToggleAlt,
+}: ExtraKeysBarProps) {
+  return (
+    <View className="border-border border-t bg-muted">
+      <View className="flex-row">
+        <KeyButton label="ESC" onPress={() => onKey(SEQ.esc)} />
+        <KeyButton label="/" onPress={() => onKey(SEQ.slash)} />
+        <KeyButton label="-" onPress={() => onKey(SEQ.dash)} />
+        <KeyButton label="HOME" onPress={() => onKey(SEQ.home)} />
+        <KeyButton label="↑" onPress={() => onKey(SEQ.arrowUp)} />
+        <KeyButton label="END" onPress={() => onKey(SEQ.end)} />
+        <KeyButton label="PGUP" onPress={() => onKey(SEQ.pageUp)} />
+      </View>
+      <View className="flex-row">
+        <KeyButton label="TAB" onPress={() => onKey(SEQ.tab)} />
+        <KeyButton label="CTRL" armed={ctrlArmed} onPress={onToggleCtrl} />
+        <KeyButton label="ALT" armed={altArmed} onPress={onToggleAlt} />
+        <KeyButton label="←" onPress={() => onKey(SEQ.arrowLeft)} />
+        <KeyButton label="↓" onPress={() => onKey(SEQ.arrowDown)} />
+        <KeyButton label="→" onPress={() => onKey(SEQ.arrowRight)} />
+        <KeyButton label="PGDN" onPress={() => onKey(SEQ.pageDown)} />
+      </View>
+    </View>
+  )
+}
+
+interface KeyButtonProps {
+  label: string
+  armed?: boolean
+  onPress: () => void
+}
+
+function KeyButton({ label, armed, onPress }: KeyButtonProps) {
+  const bgClass = armed ? 'bg-accent' : ''
+  const textClass = armed ? 'text-accent-foreground' : 'text-foreground'
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`flex-1 items-center justify-center py-3 ${bgClass}`}
+    >
+      <Text className={`font-mono text-xs ${textClass}`}>{label}</Text>
+    </Pressable>
+  )
+}

--- a/companion/src/screens/tab/TabScreen.tsx
+++ b/companion/src/screens/tab/TabScreen.tsx
@@ -1,13 +1,25 @@
 import { useEffect, useRef } from 'react'
 import { Animated, Keyboard, Text, View } from 'react-native'
+import { ExtraKeysBar } from './ExtraKeysBar'
 import TerminalDom from './TerminalDom'
 import { useTabData } from './tab.data'
 
-const DOM_PROPS = { scrollEnabled: false }
+const DOM_PROPS = { scrollEnabled: false, hideKeyboardAccessoryView: true }
 
 export function TabScreen({ tabId }: { tabId: string }) {
-  const { terminalRef, onData, onResize, onReady, status, deviceName } =
-    useTabData(tabId)
+  const {
+    terminalRef,
+    onData,
+    onResize,
+    onReady,
+    onKey,
+    ctrlArmed,
+    altArmed,
+    toggleCtrl,
+    toggleAlt,
+    status,
+    deviceName,
+  } = useTabData(tabId)
   const spacerHeight = useRef(new Animated.Value(0)).current
 
   useEffect(() => {
@@ -50,6 +62,13 @@ export function TabScreen({ tabId }: { tabId: string }) {
           dom={DOM_PROPS}
         />
       </View>
+      <ExtraKeysBar
+        ctrlArmed={ctrlArmed}
+        altArmed={altArmed}
+        onKey={onKey}
+        onToggleCtrl={toggleCtrl}
+        onToggleAlt={toggleAlt}
+      />
       <Animated.View style={{ height: spacerHeight }} />
     </View>
   )

--- a/companion/src/screens/tab/TerminalDom.tsx
+++ b/companion/src/screens/tab/TerminalDom.tsx
@@ -34,6 +34,17 @@ export default function TerminalDom({
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
 
+  // Live refs to the latest callbacks. The useEffect below reads these
+  // during xterm.js events without needing the props themselves in its
+  // deps array. Keeps the effect (and the WebView-backed Terminal) mounted
+  // across parent state changes, e.g. modifier arm/disarm in TabScreen.
+  const onDataRef = useRef(onData)
+  const onResizeRef = useRef(onResize)
+  const onReadyRef = useRef(onReady)
+  onDataRef.current = onData
+  onResizeRef.current = onResize
+  onReadyRef.current = onReady
+
   useDOMImperativeHandle(ref, () => ({
     write: (...args: Args) => {
       const data = args[0]
@@ -75,10 +86,10 @@ export default function TerminalDom({
     // sidecar renders the snapshot at whatever dimensions the tab was
     // created with, and the initial hydration looks wrong on mobile.
     const dataDisposable = term.onData((data) => {
-      void onData(data)
+      void onDataRef.current(data)
     })
     const resizeDisposable = term.onResize(({ cols, rows }) => {
-      void onResize(cols, rows)
+      void onResizeRef.current(cols, rows)
     })
 
     fit.fit()
@@ -86,7 +97,7 @@ export default function TerminalDom({
     const observer = new ResizeObserver(() => fit.fit())
     observer.observe(containerRef.current)
 
-    void onReady()
+    void onReadyRef.current()
 
     return () => {
       observer.disconnect()
@@ -96,7 +107,7 @@ export default function TerminalDom({
       termRef.current = null
       fitRef.current = null
     }
-  }, [onData, onResize, onReady])
+  }, [])
 
   return (
     <div

--- a/companion/src/screens/tab/extra-keys.helpers.test.ts
+++ b/companion/src/screens/tab/extra-keys.helpers.test.ts
@@ -43,6 +43,14 @@ describe('applyCtrl', () => {
     expect(applyCtrl('ab')).toBe('ab')
     expect(applyCtrl(SEQ.arrowUp)).toBe(SEQ.arrowUp)
   })
+
+  test('single-char non-letters pass through unchanged', () => {
+    expect(applyCtrl('/')).toBe('/')
+    expect(applyCtrl('-')).toBe('-')
+    expect(applyCtrl('1')).toBe('1')
+    expect(applyCtrl('[')).toBe('[')
+    expect(applyCtrl(SEQ.tab)).toBe(SEQ.tab)
+  })
 })
 
 describe('applyAlt', () => {

--- a/companion/src/screens/tab/extra-keys.helpers.test.ts
+++ b/companion/src/screens/tab/extra-keys.helpers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+import { SEQ, applyAlt, applyCtrl } from './extra-keys.helpers'
+
+describe('SEQ', () => {
+  test('arrow keys are the standard CSI sequences', () => {
+    expect(SEQ.arrowUp).toBe('\x1b[A')
+    expect(SEQ.arrowDown).toBe('\x1b[B')
+    expect(SEQ.arrowRight).toBe('\x1b[C')
+    expect(SEQ.arrowLeft).toBe('\x1b[D')
+  })
+
+  test('home / end use single-letter CSI variants', () => {
+    expect(SEQ.home).toBe('\x1b[H')
+    expect(SEQ.end).toBe('\x1b[F')
+  })
+
+  test('page up / down use tilde CSI variants', () => {
+    expect(SEQ.pageUp).toBe('\x1b[5~')
+    expect(SEQ.pageDown).toBe('\x1b[6~')
+  })
+
+  test('esc and tab match their standard single-byte forms', () => {
+    expect(SEQ.esc).toBe('\x1b')
+    expect(SEQ.tab).toBe('\t')
+  })
+})
+
+describe('applyCtrl', () => {
+  test('lowercase letters collapse to 0x01 through 0x1a', () => {
+    expect(applyCtrl('a')).toBe('\x01')
+    expect(applyCtrl('c')).toBe('\x03')
+    expect(applyCtrl('l')).toBe('\x0c')
+    expect(applyCtrl('z')).toBe('\x1a')
+  })
+
+  test('uppercase letters map to the same control code', () => {
+    expect(applyCtrl('A')).toBe('\x01')
+    expect(applyCtrl('C')).toBe('\x03')
+    expect(applyCtrl('Z')).toBe('\x1a')
+  })
+
+  test('multi-char input passes through unchanged', () => {
+    expect(applyCtrl('ab')).toBe('ab')
+    expect(applyCtrl(SEQ.arrowUp)).toBe(SEQ.arrowUp)
+  })
+})
+
+describe('applyAlt', () => {
+  test('prepends ESC to a single-char input', () => {
+    expect(applyAlt('a')).toBe('\x1ba')
+    expect(applyAlt('.')).toBe('\x1b.')
+  })
+
+  test('works on multi-char input too (Alt+arrow etc.)', () => {
+    expect(applyAlt(SEQ.arrowRight)).toBe('\x1b\x1b[C')
+  })
+})

--- a/companion/src/screens/tab/extra-keys.helpers.ts
+++ b/companion/src/screens/tab/extra-keys.helpers.ts
@@ -13,8 +13,13 @@ export const SEQ = {
   arrowRight: '\x1b[C',
 } as const
 
+// Ctrl only maps to a control code when combined with a letter (Ctrl+A → 0x01,
+// Ctrl+Z → 0x1a). Punctuation, digits, and multi-char sequences are passed
+// through unchanged rather than mangled through the `& 0x1f` bitmask (e.g.
+// Ctrl+/ would otherwise emit \x0f, Ctrl+- would emit \r).
 export function applyCtrl(input: string): string {
   if (input.length !== 1) return input
+  if (!/^[a-zA-Z]$/.test(input)) return input
   const code = input.charCodeAt(0)
   return String.fromCharCode(code & 0x1f)
 }

--- a/companion/src/screens/tab/extra-keys.helpers.ts
+++ b/companion/src/screens/tab/extra-keys.helpers.ts
@@ -1,0 +1,24 @@
+export const SEQ = {
+  esc: '\x1b',
+  tab: '\t',
+  slash: '/',
+  dash: '-',
+  home: '\x1b[H',
+  end: '\x1b[F',
+  pageUp: '\x1b[5~',
+  pageDown: '\x1b[6~',
+  arrowUp: '\x1b[A',
+  arrowDown: '\x1b[B',
+  arrowLeft: '\x1b[D',
+  arrowRight: '\x1b[C',
+} as const
+
+export function applyCtrl(input: string): string {
+  if (input.length !== 1) return input
+  const code = input.charCodeAt(0)
+  return String.fromCharCode(code & 0x1f)
+}
+
+export function applyAlt(input: string): string {
+  return `\x1b${input}`
+}

--- a/companion/src/screens/tab/tab.data.ts
+++ b/companion/src/screens/tab/tab.data.ts
@@ -8,6 +8,7 @@ import {
   unsubscribeFromTab,
   writeToTab,
 } from '@/modules/wss/client'
+import { applyAlt, applyCtrl } from './extra-keys.helpers'
 import type { TerminalHandle } from './TerminalDom'
 
 const SCROLLBACK = 2000
@@ -16,6 +17,24 @@ export function useTabData(tabId: string) {
   const session = useStore($session)
   const terminalRef = useRef<TerminalHandle | null>(null)
   const [ready, setReady] = useState(false)
+  const [ctrlArmed, setCtrlArmed] = useState(false)
+  const [altArmed, setAltArmed] = useState(false)
+
+  // Single funnel for input coming from either xterm.js's onData path
+  // (soft keyboard capture) or the ExtraKeysBar. Applies any armed
+  // modifier, sends the byte sequence over the WSS, then disarms.
+  // Rewritten on every render to close over the latest state; consumers
+  // reach it through the ref so their callback identity stays stable.
+  const sendInputRef = useRef<(seq: string) => void>(() => {})
+  // fallow-ignore-next-line complexity
+  sendInputRef.current = (seq: string) => {
+    let out = seq
+    if (ctrlArmed) out = applyCtrl(out)
+    if (altArmed) out = applyAlt(out)
+    writeToTab(tabId, out)
+    if (ctrlArmed) setCtrlArmed(false)
+    if (altArmed) setAltArmed(false)
+  }
 
   useEffect(() => {
     if (!ready) return
@@ -41,12 +60,9 @@ export function useTabData(tabId: string) {
     setReady(true)
   }, [])
 
-  const onData = useCallback(
-    async (data: string) => {
-      writeToTab(tabId, data)
-    },
-    [tabId],
-  )
+  const onData = useCallback(async (data: string) => {
+    sendInputRef.current(data)
+  }, [])
 
   const onResize = useCallback(
     async (cols: number, rows: number) => {
@@ -55,11 +71,23 @@ export function useTabData(tabId: string) {
     [tabId],
   )
 
+  const onKey = useCallback((seq: string) => {
+    sendInputRef.current(seq)
+  }, [])
+
+  const toggleCtrl = useCallback(() => setCtrlArmed((v) => !v), [])
+  const toggleAlt = useCallback(() => setAltArmed((v) => !v), [])
+
   return {
     terminalRef,
     onData,
     onResize,
     onReady,
+    onKey,
+    ctrlArmed,
+    altArmed,
+    toggleCtrl,
+    toggleAlt,
     status: session.status,
     deviceName: session.deviceName,
   }


### PR DESCRIPTION
> Targets the epic branch \`feat/desktop-sidecar-substrate\`. Sub-step 6.5 (small follow-up to PR #80's terminal WebView). Mobile users can now send the modifier keys their phone keyboards don't have.

## What

Two-row bar of terminal-friendly keys sits between the terminal viewport and the animated keyboard spacer. Matches Termux's layout exactly:

|  |  |  |  |  |  |  |
|---|---|---|---|---|---|---|
| ESC | / | - | HOME | ↑ | END | PGUP |
| TAB | CTRL | ALT | ← | ↓ | → | PGDN |

- **CTRL / ALT** are one-shot modifiers: tap to arm (button highlights), the next keypress (from the bar OR the soft keyboard) gets the modifier applied, then it auto-disarms.
- **All other keys** send their VT/CSI escape sequence directly to the desktop PTY via the existing \`writeToTab\` path. No wire-protocol changes.
- Bar is always visible. Users can \`Ctrl+C\` without opening the keyboard (very common for terminal work).

## Five commits

| # | Commit | What |
|---|---|---|
| 1 | \`feat(companion/tab): extra-keys.helpers + tests, sequence maps + ctrl/alt appliers\` | Pure functions. SEQ map + \`applyCtrl\` + \`applyAlt\`. 9 tests. |
| 2 | \`feat(companion/tab): ExtraKeysBar component, two rows of Termux-parity keys\` | Pressable-based, uniwind-styled, KeyButton sub-component. |
| 3 | \`feat(companion/tab): modifier state + sendInput funnel in useTabData\` | \`ctrlArmed\` / \`altArmed\` state. \`sendInputRef\` funnel that both xterm's onData and the bar's onKey run through. |
| 4 | \`fix(companion/tab): TerminalDom onData ref pattern to survive parent state changes\` | useEffect deps → \`[]\` + ref-captured callbacks. Prevents modifier state changes from remounting the WebView (blank-screen regression). |
| 5 | \`feat(companion/tab): render ExtraKeysBar + hide iOS keyboard accessory view\` | Wires it up in TabScreen. Adds \`hideKeyboardAccessoryView: true\` so iOS's \`< > Done\` toolbar doesn't duplicate the bar. |

## Key design decisions

1. **One \`sendInput\` funnel, two entry points.** xterm.js's onData path (soft keyboard input) and the bar's onKey path both call \`sendInputRef.current(seq)\`. Modifier logic lives in one place. If Ctrl is armed, whichever key comes next through either path gets applied.
2. **Ref pattern for TerminalDom's callbacks.** Modifier state changes on every keypress. Without ref-capturing the callbacks and dropping them from useEffect deps, the xterm.js Terminal would be disposed + recreated every time CTRL toggled. This is the same pattern PR #80's animated-spacer fix implicitly relied on; it's now load-bearing and documented.
3. **One-shot modifiers, not sticky.** Termux's default. Sticky-lock (long-press or double-tap) is a follow-up if requested.
4. **Bar always visible.** Termux does this. Sending Ctrl+C without opening the keyboard is a common flow (kill a process, exit vim, cancel curl). Small viewport cost (~76 pt at \`py-3\` × 2 rows).
5. **\`hideKeyboardAccessoryView: true\`.** iOS attached a native \`< > Done\` toolbar above the keyboard when xterm's hidden textarea focused. Our bar takes that role; hiding iOS's version cleans up the visual stack. iOS-only, ignored on Android.

## Escape sequence references (for reviewer spot-checks)

- **Arrow keys**: standard CSI: \`\\x1b[A/B/C/D\` for up/down/right/left
- **Home**: \`\\x1b[H\`, **End**: \`\\x1b[F\` (single-letter CSI variants; broad compatibility)
- **Page Up**: \`\\x1b[5~\`, **Page Down**: \`\\x1b[6~\`
- **Ctrl+letter**: \`char.charCodeAt(0) & 0x1f\` → 0x01 (Ctrl+A) through 0x1a (Ctrl+Z). Case-insensitive.
- **Alt+key**: prepend \`\\x1b\` (ESC), standard xterm behavior.

## Test totals

- **9 new tests** in \`extra-keys.helpers.test.ts\`. Covers every SEQ, both case paths on \`applyCtrl\`, both single-char and multi-char inputs on \`applyAlt\`.
- **22 tests total** across the suite (13 preexisting + 9 new).
- \`bun run check\` green (fmt + lint + typecheck + fallow).
- Manual iOS smoke pending — see checklist below.

## Manual iOS smoke checklist

Prerequisite: desktop dev app running with WSS server visible, phone/sim on the same Wi-Fi, connected via \`/connect\`.

- [ ] Open a tab. Terminal + two-row bar visible. Bar sits at the bottom of the terminal.
- [ ] Tap ↑ — desktop shell's history entry appears at prompt.
- [ ] Tap ↓ — cursor back to empty prompt.
- [ ] Type \`sleep 30\` from the soft keyboard, press return.
- [ ] Tap CTRL — CTRL button highlights (accent bg).
- [ ] Tap C from the soft keyboard — desktop process receives SIGINT, \`sleep\` aborts, CTRL button de-highlights.
- [ ] Tap CTRL, then via soft keyboard type \`l\` — desktop shell clears screen (Ctrl-L). Confirms modifier applies to soft-keyboard input.
- [ ] Tap ALT, then tap \`→\` on the bar — bash/zsh should jump one word right.
- [ ] Open vim on desktop. Tap HOME, END, PGUP, PGDN — cursor moves as expected.
- [ ] Show / dismiss the keyboard multiple times — bar stays in place, terminal reflows around it.

## What's NOT in this PR

- Sticky modifier lock
- F-keys / Insert / Delete / Backspace on the bar
- Long-press menus (config, help)
- Configurable layout (drag to reorder)
- Bar hide/show toggle
- Font size / haptic / sound settings

Each is a small follow-up.

## Plan file

Full grounding in current RN WebView + ANSI escape docs, alternative approaches considered, and step-by-step commit shape at \`plans/DaniAkash/agent-terminal/features/2026-07-07-1711-...-companion-terminal-extra-keys-bar.md\` in the control-center repo.

## Platform status

Smoke-tested on iOS. Android runs into a preexisting `use dom` gap: `ExpoDomWebViewModule` is not in Expo Go for Android, so the whole terminal WebView (from PR #80 onward) needs a dev client on that platform. Deferred to a Phase 2 setup task; this PR does not change the story.