### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agent-terminal"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-terminal",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-terminal"
-version = "0.1.5"
+version = "0.2.0"
 description = "Agent Terminal — a mouse-first project-scoped terminal workspace"
 authors = ["DaniAkash"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agent Terminal",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "identifier": "com.daniakash.agent-terminal",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Version bump for the v0.2.0 release. Bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `Cargo.lock` from `0.1.5` to `0.2.0`.

## Why 0.2.0 (not 0.1.6)

Roughly 150 commits since v0.1.5 dominated by three feature themes: a full TLS + QR-pairing security transport (rustls, mDNS, per-device Keychain tokens, resolver ladder, Revoke), an agent-state overhaul (registry-driven agent detection for claude-code / codex / opencode, self-healing state engine, OSC signatures), and a companion dev-client migration. That scope justifies a minor bump per SemVer while we're still pre-1.0.

## Test plan

- [ ] CI green (build + tests)
- [ ] Merge this PR, then tag `v0.2.0` on main to trigger the signed + notarized macOS release workflow
- [ ] Publish the resulting draft release from the GitHub UI once the notarization job finishes

## Note on the commit message

`chore(release)` is filtered out by `cliff.toml` so this bump commit does not appear in the auto-generated v0.2.0 release notes.