### PR TITLE
feat(companion): Phase A part 2 — auto-spawn PTY on mobile subscribe to sleeping tab

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -73,7 +73,7 @@ pub async fn open_tab(
         tab_id,
         cwd,
         shell,
-        on_data,
+        Some(on_data),
     )?;
     // Notify any WSS subscribers that the tab inventory changed so
     // they push a fresh Projects frame to their mobile clients.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -229,6 +229,7 @@ pub fn run() {
             // over to Tauri's managed-state store — after `app.manage`
             // moves it, direct access goes away.
             let mod_engine_handle = mod_engine.handle();
+            let cwd_table = mod_engine.cwd_table();
             app.manage(mod_engine);
 
             // Headless-xterm sidecar. Spawned as best-effort so a missing
@@ -291,6 +292,8 @@ pub fn run() {
                             projects_cache: projects_cache_for_wss,
                             pty_map: Arc::clone(&pty_map_for_setup),
                             mod_engine_handle,
+                            cwd_table,
+                            app_handle: Some(app.handle().clone()),
                         });
                         let bind_addr = auth.bind_addr;
                         app.manage(auth);

--- a/src-tauri/src/projects_cache.rs
+++ b/src-tauri/src/projects_cache.rs
@@ -90,6 +90,21 @@ impl ProjectsCache {
         let _ = self.change_tx.send(*v);
     }
 
+    /// Find a specific tab across all projects. Used by the WSS server's
+    /// auto-spawn path to resolve the initial cwd + shell of a sleeping
+    /// tab before its PTY is created.
+    pub fn find_tab(&self, tab_id: &str) -> Option<TabSummary> {
+        let projects = self.inner.lock().expect("projects_cache lock poisoned");
+        for project in projects.iter() {
+            for tab in &project.tabs {
+                if tab.tab_id == tab_id {
+                    return Some(tab.clone());
+                }
+            }
+        }
+        None
+    }
+
     pub fn subscribe_changes(&self) -> watch::Receiver<u64> {
         self.change_rx.clone()
     }
@@ -285,6 +300,54 @@ mod tests {
     fn load_from_disk_returns_none_on_missing_file() {
         let tmp = tempfile::tempdir().unwrap();
         assert!(ProjectsCache::load_from_disk(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn find_tab_returns_summary_across_projects() {
+        let cache = ProjectsCache::new();
+        cache.set(vec![
+            ProjectSummary {
+                project_id: "p1".into(),
+                name: "one".into(),
+                path: None,
+                pinned: false,
+                is_expanded: true,
+                tabs: vec![TabSummary {
+                    tab_id: "t1".into(),
+                    label: "a".into(),
+                    cwd: None,
+                    agent: None,
+                    cmd: None,
+                    last_cwd: Some("/tmp".into()),
+                    pinned: false,
+                    user_renamed: false,
+                    is_spawned: false,
+                }],
+            },
+            ProjectSummary {
+                project_id: "p2".into(),
+                name: "two".into(),
+                path: None,
+                pinned: false,
+                is_expanded: true,
+                tabs: vec![TabSummary {
+                    tab_id: "t2".into(),
+                    label: "b".into(),
+                    cwd: None,
+                    agent: None,
+                    cmd: Some("bash".into()),
+                    last_cwd: None,
+                    pinned: false,
+                    user_renamed: false,
+                    is_spawned: false,
+                }],
+            },
+        ]);
+        let t1 = cache.find_tab("t1").expect("t1 should be found");
+        assert_eq!(t1.last_cwd.as_deref(), Some("/tmp"));
+        let t2 = cache.find_tab("t2").expect("t2 should be found");
+        assert_eq!(t2.cmd.as_deref(), Some("bash"));
+        assert!(cache.find_tab("t3").is_none());
     }
 
     #[test]

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -484,6 +484,13 @@ fn build_shell_command(
 // Long signature is the trade-off for keeping spawn_pty callable from both
 // the open_tab command and the respawn / try_reattach paths without a
 // builder. A SpawnConfig struct would be cleaner but is scope creep here.
+//
+// `on_data` is `Option<Channel<PtyDataPayload>>` so mobile-first spawn (via
+// wss_server auto-spawn on Subscribe) can create a PTY with no local
+// WebView Channel. The SharedChannel starts as None; when the desktop
+// later navigates to the same tab, try_reattach swaps in the WebView's
+// Channel and future broadcasts reach both surfaces. Same "reattachable
+// local subscriber" shape the hub was designed around.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_pty(
     app: AppHandle,
@@ -495,7 +502,7 @@ pub fn spawn_pty(
     tab_id: String,
     cwd: Option<String>,
     shell: Option<String>,
-    on_data: Channel<PtyDataPayload>,
+    on_data: Option<Channel<PtyDataPayload>>,
 ) -> Result<(), String> {
     let pty_system = native_pty_system();
     let pair = pty_system
@@ -517,7 +524,11 @@ pub fn spawn_pty(
     // on_output from the same tab.
     mod_handle.on_tab_open(&tab_id, shell_pid);
 
-    let channel: SharedChannel = Arc::new(Mutex::new(Some(on_data)));
+    // Initial value is Some(channel) for desktop-first spawn, None for
+    // mobile-first spawn. The hub's Local subscriber slot below still gets
+    // wired either way; a None channel is a no-op broadcast target until
+    // try_reattach populates it.
+    let channel: SharedChannel = Arc::new(Mutex::new(on_data));
     let reader_alive = Arc::new(AtomicBool::new(true));
     let closing = Arc::new(AtomicBool::new(false));
     let respawn_history = Arc::new(Mutex::new(Vec::new()));
@@ -568,4 +579,52 @@ pub fn spawn_pty(
     );
 
     Ok(())
+}
+
+/// Spawn a PTY for `tab_id` only if it is not already in the map. Used
+/// by the WSS server when a mobile client subscribes to a sleeping tab
+/// (defined in projects.json but no live PtyHandle). Returns true if a
+/// new PTY was spawned, false if one was already alive.
+///
+/// The spawned PTY has no local WebView Channel; broadcasts fan out
+/// through the hub to remote subscribers only. When the desktop later
+/// navigates to the same tab, `try_reattach` populates the SharedChannel
+/// and the desktop terminal takes over rendering seamlessly.
+///
+/// Runs the same "already-alive but reader thread just died" check
+/// `try_reattach` uses so mobile-triggered spawn of an entry-in-transition
+/// doesn't race with the reader thread's exit path.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_pty_if_absent(
+    app: AppHandle,
+    pty_map: &PtyMap,
+    mod_handle: ModEngineHandle,
+    cwd_table: CwdTable,
+    hub: Arc<StreamHub>,
+    projects_cache: Option<Arc<ProjectsCache>>,
+    tab_id: String,
+    cwd: Option<String>,
+    shell: Option<String>,
+) -> Result<bool, String> {
+    {
+        let map = pty_map.lock().unwrap();
+        if let Some(handle) = map.get(&tab_id) {
+            if handle.reader_alive.load(Ordering::Acquire) {
+                return Ok(false);
+            }
+        }
+    }
+    spawn_pty(
+        app,
+        pty_map,
+        mod_handle,
+        cwd_table,
+        hub,
+        projects_cache,
+        tab_id,
+        cwd,
+        shell,
+        None,
+    )?;
+    Ok(true)
 }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 use tauri::ipc::Channel;
@@ -594,6 +594,14 @@ pub fn spawn_pty(
 /// Runs the same "already-alive but reader thread just died" check
 /// `try_reattach` uses so mobile-triggered spawn of an entry-in-transition
 /// doesn't race with the reader thread's exit path.
+///
+/// Concurrent-call safety: two mobile clients subscribing to the same
+/// sleeping tab at once would both pass the map check and both call
+/// `spawn_pty`, whose unconditional `pty_map.insert` overwrites the
+/// first entry — leaking the first child + reader thread. The
+/// `SPAWN_GATE` global mutex serialises the check-and-spawn window so
+/// only one caller proceeds per tab. Contention is negligible because
+/// spawn is a rare, ms-scale operation.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_pty_if_absent(
     app: AppHandle,
@@ -606,8 +614,9 @@ pub fn spawn_pty_if_absent(
     cwd: Option<String>,
     shell: Option<String>,
 ) -> Result<bool, String> {
+    let _spawn_gate = SPAWN_GATE.lock().expect("SPAWN_GATE poisoned");
     {
-        let map = pty_map.lock().unwrap();
+        let map = pty_map.lock().expect("pty_map lock poisoned");
         if let Some(handle) = map.get(&tab_id) {
             if handle.reader_alive.load(Ordering::Acquire) {
                 return Ok(false);
@@ -628,3 +637,10 @@ pub fn spawn_pty_if_absent(
     )?;
     Ok(true)
 }
+
+/// Serialises concurrent `spawn_pty_if_absent` calls so two mobile
+/// clients subscribing to the same sleeping tab_id at once cannot both
+/// pass the pty_map check and both spawn. Global rather than per-tab
+/// because auto-spawn is rare and the whole operation is ms-scale; the
+/// simplicity of one Mutex beats the storage of a per-tab HashMap.
+static SPAWN_GATE: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));

--- a/src-tauri/src/wss_server.rs
+++ b/src-tauri/src/wss_server.rs
@@ -304,8 +304,20 @@ async fn dispatch_client_frame(
                     state.app_handle.as_ref(),
                     state.projects_cache.find_tab(&tab_id),
                 ) {
-                    let cwd = tab.last_cwd.clone().or_else(|| tab.cwd.clone());
-                    let shell = tab.cmd.clone();
+                    // Desktop's addTab initializes `cmd: ''` for every new
+                    // tab; that arrives here as Some("") which spawn_pty
+                    // would try to run as the shell path, spawning an empty
+                    // command that crashes on write and hits the reader
+                    // thread's respawn-rate limit within seconds. Normalise
+                    // empty strings to None so spawn_pty falls back to
+                    // $SHELL / /bin/zsh — matching the desktop open_tab
+                    // path, which never passes `shell` at all.
+                    let cwd = tab
+                        .last_cwd
+                        .clone()
+                        .or_else(|| tab.cwd.clone())
+                        .filter(|s| !s.is_empty());
+                    let shell = tab.cmd.clone().filter(|s| !s.is_empty());
                     match spawn_pty_if_absent(
                         app.clone(),
                         &state.pty_map,

--- a/src-tauri/src/wss_server.rs
+++ b/src-tauri/src/wss_server.rs
@@ -298,46 +298,50 @@ async fn dispatch_client_frame(
             // cwd chain: TabSummary.last_cwd (OSC 7-derived, persisted)
             // → TabSummary.cwd → spawn_pty's HOME default. Shell comes
             // from `cmd` when set, matching desktop's semantics.
-            let needs_spawn = !state.pty_map.lock().unwrap().contains_key(&tab_id);
-            if needs_spawn {
-                if let (Some(app), Some(tab)) = (
-                    state.app_handle.as_ref(),
-                    state.projects_cache.find_tab(&tab_id),
+            //
+            // We do NOT gate on `pty_map.contains_key` here — a
+            // just-died reader thread leaves the entry present with
+            // `reader_alive=false`, and spawn_pty_if_absent's internal
+            // check handles both "healthy PTY, skip" and "zombie entry,
+            // respawn" correctly. Duplicating the check outside the
+            // helper would miss the zombie case.
+            if let (Some(app), Some(tab)) = (
+                state.app_handle.as_ref(),
+                state.projects_cache.find_tab(&tab_id),
+            ) {
+                // Desktop's addTab initializes `cmd: ''` for every new
+                // tab; that arrives here as Some("") which spawn_pty
+                // would try to run as the shell path, spawning an empty
+                // command that crashes on write and hits the reader
+                // thread's respawn-rate limit within seconds. Normalise
+                // empty strings to None so spawn_pty falls back to
+                // $SHELL / /bin/zsh — matching the desktop open_tab
+                // path, which never passes `shell` at all.
+                let cwd = tab
+                    .last_cwd
+                    .clone()
+                    .or_else(|| tab.cwd.clone())
+                    .filter(|s| !s.is_empty());
+                let shell = tab.cmd.clone().filter(|s| !s.is_empty());
+                match spawn_pty_if_absent(
+                    app.clone(),
+                    &state.pty_map,
+                    state.mod_engine_handle.clone(),
+                    state.cwd_table.clone(),
+                    Arc::clone(&state.hub),
+                    Some(Arc::clone(&state.projects_cache)),
+                    tab_id.clone(),
+                    cwd,
+                    shell,
                 ) {
-                    // Desktop's addTab initializes `cmd: ''` for every new
-                    // tab; that arrives here as Some("") which spawn_pty
-                    // would try to run as the shell path, spawning an empty
-                    // command that crashes on write and hits the reader
-                    // thread's respawn-rate limit within seconds. Normalise
-                    // empty strings to None so spawn_pty falls back to
-                    // $SHELL / /bin/zsh — matching the desktop open_tab
-                    // path, which never passes `shell` at all.
-                    let cwd = tab
-                        .last_cwd
-                        .clone()
-                        .or_else(|| tab.cwd.clone())
-                        .filter(|s| !s.is_empty());
-                    let shell = tab.cmd.clone().filter(|s| !s.is_empty());
-                    match spawn_pty_if_absent(
-                        app.clone(),
-                        &state.pty_map,
-                        state.mod_engine_handle.clone(),
-                        state.cwd_table.clone(),
-                        Arc::clone(&state.hub),
-                        Some(Arc::clone(&state.projects_cache)),
-                        tab_id.clone(),
-                        cwd,
-                        shell,
-                    ) {
-                        Ok(true) => {
-                            // is_spawned overlay just flipped for this
-                            // tab; broadcast so every mobile client sees
-                            // the change in the next Projects push.
-                            state.projects_cache.notify_spawn_change();
-                        }
-                        Ok(false) => {}
-                        Err(e) => eprintln!("[wss] auto-spawn {tab_id} failed: {e}"),
+                    Ok(true) => {
+                        // is_spawned overlay just flipped for this
+                        // tab; broadcast so every mobile client sees
+                        // the change in the next Projects push.
+                        state.projects_cache.notify_spawn_change();
                     }
+                    Ok(false) => {}
+                    Err(e) => eprintln!("[wss] auto-spawn {tab_id} failed: {e}"),
                 }
             }
 

--- a/src-tauri/src/wss_server.rs
+++ b/src-tauri/src/wss_server.rs
@@ -17,10 +17,10 @@
 // handshake per-device tokens stored in the macOS Keychain.
 
 use crate::auth_stub::AuthStub;
-use crate::mod_engine::ModEngineHandle;
+use crate::mod_engine::{CwdTable, ModEngineHandle};
 use crate::projects_cache::ProjectsCache;
 use crate::protocol::{ClientFrame, ServerFrame};
-use crate::pty_manager::PtyMap;
+use crate::pty_manager::{spawn_pty_if_absent, PtyMap};
 use crate::stream_hub::{StreamHub, SubscriberId};
 use axum::{
     Router,
@@ -70,6 +70,19 @@ pub struct ServerState {
     /// contention shows in profiling we split the lock.
     pub pty_map: PtyMap,
     pub mod_engine_handle: ModEngineHandle,
+    /// Tab OSC 7 cwd table, shared with the mod engine + the desktop
+    /// spawn path. Auto-spawn on Subscribe resolves the initial cwd of
+    /// a sleeping tab against `last_cwd` from the ProjectsCache first;
+    /// this table is threaded to spawn_pty for symmetry with the
+    /// desktop's open_tab flow so a subsequent local visit lands in the
+    /// same cwd via OSC 7.
+    pub cwd_table: CwdTable,
+    /// AppHandle for the Tauri commands + events spawn_pty emits
+    /// (pty:exit, pty:respawned). Cloned into each auto-spawn call.
+    /// `Option` so integration tests can build a ServerState without
+    /// standing up a full Tauri mock runtime; the auto-spawn branch
+    /// gates on `Some` and treats `None` as "no-op, don't spawn".
+    pub app_handle: Option<tauri::AppHandle>,
 }
 
 /// Bind the WSS server to `addr` and serve until the listener closes.
@@ -276,6 +289,46 @@ async fn dispatch_client_frame(
         ClientFrame::Auth { .. } => {}
 
         ClientFrame::Subscribe { tab_id, scrollback } => {
+            // Auto-spawn: mobile clients see every tab the desktop knows
+            // about, including sleeping ones. Tapping a sleeping tab
+            // lands here with no PtyHandle in the map. Create one from
+            // the cache's TabSummary metadata so mobile can drive the
+            // shell without the desktop having to visit the tab first.
+            //
+            // cwd chain: TabSummary.last_cwd (OSC 7-derived, persisted)
+            // → TabSummary.cwd → spawn_pty's HOME default. Shell comes
+            // from `cmd` when set, matching desktop's semantics.
+            let needs_spawn = !state.pty_map.lock().unwrap().contains_key(&tab_id);
+            if needs_spawn {
+                if let (Some(app), Some(tab)) = (
+                    state.app_handle.as_ref(),
+                    state.projects_cache.find_tab(&tab_id),
+                ) {
+                    let cwd = tab.last_cwd.clone().or_else(|| tab.cwd.clone());
+                    let shell = tab.cmd.clone();
+                    match spawn_pty_if_absent(
+                        app.clone(),
+                        &state.pty_map,
+                        state.mod_engine_handle.clone(),
+                        state.cwd_table.clone(),
+                        Arc::clone(&state.hub),
+                        Some(Arc::clone(&state.projects_cache)),
+                        tab_id.clone(),
+                        cwd,
+                        shell,
+                    ) {
+                        Ok(true) => {
+                            // is_spawned overlay just flipped for this
+                            // tab; broadcast so every mobile client sees
+                            // the change in the next Projects push.
+                            state.projects_cache.notify_spawn_change();
+                        }
+                        Ok(false) => {}
+                        Err(e) => eprintln!("[wss] auto-spawn {tab_id} failed: {e}"),
+                    }
+                }
+            }
+
             // Drop any prior subscription on the same tab first so we
             // don't leak SubscriberIds if a client re-subscribes.
             if let Some(prev) = subscriptions.remove(&tab_id) {

--- a/src-tauri/tests/wss_integration.rs
+++ b/src-tauri/tests/wss_integration.rs
@@ -12,7 +12,7 @@
 // app).
 
 use agent_terminal_lib::auth_stub::AuthStub;
-use agent_terminal_lib::ModEngineHandle;
+use agent_terminal_lib::{CwdTable, ModEngineHandle};
 use agent_terminal_lib::projects_cache::ProjectsCache;
 use agent_terminal_lib::protocol::{ClientFrame, ServerFrame};
 use agent_terminal_lib::pty_manager::PtyMap;
@@ -65,6 +65,12 @@ async fn spawn_server(token: &str) -> (SocketAddr, Arc<ServerState>) {
         // or Resize dispatch (they need a real PtyHandle), so the mod
         // engine channels this drops onto never matter.
         mod_engine_handle: ModEngineHandle::noop(),
+        cwd_table: Arc::new(Mutex::new(HashMap::new())) as CwdTable,
+        // No AppHandle in tests — auto-spawn on Subscribe gates on Some
+        // and treats None as "skip spawn", so Subscribe-to-sleeping-tab
+        // still routes through subscribe_remote (yields no bytes because
+        // no PtyHandle exists, matching pre-Phase-A-part-2 behaviour).
+        app_handle: None,
     });
 
     let state_for_task = Arc::clone(&state);

--- a/src-tauri/tests/wss_integration.rs
+++ b/src-tauri/tests/wss_integration.rs
@@ -12,7 +12,7 @@
 // app).
 
 use agent_terminal_lib::auth_stub::AuthStub;
-use agent_terminal_lib::{CwdTable, ModEngineHandle};
+use agent_terminal_lib::ModEngineHandle;
 use agent_terminal_lib::projects_cache::ProjectsCache;
 use agent_terminal_lib::protocol::{ClientFrame, ServerFrame};
 use agent_terminal_lib::pty_manager::PtyMap;
@@ -65,7 +65,7 @@ async fn spawn_server(token: &str) -> (SocketAddr, Arc<ServerState>) {
         // or Resize dispatch (they need a real PtyHandle), so the mod
         // engine channels this drops onto never matter.
         mod_engine_handle: ModEngineHandle::noop(),
-        cwd_table: Arc::new(Mutex::new(HashMap::new())) as CwdTable,
+        cwd_table: Arc::new(Mutex::new(HashMap::new())),
         // No AppHandle in tests — auto-spawn on Subscribe gates on Some
         // and treats None as "skip spawn", so Subscribe-to-sleeping-tab
         // still routes through subscribe_remote (yields no bytes because


### PR DESCRIPTION
> Stacked on top of #83. Completes Phase A: mobile clients can now tap a sleeping tab and get a live shell, without the desktop having to visit that tab first. Phone becomes a full driver of the desktop.

## What

Part 1 (PR #83) made every tab visible on mobile including sleeping ones (in \`projects.json\` but no live PtyHandle). But tapping a sleeping tab subscribed to a tab_id the server had no PTY for — no snapshot arrived, terminal stayed empty. Part 2 closes that gap.

**Flow in \`wss_server::dispatch_client_frame\` on Subscribe:**

1. If \`pty_map.contains_key(tab_id)\` → skip spawn, subscribe as today
2. Look up \`TabSummary\` in \`ProjectsCache\` via new \`find_tab\` helper
3. Resolve cwd: \`last_cwd\` (OSC 7-derived, persisted) → \`cwd\` → HOME
4. Resolve shell: \`TabSummary.cmd\` → SHELL env → \`/bin/zsh\`
5. Call \`spawn_pty_if_absent\` with \`on_data=None\` (no local channel; hub fans out to remote subscribers directly)
6. Fire \`notify_spawn_change\` so every connected mobile client sees the \`is_spawned\` overlay flip in the next Projects push
7. Continue to \`hub.subscribe_remote\` as today

## Two commits

| # | Commit | What |
|---|---|---|
| 1 | \`feat(desktop/pty): make spawn_pty's on_data Optional + add spawn_pty_if_absent helper\` | Channel refactor. spawn_pty accepts \`Option<Channel<PtyDataPayload>>\`. New helper wraps the reader_alive check + calls spawn_pty with None. \`commands::open_tab\` wraps its Channel in Some(). |
| 2 | \`feat(desktop/wss): auto-spawn PTY when mobile subscribes to a sleeping tab\` | Subscribe branch does the lookup + spawn. ServerState gains cwd_table + Option<AppHandle>. ProjectsCache.find_tab helper + test. Integration test scaffolding updated. |

## Key design decisions

1. **Channel becomes Optional, not "always some or always none".** The SharedChannel wrapping model was already designed around Option (flips to None on close). Making the initial value Optional is a natural extension: mobile-first spawn stores None, and try_reattach's existing swap-in-Some path handles the later desktop attach cleanly. No new plumbing for the "who owns the local channel" question — the reattach flow already answered it.
2. **App handle is Option<AppHandle>, not Runtime<MockRuntime>.** Integration tests can construct \`ServerState\` without spinning up a Tauri mock. The auto-spawn branch gates on Some; None means "skip spawn" (integration tests hit this path — they subscribe to sleeping tabs that stay empty, matching pre-Part-2 behaviour). Production always has Some.
3. **cwd chain matches desktop's semantics.** \`last_cwd\` (OSC 7-derived, persisted across sessions) is the closest thing to "where the tab was" for a mobile spawn. Falls back to \`cwd\` (initial) then to spawn_pty's HOME default. Shell override via \`TabSummary.cmd\` mirrors desktop's rename-aware behaviour.
4. **notify_spawn_change fires after successful spawn.** Every mobile client sees the pill flip from 'sleeping' to live within a round trip. Includes the client that just triggered the spawn — its own view refreshes with the new state.

## Backward compat

Wire protocol unchanged. Old clients keep sending the same Subscribe frame. Server transparently spawns on their behalf if needed. No new fields to migrate.

## Test totals

- **99 Rust lib tests** (was 98 before Part 1; +1 for \`find_tab\` cross-project lookup pin)
- **6 Rust integration tests** (unchanged)
- **36 companion tests** (unchanged)
- \`cargo build --lib\` + \`cargo test\` green
- \`bun run check\` + \`bun test\` green

## Manual smoke checklist

Prerequisite: PR #83 merged into the epic branch, desktop dev app running, mobile paired.

- [ ] On desktop, ensure at least one project has multiple tabs. Close all desktop tabs. Verify at least one shows as 'sleeping' on mobile Projects screen.
- [ ] Tap a sleeping tab on mobile. Within ~500 ms, the pill disappears (is_spawned flips), terminal chrome renders, prompt is visible.
- [ ] Type a command (\`echo hi\\r\`) on mobile. Desktop shell (invisible, no WebView) receives and echoes back. Confirmed via next mobile keystroke reaching the same shell.
- [ ] Open the same tab on desktop (click it in sidebar). Desktop UI attaches to the running PTY via \`try_reattach\`, WebView renders the same buffer mobile has been driving.
- [ ] Continue typing on mobile while desktop UI is open. Both surfaces see the same output. \`try_reattach\`'s SharedChannel swap works — the tab was mobile-first-spawned, so the None → Some transition just happened live.
- [ ] Close the desktop tab (X). Mobile continues typing, tab keeps running. Reopen from mobile via /projects → tap → snapshot back. Confirms the reader thread's respawn / user-close paths are unchanged.
- [ ] Kill desktop app entirely, restart, mobile reconnects. Cold-start load_from_disk + auto-spawn on mobile's next subscribe still works.

## What's still deferred

- **Mobile CRUD (Phase B).** \`create_project\`, \`create_tab\`, \`rename\`, \`delete\`, \`reorder\` client frames + editable Projects UI.
- **Drag-to-reorder from mobile.** \`react-native-draggable-flatlist\` follow-up.
- **Optimistic UI + pending-ops map.** Deferred until latency proves it necessary.

## Plan file

Master plan at \`plans/DaniAkash/agent-terminal/features/2026-07-08-0816-...-companion-full-project-sync.md\` (control-center repo). Phase A step 5 is what this PR implements; the plan describes both parts as one coherent block.