### PR TITLE
chore: postinstall hook to bootstrap sidecar node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:rust": "cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets",
     "typecheck": "tsc --noEmit",
     "test": "bun test src/ && cargo test --manifest-path src-tauri/Cargo.toml --lib && cargo test --manifest-path src-tauri/Cargo.toml --test hook_integration -- --test-threads=1",
-    "lint:fix": "biome check --write --unsafe && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --fix --allow-dirty --allow-staged"
+    "lint:fix": "biome check --write --unsafe && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --fix --allow-dirty --allow-staged",
+    "postinstall": "cd src-tauri/sidecar && bun install --frozen-lockfile"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",


### PR DESCRIPTION
## Summary

`src-tauri/sidecar/` is its own bun workspace (own `package.json` + `bun.lock`). Fresh clones, new worktrees, and CI jobs that only ran root's `bun install` were leaving `src-tauri/sidecar/node_modules/` missing, so `tauri dev` and `tauri build` would fail the moment the Rust side spawned the sidecar with a `Cannot find module '@xterm/headless'`. Everyone was expected to remember `cd src-tauri/sidecar && bun install` by hand.

Add a root `postinstall` script that runs `bun install --frozen-lockfile` inside `src-tauri/sidecar/`. Any `bun install` at the repo root now bootstraps the sidecar automatically. `--frozen-lockfile` because `src-tauri/sidecar/bun.lock` is committed and CI reproducibility matters.

## Test plan

Verified locally:

```
$ rm -rf src-tauri/sidecar/node_modules
$ bun install
...
$ cd src-tauri/sidecar && bun install --frozen-lockfile
+ @xterm/addon-serialize@0.13.0
+ @xterm/headless@5.5.0
$ ls src-tauri/sidecar/node_modules/@xterm/
addon-serialize  headless  xterm
```

- [ ] CI green
- [ ] Merge before the v0.2.0 release PR so the release workflow's build runner also picks it up automatically