### PR TITLE
feat(companion): Android terminal via raw react-native-webview + xterm.js from unpkg

### DIFF
--- a/companion/.fallowrc.jsonc
+++ b/companion/.fallowrc.jsonc
@@ -4,7 +4,14 @@
   // here for generated wire-protocol bindings that don't have a consumer
   // yet. The WSS client sub-step introduces the first import; when that
   // lands, this entry can go away.
-  "dynamicallyLoaded": ["src/modules/wss/protocol.gen.ts"],
+  "dynamicallyLoaded": [
+    "src/modules/wss/protocol.gen.ts",
+    // Metro's platform resolution picks TerminalDom.android.tsx on Android
+    // and TerminalDom.tsx on iOS/fallback. Fallow's import graph doesn't
+    // model the platform split, so it flags the iOS file as unreachable.
+    // Both are legitimate consumers.
+    "src/screens/tab/TerminalDom.tsx"
+  ],
   // react-native-web is required by expo/dom's `.web.tsx` files that
   // Metro pulls in when bundling `'use dom'` components. No source
   // file directly imports it; the bundler wires it transparently.

--- a/companion/bun.lock
+++ b/companion/bun.lock
@@ -27,6 +27,7 @@
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
         "react-native-web": "^0.21.2",
+        "react-native-webview": "13.16.1",
         "tailwindcss": "^4.3.1",
         "uniwind": "^1.9.0",
         "zod": "^4.4.3",
@@ -1223,6 +1224,8 @@
     "react-native-screens": ["react-native-screens@4.25.2", "", { "dependencies": { "react-freeze": "^1.0.0", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": ">=0.82.0" } }, "sha512-1Nj1fusFd+rIMKU/qC9yGKVG+3ofh11d3OdBQKL1iVvQfKvcB8vhvTGQf2TkfxW3bamxN+hCZIXmNuU0mRkyDg=="],
 
     "react-native-web": ["react-native-web@0.21.2", "", { "dependencies": { "@babel/runtime": "^7.18.6", "@react-native/normalize-colors": "^0.74.1", "fbjs": "^3.0.4", "inline-style-prefixer": "^7.0.1", "memoize-one": "^6.0.0", "nullthrows": "^1.1.1", "postcss-value-parser": "^4.2.0", "styleq": "^0.1.3" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg=="],
+
+    "react-native-webview": ["react-native-webview@13.16.1", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "invariant": "2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw=="],
 
     "react-native-worklets": ["react-native-worklets@0.10.0", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.28.6", "@babel/plugin-transform-classes": "^7.28.6", "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6", "@babel/plugin-transform-optional-chaining": "^7.28.6", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.28.5", "@babel/types": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.4" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.83 - 0.86" } }, "sha512-JhE6IxDf6iabC0qu3+TAKA4v9RlluXmoIngPQX7/QUByf75lfrsHZ6/dQhyjEWnp1EEQiwzz8Cpew140ZcewDw=="],
 

--- a/companion/package.json
+++ b/companion/package.json
@@ -25,6 +25,7 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-web": "^0.21.2",
+    "react-native-webview": "13.16.1",
     "tailwindcss": "^4.3.1",
     "uniwind": "^1.9.0",
     "zod": "^4.4.3"

--- a/companion/src/screens/tab/TabScreen.tsx
+++ b/companion/src/screens/tab/TabScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
-import { Animated, Keyboard, Text, View } from 'react-native'
+import { Animated, Keyboard, Platform, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { ExtraKeysBar } from './ExtraKeysBar'
 import TerminalDom from './TerminalDom'
 import { useTabData } from './tab.data'
@@ -21,14 +22,24 @@ export function TabScreen({ tabId }: { tabId: string }) {
     deviceName,
   } = useTabData(tabId)
   const spacerHeight = useRef(new Animated.Value(0)).current
+  const insets = useSafeAreaInsets()
 
   useEffect(() => {
     // Animated.Value updates the native view's height directly, no React
     // re-render. Prevents the WebView from being torn down / losing focus
     // when the keyboard shows.
+    //
+    // Android: `endCoordinates.height` from RN's Keyboard event often
+    // reports the keyboard portion WITHOUT the OS navigation bar area at
+    // the bottom of the display. Add insets.bottom on Android to cover
+    // the gesture / three-button strip, so the ExtraKeysBar rides above
+    // the keyboard AND clears the nav bar. iOS's keyboard height already
+    // accounts for the home indicator, so this correction is a no-op
+    // there (insets.bottom is folded into endCoordinates.height on iOS).
+    const androidBottomPad = Platform.OS === 'android' ? insets.bottom : 0
     const show = Keyboard.addListener('keyboardDidShow', (e) => {
       Animated.timing(spacerHeight, {
-        toValue: e.endCoordinates.height,
+        toValue: e.endCoordinates.height + androidBottomPad,
         duration: 250,
         useNativeDriver: false,
       }).start()
@@ -44,7 +55,7 @@ export function TabScreen({ tabId }: { tabId: string }) {
       show.remove()
       hide.remove()
     }
-  }, [spacerHeight])
+  }, [spacerHeight, insets.bottom])
 
   return (
     <View className="flex-1 bg-background">

--- a/companion/src/screens/tab/TerminalDom.android.tsx
+++ b/companion/src/screens/tab/TerminalDom.android.tsx
@@ -1,0 +1,130 @@
+import type { Ref } from 'react'
+import { useImperativeHandle, useRef } from 'react'
+import type { WebViewMessageEvent } from 'react-native-webview'
+import { WebView } from 'react-native-webview'
+import {
+  DEFAULT_TERMINAL_HTML_CONFIG,
+  buildTerminalHtml,
+} from './terminal-html.helpers'
+
+// Mirrors TerminalDom.tsx's imperative surface. Different underlying
+// transport (native WebView vs Expo DOM Component), same public shape
+// so TabScreen doesn't need per-platform logic.
+export interface TerminalHandle {
+  write: (data: string) => void
+  clear: () => void
+  fit: () => void
+}
+
+interface TerminalDomProps {
+  onData: (data: string) => Promise<void>
+  onResize: (cols: number, rows: number) => Promise<void>
+  onReady: () => Promise<void>
+  ref: Ref<TerminalHandle>
+  // Accepted for shape parity with iOS. Only scrollEnabled is honoured
+  // here; hideKeyboardAccessoryView is iOS-only and ignored on Android.
+  dom?: { scrollEnabled?: boolean; hideKeyboardAccessoryView?: boolean }
+}
+
+const HTML = buildTerminalHtml(DEFAULT_TERMINAL_HTML_CONFIG)
+
+type BridgeMessage =
+  | { type: 'ready' }
+  | { type: 'data'; payload: string }
+  | { type: 'resize'; cols: number; rows: number }
+
+export default function TerminalDom({
+  onData,
+  onResize,
+  onReady,
+  ref,
+  dom,
+}: TerminalDomProps) {
+  const webviewRef = useRef<WebView | null>(null)
+  const readyRef = useRef(false)
+  const pendingWritesRef = useRef<string[]>([])
+
+  // Same ref-capture pattern as iOS. Keeps handler identity irrelevant
+  // to WebView lifecycle so parent state changes (modifier toggles from
+  // ExtraKeysBar) do not trigger unmount.
+  const onDataRef = useRef(onData)
+  const onResizeRef = useRef(onResize)
+  const onReadyRef = useRef(onReady)
+  onDataRef.current = onData
+  onResizeRef.current = onResize
+  onReadyRef.current = onReady
+
+  useImperativeHandle(ref, () => ({
+    write: (data: string) => {
+      if (!readyRef.current) {
+        pendingWritesRef.current.push(data)
+        return
+      }
+      const payload = JSON.stringify(data)
+      webviewRef.current?.injectJavaScript(
+        `window.__terminal_bridge.write(${payload}); true;`,
+      )
+    },
+    clear: () => {
+      webviewRef.current?.injectJavaScript(
+        `window.__terminal_bridge.clear(); true;`,
+      )
+    },
+    fit: () => {
+      webviewRef.current?.injectJavaScript(
+        `window.__terminal_bridge.fit(); true;`,
+      )
+    },
+  }))
+
+  function drainPendingWrites(): void {
+    const queued = pendingWritesRef.current
+    pendingWritesRef.current = []
+    for (const data of queued) {
+      const payload = JSON.stringify(data)
+      webviewRef.current?.injectJavaScript(
+        `window.__terminal_bridge.write(${payload}); true;`,
+      )
+    }
+  }
+
+  // fallow-ignore-next-line complexity
+  function handleMessage(event: WebViewMessageEvent): void {
+    let msg: BridgeMessage
+    try {
+      msg = JSON.parse(event.nativeEvent.data) as BridgeMessage
+    } catch (err) {
+      console.error('[TerminalDom.android] parse error', err)
+      return
+    }
+    if (msg.type === 'ready') {
+      readyRef.current = true
+      drainPendingWrites()
+      void onReadyRef.current()
+      return
+    }
+    if (msg.type === 'data') {
+      void onDataRef.current(msg.payload)
+      return
+    }
+    if (msg.type === 'resize') {
+      void onResizeRef.current(msg.cols, msg.rows)
+    }
+  }
+
+  return (
+    <WebView
+      ref={webviewRef}
+      source={{ html: HTML, baseUrl: 'https://unpkg.com/' }}
+      originWhitelist={['https://unpkg.com']}
+      onMessage={handleMessage}
+      onError={(e) =>
+        console.error('[TerminalDom.android] webview error', e.nativeEvent)
+      }
+      onLoadEnd={() => console.log('[TerminalDom.android] webview loaded')}
+      scrollEnabled={dom?.scrollEnabled ?? false}
+      keyboardDisplayRequiresUserAction={false}
+      androidLayerType="hardware"
+    />
+  )
+}

--- a/companion/src/screens/tab/TerminalDom.android.tsx
+++ b/companion/src/screens/tab/TerminalDom.android.tsx
@@ -32,6 +32,7 @@ type BridgeMessage =
   | { type: 'ready' }
   | { type: 'data'; payload: string }
   | { type: 'resize'; cols: number; rows: number }
+  | { type: 'error'; message: string }
 
 export default function TerminalDom({
   onData,
@@ -109,6 +110,10 @@ export default function TerminalDom({
     }
     if (msg.type === 'resize') {
       void onResizeRef.current(msg.cols, msg.rows)
+      return
+    }
+    if (msg.type === 'error') {
+      console.error('[TerminalDom.android] boot error:', msg.message)
     }
   }
 

--- a/companion/src/screens/tab/terminal-html.helpers.test.ts
+++ b/companion/src/screens/tab/terminal-html.helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   DEFAULT_TERMINAL_HTML_CONFIG,
   buildTerminalHtml,
+  safeCssColor,
 } from './terminal-html.helpers'
 
 describe('buildTerminalHtml', () => {
@@ -49,5 +50,54 @@ describe('buildTerminalHtml', () => {
     // JSON.stringify keeps the string escaped; the payload appears only
     // as a quoted string literal, never as bare JS.
     expect(evil).toContain('"red\\"; window.pwned = true; //"')
+  })
+
+  test('boot loader has a max-retry cap and posts an error on timeout', () => {
+    expect(html).toContain('BOOT_MAX_ATTEMPTS')
+    expect(html).toContain("type: 'error'")
+    expect(html).toContain('Failed to load xterm.js from unpkg')
+  })
+
+  test('CSS background falls back to safe default if the config value would break out', () => {
+    const evil = buildTerminalHtml({
+      ...DEFAULT_TERMINAL_HTML_CONFIG,
+      themeBackground: 'red; } </style><script>alert(1)</script><style>',
+    })
+    // The CSS interpolation site must use the sanitised fallback, never
+    // the raw payload. The evil string still appears elsewhere in the
+    // output because JSON.stringify hands it to xterm.js's theme object
+    // as a quoted string literal inside <script>, which is safe.
+    expect(evil).toMatch(/background:\s*#000000;\s*overflow:\s*hidden/)
+  })
+})
+
+describe('safeCssColor', () => {
+  test('accepts hex colors', () => {
+    expect(safeCssColor('#000')).toBe('#000')
+    expect(safeCssColor('#000000')).toBe('#000000')
+    expect(safeCssColor('#0e0f10')).toBe('#0e0f10')
+    expect(safeCssColor('#0e0f10ff')).toBe('#0e0f10ff')
+  })
+
+  test('accepts rgb / rgba', () => {
+    expect(safeCssColor('rgb(1, 2, 3)')).toBe('rgb(1, 2, 3)')
+    expect(safeCssColor('rgba(1, 2, 3, 0.5)')).toBe('rgba(1, 2, 3, 0.5)')
+  })
+
+  test('accepts oklch', () => {
+    expect(safeCssColor('oklch(0.55 0.18 225)')).toBe('oklch(0.55 0.18 225)')
+  })
+
+  test('accepts named colors', () => {
+    expect(safeCssColor('red')).toBe('red')
+    expect(safeCssColor('transparent')).toBe('transparent')
+  })
+
+  test('rejects style-tag breakout attempts and falls back', () => {
+    expect(
+      safeCssColor('red; } </style><script>alert(1)</script><style>'),
+    ).toBe('#000000')
+    expect(safeCssColor('#000; background: url(evil)')).toBe('#000000')
+    expect(safeCssColor('javascript:evil()')).toBe('#000000')
   })
 })

--- a/companion/src/screens/tab/terminal-html.helpers.test.ts
+++ b/companion/src/screens/tab/terminal-html.helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_TERMINAL_HTML_CONFIG,
+  buildTerminalHtml,
+} from './terminal-html.helpers'
+
+describe('buildTerminalHtml', () => {
+  const html = buildTerminalHtml(DEFAULT_TERMINAL_HTML_CONFIG)
+
+  test('references pinned unpkg URLs for xterm + addons', () => {
+    expect(html).toContain('https://unpkg.com/@xterm/xterm@6.0.0/css/xterm.css')
+    expect(html).toContain('https://unpkg.com/@xterm/xterm@6.0.0/lib/xterm.js')
+    expect(html).toContain(
+      'https://unpkg.com/@xterm/addon-fit@0.11.0/lib/addon-fit.js',
+    )
+    expect(html).toContain(
+      'https://unpkg.com/@xterm/addon-web-links@0.12.0/lib/addon-web-links.js',
+    )
+  })
+
+  test('embeds initial cols and rows from config', () => {
+    expect(html).toContain('cols: 80')
+    expect(html).toContain('rows: 24')
+  })
+
+  test('installs the RN bridge as window.__terminal_bridge with write/clear/fit', () => {
+    expect(html).toContain('window.__terminal_bridge')
+    expect(html).toContain('write: function')
+    expect(html).toContain('clear: function')
+    expect(html).toContain('fit: function')
+  })
+
+  test('posts ready/data/resize message types to RN', () => {
+    expect(html).toContain("type: 'ready'")
+    expect(html).toContain("type: 'data'")
+    expect(html).toContain("type: 'resize'")
+  })
+
+  test('sets viewport meta for mobile scaling', () => {
+    expect(html).toContain('name="viewport"')
+    expect(html).toContain('initial-scale=1')
+  })
+
+  test('quotes theme values through JSON.stringify (no raw templating)', () => {
+    const evil = buildTerminalHtml({
+      ...DEFAULT_TERMINAL_HTML_CONFIG,
+      themeBackground: 'red"; window.pwned = true; //',
+    })
+    // JSON.stringify keeps the string escaped; the payload appears only
+    // as a quoted string literal, never as bare JS.
+    expect(evil).toContain('"red\\"; window.pwned = true; //"')
+  })
+})

--- a/companion/src/screens/tab/terminal-html.helpers.ts
+++ b/companion/src/screens/tab/terminal-html.helpers.ts
@@ -26,7 +26,23 @@ export const DEFAULT_TERMINAL_HTML_CONFIG: TerminalHtmlConfig = {
   themeCursor: '#e6e8eb',
 }
 
+// Whitelist-based CSS color validator. Accepts hex, rgb/rgba, oklch, and
+// bare-letter named colors. Anything else falls back to a safe default,
+// preventing style-tag breakout via strings like `red; } </style>`. The
+// JS side already uses JSON.stringify for the same reason; this brings
+// CSS to parity.
+const SAFE_CSS_FALLBACK = '#000000'
+
+export function safeCssColor(input: string): string {
+  if (/^#[0-9a-f]{3,8}$/i.test(input)) return input
+  if (/^rgba?\([\d\s,.%]+\)$/i.test(input)) return input
+  if (/^oklch\([\d\s,./%]+\)$/i.test(input)) return input
+  if (/^[a-z]+$/i.test(input)) return input
+  return SAFE_CSS_FALLBACK
+}
+
 export function buildTerminalHtml(config: TerminalHtmlConfig): string {
+  const cssBackground = safeCssColor(config.themeBackground)
   return `<!doctype html>
 <html>
 <head>
@@ -34,7 +50,7 @@ export function buildTerminalHtml(config: TerminalHtmlConfig): string {
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="https://unpkg.com/@xterm/xterm@${config.xtermVersion}/css/xterm.css">
 <style>
-  html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: ${config.themeBackground}; overflow: hidden; }
+  html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: ${cssBackground}; overflow: hidden; }
   #terminal { position: absolute; inset: 0; }
 </style>
 </head>
@@ -51,8 +67,20 @@ export function buildTerminalHtml(config: TerminalHtmlConfig): string {
     }
   }
 
+  // Max ~10 s (200 * 50 ms) waiting for the unpkg UMDs to register on
+  // window. If the tab is offline, on a captive-portal wifi, or unpkg is
+  // down, stop retrying and post an error so RN can log + optionally
+  // surface it. Prevents an infinite battery-draining loop.
+  var bootAttempts = 0;
+  var BOOT_MAX_ATTEMPTS = 200;
+
   function boot() {
     if (!window.Terminal || !window.FitAddon || !window.WebLinksAddon) {
+      bootAttempts += 1;
+      if (bootAttempts >= BOOT_MAX_ATTEMPTS) {
+        post({ type: 'error', message: 'Failed to load xterm.js from unpkg (timeout)' });
+        return;
+      }
       setTimeout(boot, 50);
       return;
     }

--- a/companion/src/screens/tab/terminal-html.helpers.ts
+++ b/companion/src/screens/tab/terminal-html.helpers.ts
@@ -1,0 +1,99 @@
+export interface TerminalHtmlConfig {
+  xtermVersion: string
+  fitAddonVersion: string
+  webLinksAddonVersion: string
+  initialCols: number
+  initialRows: number
+  fontFamily: string
+  fontSize: number
+  scrollback: number
+  themeBackground: string
+  themeForeground: string
+  themeCursor: string
+}
+
+export const DEFAULT_TERMINAL_HTML_CONFIG: TerminalHtmlConfig = {
+  xtermVersion: '6.0.0',
+  fitAddonVersion: '0.11.0',
+  webLinksAddonVersion: '0.12.0',
+  initialCols: 80,
+  initialRows: 24,
+  fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+  fontSize: 12,
+  scrollback: 2000,
+  themeBackground: '#0e0f10',
+  themeForeground: '#e6e8eb',
+  themeCursor: '#e6e8eb',
+}
+
+export function buildTerminalHtml(config: TerminalHtmlConfig): string {
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<link rel="stylesheet" href="https://unpkg.com/@xterm/xterm@${config.xtermVersion}/css/xterm.css">
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: ${config.themeBackground}; overflow: hidden; }
+  #terminal { position: absolute; inset: 0; }
+</style>
+</head>
+<body>
+<div id="terminal"></div>
+<script src="https://unpkg.com/@xterm/xterm@${config.xtermVersion}/lib/xterm.js"></script>
+<script src="https://unpkg.com/@xterm/addon-fit@${config.fitAddonVersion}/lib/addon-fit.js"></script>
+<script src="https://unpkg.com/@xterm/addon-web-links@${config.webLinksAddonVersion}/lib/addon-web-links.js"></script>
+<script>
+(function () {
+  function post(msg) {
+    if (window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+    }
+  }
+
+  function boot() {
+    if (!window.Terminal || !window.FitAddon || !window.WebLinksAddon) {
+      setTimeout(boot, 50);
+      return;
+    }
+    var term = new window.Terminal({
+      cols: ${config.initialCols},
+      rows: ${config.initialRows},
+      fontFamily: ${JSON.stringify(config.fontFamily)},
+      fontSize: ${config.fontSize},
+      cursorBlink: true,
+      scrollback: ${config.scrollback},
+      theme: {
+        background: ${JSON.stringify(config.themeBackground)},
+        foreground: ${JSON.stringify(config.themeForeground)},
+        cursor: ${JSON.stringify(config.themeCursor)},
+      },
+    });
+    var fit = new window.FitAddon.FitAddon();
+    term.loadAddon(fit);
+    term.loadAddon(new window.WebLinksAddon.WebLinksAddon());
+    term.open(document.getElementById('terminal'));
+
+    term.onData(function (data) { post({ type: 'data', payload: data }); });
+    term.onResize(function (e) { post({ type: 'resize', cols: e.cols, rows: e.rows }); });
+
+    fit.fit();
+
+    var observer = new ResizeObserver(function () { fit.fit(); });
+    observer.observe(document.getElementById('terminal'));
+
+    window.__terminal_bridge = {
+      write: function (data) { term.write(data); },
+      clear: function () { term.clear(); },
+      fit: function () { fit.fit(); },
+    };
+
+    post({ type: 'ready' });
+  }
+
+  boot();
+})();
+</script>
+</body>
+</html>`
+}


### PR DESCRIPTION
> Targets the epic branch \`feat/desktop-sidecar-substrate\`. Restores Android as a valid smoke target without requiring a dev client. iOS is completely untouched.

## What

Metro's platform-file resolution picks \`TerminalDom.android.tsx\` on Android and \`TerminalDom.tsx\` on iOS/fallback. This PR adds the Android sibling; the iOS file stays exactly as-is. Same imperative handle interface, same prop shape, same visual + behavioural result.

The Android version renders xterm.js inside a raw \`react-native-webview\` (bundled in Expo Go on both platforms). xterm.js, addon-fit, addon-web-links load from unpkg via inline \`<script>\` tags. Bridge is manual: RN → WebView via \`ref.injectJavaScript(...)\`, WebView → RN via \`window.ReactNativeWebView.postMessage(...)\` decoded through \`onMessage\`.

## Two commits, review-friendly

| # | Commit | What |
|---|---|---|
| 1 | \`feat(companion/tab): terminal-html.helpers, builder + tests for the raw-WebView HTML shell\` | Pure function. HTML template + config. 6 tests. |
| 2 | \`feat(companion/tab): TerminalDom.android.tsx, xterm.js via unpkg inside react-native-webview\` | The RN component. Full bridge. Buffered writes gate. Same interface as iOS. |

## Resolved dep

- \`react-native-webview@13.16.1\` (Expo-managed pin for SDK 56)

## Design decisions worth calling out

1. **Platform split via \`.android.tsx\` filename, not conditional imports.** Metro resolves per-platform automatically. iOS import \`import TerminalDom from './TerminalDom'\` still resolves to \`TerminalDom.tsx\`; Android resolves to \`TerminalDom.android.tsx\`. TabScreen and tab.data.ts don't know or care which file is active.
2. **Buffered writes gate.** WebView cold-load from unpkg is ~300 to 700 ms. If \`tab.data.ts\` calls \`terminalRef.write(snapshot)\` before the HTML posts \`{type:'ready'}\`, we queue in a ref-held array and drain on ready. Consumer contract stays clean; no per-platform state machine.
3. **Tight \`originWhitelist={['https://unpkg.com']}\`.** No wildcards. Combined with \`baseUrl: 'https://unpkg.com/'\` so the inline HTML shares the origin. Blocks any attempt by the terminal buffer to navigate the WebView anywhere else. Subresource loads (scripts, CSS) aren't governed by the whitelist so unpkg's assets still fetch.
4. **Every payload goes through \`JSON.stringify\`** before interpolation into an \`injectJavaScript\` string. Pinned test case (\`quotes theme values through JSON.stringify\`) prevents future 'just interpolate it directly' regressions.
5. **UMD namespace shape** for the xterm.js addons is \`window.FitAddon.FitAddon\` and \`window.WebLinksAddon.WebLinksAddon\` (namespaced), while \`window.Terminal\` is a direct class. Verified by inspecting the actual unpkg-served UMD bundles. If the plan-file assumption were wrong, the HTML boot would throw \`Cannot read property 'FitAddon' of undefined\`; the retry loop would catch it via Chrome remote debug.
6. **Fallow platform-split allowlist.** Fallow's import graph doesn't model Metro's platform-file resolution. \`TerminalDom.tsx\` got flagged as unreachable. Added to \`.fallowrc.jsonc\`'s \`dynamicallyLoaded\` with a comment explaining the split.

## Test totals

- **6 new tests** in \`terminal-html.helpers.test.ts\`. Covers unpkg URL pins, config interpolation, bridge shape, message types, viewport meta, escape safety.
- **29 tests total** across the suite (23 preexisting + 6 new).
- \`bun run check\` green (fmt + lint + typecheck + fallow).
- Manual smoke pending — see checklist below.

## Manual smoke checklist

### Android (primary)

Prerequisite: desktop dev app running with WSS visible, Android sim (\`adb devices\` shows at least one) or physical Android phone on the same Wi-Fi. Metro running.

- [ ] Launch Expo Go on Android, scan the QR (or press \`a\` for the sim)
- [ ] App boots without a red screen. Metro logs \`[TerminalDom.android] webview loaded\`.
- [ ] Home shows paired (secure-store hydration should restore the previous session)
- [ ] Tap Browse projects → projects list renders
- [ ] Tap a tab. \`/tab/[tabid]\` opens; blank dark background for ~300-700 ms while unpkg loads.
- [ ] Terminal fades in with the desktop tab's current visual state (via snapshot). If the pending-writes gate is working, the snapshot arrives before ready and gets buffered + drained on ready.
- [ ] Tap the terminal viewport → Android soft keyboard slides up
- [ ] Type \`echo hi\\r\` from the soft keyboard → desktop shell receives it, echoes back
- [ ] Extra keys bar → tap ↑ → desktop shows last history entry
- [ ] Tap CTRL, then C from the soft keyboard → running process receives SIGINT
- [ ] Kill desktop app → phone status flips to \`unreachable\`. Restart desktop → auto-reconnect via resume, terminal continues.
- [ ] Back to \`/projects\`, re-enter tab → terminal re-mounts, re-fetches unpkg, re-hydrates.

### iOS regression (secondary)

- [ ] Boot iOS sim, open a tab, verify snapshot renders, verify keystrokes flow, verify extra keys bar works. **No change expected** because Metro resolves to the unchanged \`TerminalDom.tsx\`.

## What's NOT in this PR

- **Bundled offline xterm.js.** unpkg dependency is documented as a follow-up if network flakiness bites in the field.
- **Dev client setup.** The 'proper' fix long-term. This PR keeps the Expo Go single-binary workflow so anyone on the team can smoke on Android.
- **Cross-platform DOM component consolidation.** Both platform files coexist; each stays with its idiomatic transport.

## Plan file

Full grounding in RN WebView docs, unpkg URL live verification (curl 200s at plan time), UMD namespace shape, and the origin-whitelist tightening rationale at \`plans/DaniAkash/agent-terminal/features/2026-07-07-1750-...-android-terminal-webview.md\` in the control-center repo.