### PR TITLE
ci: run the companion Expo app's check suite on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,12 +205,13 @@ jobs:
   # for its `preset` rules key which the root's 2.4.x biome refuses to
   # load), own tsconfig, own fallow config.
   #
-  # Split into one step per check (mirroring js-checks / rust-checks)
-  # rather than running the local `bun run check` script as a single
-  # step. `if: !cancelled()` on every check means a fmt failure does
-  # not skip lint / typecheck / fallow — the whole job surfaces every
-  # issue on the first run, and each check gets its own collapsible
-  # section in the GHA UI so failure attribution is one click.
+  # Runs `bun run check` as a single step by design. The script fans
+  # biome format + biome lint + tsc + fallow through `concurrently
+  # --group` with no `-k` / `--kill-others-on-fail` flag, so every check
+  # runs to completion regardless of what any other check does. One
+  # workflow run surfaces every failure across every check on the first
+  # pass, with `--group` prefixing each line by which check produced it
+  # so the log reads cleanly.
   companion-checks:
     name: Companion (Expo)
     needs: approve
@@ -224,20 +225,7 @@ jobs:
       - name: Install companion deps
         working-directory: companion
         run: bun install --frozen-lockfile
-
-      - name: Biome format
+      - name: bun run check
         if: ${{ !cancelled() }}
         working-directory: companion
-        run: bun run fmt
-      - name: Biome lint
-        if: ${{ !cancelled() }}
-        working-directory: companion
-        run: bun run lint
-      - name: tsc --noEmit
-        if: ${{ !cancelled() }}
-        working-directory: companion
-        run: bun run typecheck
-      - name: fallow
-        if: ${{ !cancelled() }}
-        working-directory: companion
-        run: bun run fallow
+        run: bun run check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,9 +203,14 @@ jobs:
 
   # Companion Expo / React Native app. Own bun lockfile, own biome (2.5.1
   # for its `preset` rules key which the root's 2.4.x biome refuses to
-  # load), own tsconfig, own fallow config. `bun run check` fans out to
-  # biome format + biome lint + tsc + fallow via `concurrently --group`
-  # so every check runs in one job and the log stays grouped by check.
+  # load), own tsconfig, own fallow config.
+  #
+  # Split into one step per check (mirroring js-checks / rust-checks)
+  # rather than running the local `bun run check` script as a single
+  # step. `if: !cancelled()` on every check means a fmt failure does
+  # not skip lint / typecheck / fallow — the whole job surfaces every
+  # issue on the first run, and each check gets its own collapsible
+  # section in the GHA UI so failure attribution is one click.
   companion-checks:
     name: Companion (Expo)
     needs: approve
@@ -219,7 +224,20 @@ jobs:
       - name: Install companion deps
         working-directory: companion
         run: bun install --frozen-lockfile
-      - name: bun run check
+
+      - name: Biome format
         if: ${{ !cancelled() }}
         working-directory: companion
-        run: bun run check
+        run: bun run fmt
+      - name: Biome lint
+        if: ${{ !cancelled() }}
+        working-directory: companion
+        run: bun run lint
+      - name: tsc --noEmit
+        if: ${{ !cancelled() }}
+        working-directory: companion
+        run: bun run typecheck
+      - name: fallow
+        if: ${{ !cancelled() }}
+        working-directory: companion
+        run: bun run fallow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ on:
     branches:
       - main
       - feat/desktop-sidecar-substrate
-    paths-ignore:
-      - 'companion/**'
   workflow_dispatch:
 
 concurrency:
@@ -202,3 +200,26 @@ jobs:
         if: ${{ !cancelled() }}
         working-directory: src-tauri
         run: cargo test --test hook_integration -- --test-threads=1
+
+  # Companion Expo / React Native app. Own bun lockfile, own biome (2.5.1
+  # for its `preset` rules key which the root's 2.4.x biome refuses to
+  # load), own tsconfig, own fallow config. `bun run check` fans out to
+  # biome format + biome lint + tsc + fallow via `concurrently --group`
+  # so every check runs in one job and the log stays grouped by check.
+  companion-checks:
+    name: Companion (Expo)
+    needs: approve
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install companion deps
+        working-directory: companion
+        run: bun install --frozen-lockfile
+      - name: bun run check
+        if: ${{ !cancelled() }}
+        working-directory: companion
+        run: bun run check


### PR DESCRIPTION
## Summary

- The workflow was excluding `companion/**` from PR CI via `paths-ignore`, and there was no companion-specific job to run against it even when unrelated changes triggered the workflow. Combined, this meant the Expo mobile app had zero PR-level protection despite shipping its own extensive check suite.
- Drop the `paths-ignore` so companion-only PRs trigger CI, and add a new `companion-checks` job that runs `bun run check` inside `companion/`.
- `bun run check` fans biome format + biome lint + tsc + fallow through `concurrently --group` without `-k` / `--kill-others-on-fail`. Every check runs to completion regardless of failure, so one workflow run surfaces every issue across every check on the first pass, with `--group` prefixing each line by check name so the log stays legible.

## Side effect

`js-checks` and `rust-checks` will now also fire for companion-only PRs. Fine because the manual approval environment bounds the extra CI minutes to whatever the reviewer chooses to approve.

## Test plan

- [ ] Approve this PR in the `ci-approval` environment and confirm all three jobs (`JS / TypeScript`, `Rust / Tauri`, `Companion (Expo)`) run.
- [ ] `Companion (Expo)` job is green (baseline `bun run check` inside `companion/` passes on `main` locally).
- [ ] Confirm the workflow triggers for a follow-up PR that only touches `companion/**`.

## Follow-ups (not in scope)

- Uniwind-generated files (`companion/global.css`, `companion/uniwind-types.d.ts`) are committed today; a drift check analogous to the wire-protocol drift check would catch "developer edited Tailwind classes without regenerating types."
- No test step on the companion job because there is no `bun test` script in `companion/` today. Add when tests land.