### PR TITLE
chore(companion): migrate from Expo Go to dev client

### DIFF
--- a/companion/app.json
+++ b/companion/app.json
@@ -11,6 +11,7 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "ios": {
+      "bundleIdentifier": "com.daniakash.agent-terminal.companion.dev",
       "supportsTablet": true,
       "infoPlist": {
         "NSAppTransportSecurity": {
@@ -20,6 +21,7 @@
       }
     },
     "android": {
+      "package": "com.daniakash.agent_terminal.companion.dev",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/android-icon-foreground.png",
@@ -46,7 +48,8 @@
             "networkSecurityConfig": "./network-security-config.xml"
           }
         }
-      ]
+      ],
+      "./plugins/withGradleWrapperVersion"
     ]
   }
 }

--- a/companion/bun.lock
+++ b/companion/bun.lock
@@ -17,6 +17,7 @@
         "expo-build-properties": "^57.0.3",
         "expo-camera": "~56.0.8",
         "expo-constants": "~56.0.20",
+        "expo-dev-client": "~56.0.22",
         "expo-linking": "~56.0.15",
         "expo-router": "~56.2.13",
         "expo-secure-store": "~56.0.4",
@@ -782,15 +783,27 @@
 
     "expo-constants": ["expo-constants@56.0.20", "", { "dependencies": { "@expo/env": "~2.3.1" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-4HgoVvUiMvcqujr/CUj7L1tumLWj8WX0PLM77OriDPoaJrMEwUHd841m4o4IoUyMPVT8XTiTiPFwJtGali8+9Q=="],
 
+    "expo-dev-client": ["expo-dev-client@56.0.22", "", { "dependencies": { "expo-dev-launcher": "~56.0.23", "expo-dev-menu": "~56.0.19", "expo-dev-menu-interface": "~56.0.0", "expo-manifests": "~56.0.4", "expo-updates-interface": "~56.0.1" }, "peerDependencies": { "expo": "*" } }, "sha512-LKhgIlMu8DkmhTtfurpX9YMPsnv4QI1hCcDZqcFn+jlB+s6yE1THB9UWZ+BVtef8kYMzsw+BH3ClXvNkRd0vXw=="],
+
+    "expo-dev-launcher": ["expo-dev-launcher@56.0.23", "", { "dependencies": { "@expo/schema-utils": "^56.0.2", "expo-dev-menu": "~56.0.19", "expo-manifests": "~56.0.4" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-OKgLAn6m15Lu+Qyg8WA0HPurFR9pxhsrHUvvafv8pTZHspB0BbOvBwhOJdxgiMfR2LHq4032cnMf8164Vzqeng=="],
+
+    "expo-dev-menu": ["expo-dev-menu@56.0.19", "", { "dependencies": { "expo-dev-menu-interface": "~56.0.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-sm6dfnkq3lgbn39Kd4yjFFm7UQAZqm6Hn3OpjagGtWBoWByQae3nKh1MF5K4Peh172TqUPJTOhjRasnZSkUkOQ=="],
+
+    "expo-dev-menu-interface": ["expo-dev-menu-interface@56.0.1", "", { "peerDependencies": { "expo": "*" } }, "sha512-odATx0ZL/Kis10sKSBiKiGQxAB6coSi/KQtKcMhnQVNno6FkRh5/4e5BqcEvpq2rNMTiQp4ytNAQHtdwbPXvGA=="],
+
     "expo-file-system": ["expo-file-system@56.0.8", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-NrH41/8snGIBSbYicwVLB4txPdgCATd7ZYhMAGS3YJZ9GbnduhlAoV4/YCbGayjrbpE9bJb/6wegPL/zmvRMnQ=="],
 
     "expo-font": ["expo-font@56.0.7", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-hpU/vRwPzsby9lPGkA4blDqLIIXYzoWnCZHr6PxvcWbY/uPObAiyhh6q+e0WYsB65SthK+PLH95jEnVag7fwEg=="],
 
     "expo-glass-effect": ["expo-glass-effect@56.0.4", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-xI9rXtDwi7RW82uAlfyaXO6+k21ApWJ2tHAWYqPr/FjfmZbKsgNJ4Q0iZzGPCwboqjTGxaRZ61SZxBl8hDt5iA=="],
 
+    "expo-json-utils": ["expo-json-utils@56.0.0", "", {}, "sha512-lUqyv9aIGDbYTQ5Nux2FnH2/Dz0w5uJ8Pr080eS0StXi2jr5OmuMNErpzUnpfnYOU55xKotd4AHv68PfV/ludg=="],
+
     "expo-keep-awake": ["expo-keep-awake@56.0.3", "", { "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-CLMJXtEiMKknD3Rpm8CRwE6ZJUzu2yCEmRk1sgfHAJ1zIbuEWY3dpPDubtsnuzWm+2k6Sru+yaFbYsvPWmTiBA=="],
 
     "expo-linking": ["expo-linking@56.0.15", "", { "dependencies": { "expo-constants": "~56.0.20", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-V3tkCxHIWO624ayw2L5Nfi0/bPgYy/0MgmoQR7g3FAKF4nyAayK8IhgAInz4MZ5Ao5Bb+5uZWDdUaS4yyEb+Gw=="],
+
+    "expo-manifests": ["expo-manifests@56.0.4", "", { "dependencies": { "expo-json-utils": "~56.0.0" }, "peerDependencies": { "expo": "*" } }, "sha512-Fokawl2UkiExIF0bqGoblRFA8lYpROVD+EpvDwSW4LgqQyPwNua1gLSgHZjdl5GsVugfRMMWE3LHaibDyX93hw=="],
 
     "expo-modules-autolinking": ["expo-modules-autolinking@56.0.16", "", { "dependencies": { "@expo/require-utils": "^56.1.3", "@expo/spawn-async": "^1.8.0", "chalk": "^4.1.0", "commander": "^7.2.0" }, "bin": { "expo-modules-autolinking": "bin/expo-modules-autolinking.js" } }, "sha512-9JnL4N46P8ubDpDIfWolDn7nxU2j1rY67xY/dNVuyH0m+HG+r/JI16VYtjIf4COpZtEuFo4D3h3MBeFzGucMnw=="],
 
@@ -807,6 +820,8 @@
     "expo-status-bar": ["expo-status-bar@56.0.4", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA=="],
 
     "expo-symbols": ["expo-symbols@56.0.6", "", { "dependencies": { "@expo-google-fonts/material-symbols": "^0.4.1", "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "expo": "*", "expo-font": "*", "react": "*", "react-native": "*" } }, "sha512-BrA81DjcNafdj7gXVhdrExb9LtUiSVyOf/NavyMmDAHgHMY1GqeR5cnn1PSAZeYKnSgQhee/H89XUpAxtog5hg=="],
+
+    "expo-updates-interface": ["expo-updates-interface@56.0.2", "", { "peerDependencies": { "expo": "*" } }, "sha512-eWTwSZ9y8vrULG2oBn2TQSSIwBGSq/TxGJ3jY6tuVS2FWH/ASRIiKs3zkUZTRoC3ZuV2alz0mUClYV7nNrFx8g=="],
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
@@ -1647,6 +1662,8 @@
     "expo/expo-constants": ["expo-constants@56.0.18", "", { "dependencies": { "@expo/env": "~2.3.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-8AMtbDGl/WVPnWlmbpGmvcdnNCy9E4PFnwdVwj600vljkMDPSxcAcjw8GVXEPk3PpZ+ngTqsrkltWyj0UKYAxw=="],
 
     "expo-asset/expo-constants": ["expo-constants@56.0.18", "", { "dependencies": { "@expo/env": "~2.3.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-8AMtbDGl/WVPnWlmbpGmvcdnNCy9E4PFnwdVwj600vljkMDPSxcAcjw8GVXEPk3PpZ+ngTqsrkltWyj0UKYAxw=="],
+
+    "expo-dev-launcher/@expo/schema-utils": ["@expo/schema-utils@56.0.2", "", {}, "sha512-WcOH1E6rwxRqNwBzPOVhd5GBbMlS04+5n+ZMdhdwKOg/Kt3suV+F8F6An+z8mUJ8eSuMM3HD9Sj09t7vc/Xjkw=="],
 
     "expo-modules-autolinking/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/companion/package.json
+++ b/companion/package.json
@@ -15,6 +15,7 @@
     "expo-build-properties": "^57.0.3",
     "expo-camera": "~56.0.8",
     "expo-constants": "~56.0.20",
+    "expo-dev-client": "~56.0.22",
     "expo-linking": "~56.0.15",
     "expo-router": "~56.2.13",
     "expo-secure-store": "~56.0.4",
@@ -47,8 +48,8 @@
   },
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "uniwind:generate": "uniwind generate-artifacts --css ./global.css --dts ./uniwind-types.d.ts",
     "fmt": "biome format",

--- a/companion/plugins/withGradleWrapperVersion.js
+++ b/companion/plugins/withGradleWrapperVersion.js
@@ -37,8 +37,22 @@ module.exports = function withGradleWrapperVersion(
         'gradle-wrapper.properties',
       )
       const src = fs.readFileSync(p, 'utf8')
+      // Anchor to a line-start `distributionUrl=` (multiline flag);
+      // verify a replacement actually happened so a future Expo
+      // template drift (extra comment on the line, CRLF endings,
+      // property split across lines) surfaces as a loud plugin
+      // error instead of a silent no-op that would bring back the
+      // Gradle 9 / foojay-0.5.0 `IBM_SEMERU` crash.
+      const pattern = /^distributionUrl=.+$/m
+      if (!pattern.test(src)) {
+        throw new Error(
+          `withGradleWrapperVersion: distributionUrl line not found in ${p}. ` +
+            `Expo's gradle-wrapper.properties template may have changed shape; ` +
+            `update the plugin's regex or bump the pinned Gradle version.`,
+        )
+      }
       const patched = src.replace(
-        /distributionUrl=.+/,
+        pattern,
         `distributionUrl=https\\://services.gradle.org/distributions/gradle-${version}-bin.zip`,
       )
       fs.writeFileSync(p, patched)

--- a/companion/plugins/withGradleWrapperVersion.js
+++ b/companion/plugins/withGradleWrapperVersion.js
@@ -1,0 +1,48 @@
+const { withDangerousMod } = require('@expo/config-plugins')
+const fs = require('node:fs')
+const path = require('node:path')
+
+/**
+ * Pin the generated Android `gradle-wrapper.properties` to a Gradle
+ * version compatible with RN 0.85's bundled foojay toolchain resolver.
+ *
+ * SDK 56's default prebuild emits `distributionUrl=…gradle-9.3.1-bin.zip`,
+ * but `@react-native/gradle-plugin@0.85.x`'s `settings.gradle.kts`
+ * hard-codes `org.gradle.toolchains.foojay-resolver-convention:0.5.0`.
+ * Foojay 0.5.0 pre-dates Gradle 9's removal / rename of
+ * `JvmVendorSpec.IBM_SEMERU` → `IBM`. The class initializer for
+ * `FoojayApi.DistributionsKt` throws `NoSuchFieldError` before any
+ * task even runs, so `expo run:android` fails during Gradle's
+ * settings-evaluation phase with no useful surface error.
+ *
+ * Pin Gradle to the last 8.x release where the old constant still
+ * exists so foojay 0.5.0 keeps working. Revert this plugin (or bump
+ * the version) once RN ships with foojay >= 0.9.x (Gradle 9 support).
+ * SDK 57 / RN 0.86+ is expected to include the newer resolver.
+ *
+ * Applied via `withDangerousMod` because `expo-build-properties` does
+ * not expose a `gradleWrapperVersion` knob in 57.x.
+ */
+module.exports = function withGradleWrapperVersion(
+  config,
+  { version = '8.14.3' } = {},
+) {
+  return withDangerousMod(config, [
+    'android',
+    async (cfg) => {
+      const p = path.join(
+        cfg.modRequest.platformProjectRoot,
+        'gradle',
+        'wrapper',
+        'gradle-wrapper.properties',
+      )
+      const src = fs.readFileSync(p, 'utf8')
+      const patched = src.replace(
+        /distributionUrl=.+/,
+        `distributionUrl=https\\://services.gradle.org/distributions/gradle-${version}-bin.zip`,
+      )
+      fs.writeFileSync(p, patched)
+      return cfg
+    },
+  ])
+}


### PR DESCRIPTION
## Summary

Ground-truth foundation for PR D (native TLS cert pinning for WebSockets). The companion now builds as a custom dev client instead of running under Expo Go, which unlocks linking any native module we want. No feature code changes; every existing screen was smoke-tested on iPhone 17 Simulator and Pixel 7 Pro before landing.

Full migration reasoning + revert-when-not-needed pointers are in the plan: `plans/DaniAkash/agent-terminal/repo-work/2026-07-14-1828-claude-code-expo-dev-client-migration.md` (control-center repo).

## What changed

- **`expo-dev-client@~56.0.22`** added. Prebuild rewrote the `ios` / `android` npm scripts from `expo start --ios/android` (Expo Go) to `expo run:ios/android` (native dev build) so `bun run android` now compiles + installs the APK.
- **`ios.bundleIdentifier`** = `com.daniakash.agent-terminal.companion.dev` and **`android.package`** = `com.daniakash.agent_terminal.companion.dev` pinned in `app.json` so `expo prebuild --clean` runs stay reproducible. `.dev` suffix mirrors the desktop's `dev-instance` cargo feature.
- **`companion/plugins/withGradleWrapperVersion.js`** (new local config plugin): pins Android's `gradle-wrapper.properties` distributionUrl to Gradle 8.14.3 on every prebuild.
- `ios/` and `android/` stay gitignored (Continuous Native Generation).

## Why the Gradle pin

SDK 56's default prebuild emits Gradle 9.3.1, but `@react-native/gradle-plugin@0.85.x`'s `settings.gradle.kts` hard-codes `foojay-resolver-convention:0.5.0`. Foojay 0.5.0 references `JvmVendorSpec.IBM_SEMERU`: a constant Gradle 9 removed (renamed to `IBM`). Result: the class initializer for `FoojayApi.DistributionsKt` throws `NoSuchFieldError` before any task runs, so `expo run:android` fails during settings evaluation with no useful surface error. Pinning to 8.14.3 (the last 8.x release where the old constant still exists) keeps foojay 0.5.0 working.

Revert the plugin when RN ships with foojay >= 0.9.x. SDK 57 / RN 0.86+ is expected to include the newer resolver.

## Test plan

Smoke checklist from the plan, walked end-to-end on both platforms:

- [x] Cold boot on iPhone 17 Simulator → unpaired home CTA.
- [x] Cold boot on Pixel 7 Pro (ADB wireless) → unpaired home CTA.
- [x] Simulator: `/connect` (dev-only manual token) → connect → projects load.
- [x] Pixel: `/pair` → camera → scan desktop QR → confirm → auto-connect.
- [x] Metro fast-refresh across both platforms.
- [x] Revoke on desktop → both mobiles self-heal to unpaired.
- [x] Cold restart → auto-reconnect via \`\$device\` subscriber.
- [x] Second `expo prebuild --clean` + `expo run:android` cycle proves the Gradle pin plugin survives regen (BUILD SUCCESSFUL in 29s incremental).

## Non-blocking follow-ups

- `expo-build-properties.android.networkSecurityConfig` accepts a boolean, not a path, so the current app.json wiring for `./network-security-config.xml` never landed in AndroidManifest. Doesn't bite today (dev is on plain `ws://`); PR D's native cert-pinning module bypasses the OS trust store anyway.
- `expo-doctor` flags three SDK-56 version drifts (expo 56.0.12→56.0.15, expo-router 56.2.13→56.2.14, expo-build-properties 57.0.3→56.0.22). Left as-is; separate version-alignment PR.

## Next up

PR D: local Expo native module (`companion/modules/pinned-websocket/`) wrapping `URLSessionWebSocketTask` on iOS + OkHttp `WebSocket` with `CertificatePinner` on Android. Reverts the five Phase 2A relaxations tracked in the security overhaul plan.