### PR TITLE
chore(release): auto-bump Homebrew tap on stable release publish

### DIFF
--- a/.github/workflows/tap-dispatch.yml
+++ b/.github/workflows/tap-dispatch.yml
@@ -1,0 +1,83 @@
+# Fire a repository_dispatch to DaniAkash/homebrew-tap when a stable
+# release is published on this repo. The tap's bump-cask.yml catches
+# the dispatch, downloads the release DMGs, computes SHA256s, patches
+# the cask file, and pushes. Result: `brew upgrade --cask agent-terminal`
+# picks up the new version within minutes of clicking "Publish" here.
+#
+# Trigger: on release published (the "Publish" button on a draft
+# release, not the tag push). Pre-releases are filtered out so RC tags
+# never bump the stable cask.
+#
+# Required repo secret:
+#   TAP_DISPATCH_TOKEN — fine-grained PAT scoped to
+#     DaniAkash/homebrew-tap with Contents: write. Needed because
+#     GITHUB_TOKEN cannot fire dispatches to another repo.
+
+name: Notify Homebrew tap on release publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enumerate release assets
+        id: assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_tag="${{ github.event.release.tag_name }}"
+          version="${release_tag#v}"
+
+          # gh release view emits a JSON payload of every asset. Pick
+          # the two DMGs by their short-name filenames (the release
+          # workflow uploads both a Tauri-default `Agent.Terminal_...dmg`
+          # AND a short-name `agent-terminal-<arch>.dmg`; the short one
+          # gives the cask a stable URL template).
+          arm_url=$(gh release view "$release_tag" -R "$GITHUB_REPOSITORY" \
+            --json assets --jq '.assets[] | select(.name == "agent-terminal-aarch64.dmg") | .url')
+          intel_url=$(gh release view "$release_tag" -R "$GITHUB_REPOSITORY" \
+            --json assets --jq '.assets[] | select(.name == "agent-terminal-x64.dmg") | .url')
+
+          if [ -z "$arm_url" ] || [ -z "$intel_url" ]; then
+            echo "::error::Missing agent-terminal-{aarch64,x64}.dmg in release $release_tag" >&2
+            gh release view "$release_tag" -R "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' >&2
+            exit 1
+          fi
+
+          echo "version=$version"     >> "$GITHUB_OUTPUT"
+          echo "arm_url=$arm_url"     >> "$GITHUB_OUTPUT"
+          echo "intel_url=$intel_url" >> "$GITHUB_OUTPUT"
+
+      - name: Fire tap dispatch
+        env:
+          TAP_TOKEN: ${{ secrets.TAP_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAP_TOKEN:-}" ]; then
+            echo "::error::TAP_DISPATCH_TOKEN secret is not configured. Add a fine-grained PAT scoped to DaniAkash/homebrew-tap with Contents: write." >&2
+            exit 1
+          fi
+
+          curl -sfL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $TAP_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/DaniAkash/homebrew-tap/dispatches" \
+            -d @- <<EOF
+          {
+            "event_type": "agent-terminal-release",
+            "client_payload": {
+              "version":   "${{ steps.assets.outputs.version }}",
+              "arm_url":   "${{ steps.assets.outputs.arm_url }}",
+              "intel_url": "${{ steps.assets.outputs.intel_url }}"
+            }
+          }
+          EOF

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
 </p>
 
 <p align="center">
+  <em>or install via Homebrew:</em><br/>
+  <code>brew tap daniakash/tap && brew install --cask agent-terminal</code>
+</p>
+
+<p align="center">
   <a href="https://www.producthunt.com/products/agent-terminal?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-agent-terminal" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1136595&theme=light&t=1777623264721" alt="Agent terminal - One terminal. Every agent. Total clarity. | Product Hunt" width="250" height="54" /></a>
 </p>
 


### PR DESCRIPTION
> Ships the sender half of the Homebrew Cask distribution setup. Companion tap repo is [DaniAkash/homebrew-tap](https://github.com/DaniAkash/homebrew-tap), already live with the v0.1.5 cask and the receiver-side bump workflow.

## What

Adds \`.github/workflows/tap-dispatch.yml\`. When a **draft release is promoted to Published** (the manual step at the end of the existing release flow), this workflow fires a \`repository_dispatch\` to \`DaniAkash/homebrew-tap\` with the version + both DMG URLs. The tap's own bump-cask workflow downloads the DMGs, computes SHA256s, patches \`Casks/agent-terminal.rb\`, and pushes.

**Users can now install via:**

\`\`\`sh
brew tap daniakash/tap
brew install --cask agent-terminal
\`\`\`

README gets a one-liner Homebrew install snippet under the existing download badges.

## Trigger design

- \`on: release: types: [published]\` fires when a draft is manually promoted, not when the draft is created. Aligns with the existing 'never auto-publish' policy in the release workflow header.
- \`if: \${{ !github.event.release.prerelease }}\` skips pre-release publishes so RC tags never touch the stable cask.
- Enumerates release assets via \`gh release view --json assets\`, picks by exact filename (\`agent-terminal-aarch64.dmg\`, \`agent-terminal-x64.dmg\`). If either is missing, the workflow errors loudly with the full asset listing rather than silently succeeding with stale hashes.

## One repo secret to add before merge

**\`TAP_DISPATCH_TOKEN\`** — fine-grained PAT scoped to \`DaniAkash/homebrew-tap\` only with \`Contents: write\` permission. Needed because the built-in \`GITHUB_TOKEN\` cannot fire dispatches to another repo.

Steps:
1. github.com → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token
2. Repository access: only \`DaniAkash/homebrew-tap\`
3. Permissions → Repository permissions → **Contents: Read and write**
4. Expiration: 1 year (renew before expiry; a stale token surfaces as a loud error in this workflow, not a silent failure)
5. Copy token, add to this repo (\`agent-terminal\`) → Settings → Secrets and variables → Actions → New repository secret → name \`TAP_DISPATCH_TOKEN\`

The workflow gates on the secret presence and errors early with a clear message if it's missing.

## What happens end-to-end (v0.1.6 hypothetical)

1. Bump version in \`package.json\` + \`tauri.conf.json\` + \`Cargo.toml\`, commit, tag \`v0.1.6\`, push.
2. Existing \`release.yml\` builds signed + notarized DMGs, creates draft release.
3. Manually review + click Publish from the GitHub UI.
4. **This new workflow** fires, dispatches to homebrew-tap.
5. Tap's \`bump-cask.yml\` downloads both DMGs, computes hashes, patches the cask file, pushes commit \`agent-terminal 0.1.6\` to \`homebrew-tap:main\`.
6. Users' next \`brew update && brew upgrade --cask agent-terminal\` picks up v0.1.6.

Whole loop is ~2 minutes after clicking Publish.

## Verification plan

After merge + PAT setup:
- [ ] Cut the next stable release
- [ ] Watch the Actions tab for this workflow → dispatch → tap's bump workflow → commit lands in homebrew-tap
- [ ] Run \`brew update && brew upgrade --cask agent-terminal\` locally to confirm the new SHA is honoured

If the dispatch chain ever breaks, the fallback is manual: \`brew edit --cask daniakash/tap/agent-terminal\` and hand-patch the version + SHAs.