### PR TITLE
fix(ci/release): use workspace-root target/ path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,11 +137,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            src-tauri/target
+            target
           # Cache key carries the target triple so the two matrix entries
           # keep separate caches. Different triples = different compiled
           # artifacts; sharing the cache would just cause misses every time.
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ matrix.target }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cargo-${{ matrix.target }}-
 
@@ -183,7 +183,7 @@ jobs:
         # download for the release page, the stable filename for the README.
         run: |
           set -euo pipefail
-          cd src-tauri/target/${{ matrix.target }}/release/bundle/dmg
+          cd target/${{ matrix.target }}/release/bundle/dmg
           case "${{ matrix.target }}" in
             aarch64-apple-darwin) STABLE=agent-terminal-aarch64.dmg ;;
             x86_64-apple-darwin)  STABLE=agent-terminal-x64.dmg ;;
@@ -204,7 +204,7 @@ jobs:
         # generation) can all rely on a stable arch suffix.
         run: |
           set -euo pipefail
-          cd src-tauri/target/${{ matrix.target }}/release/bundle/macos
+          cd target/${{ matrix.target }}/release/bundle/macos
           case "${{ matrix.target }}" in
             aarch64-apple-darwin) ARCH=aarch64 ;;
             x86_64-apple-darwin)  ARCH=x64 ;;
@@ -236,9 +236,9 @@ jobs:
         with:
           name: bundles-${{ matrix.target }}
           path: |
-            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
-            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz
-            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz.sig
+            target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz
+            target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz.sig
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
## Summary

The v0.2.0 tag push exposed a stale path in the release workflow. Commit `663cca6` promoted the repo to a Cargo workspace, moving build output from `src-tauri/target/` to workspace-root `target/`. The release workflow still hardcoded the old path in six places.

Signing + notarization actually succeeded on both matrix entries; the failure was the immediately-following `cd src-tauri/target/...` step, which stopped the workflow before any artifacts uploaded or the draft release was created. Confirmed by the workflow logs:

```
Signing /Users/runner/.../target/aarch64-apple-darwin/release/bundle/dmg/Agent Terminal_0.2.0_aarch64.dmg
...
/tmp/....sh: line 2: cd: src-tauri/target/aarch64-apple-darwin/release/bundle/dmg: No such file or directory
```

Swap all six references:

- Cache `path:` (line 140)
- Cache `key:` lockfile ref (line 144)
- `cd` for DMG stable-name copy (line 186)
- `cd` for updater bundle rename (line 207)
- Three artifact-upload globs (lines 239-241)

## Contract preserved

- DMG stable filenames stay `agent-terminal-{aarch64,x64}.dmg` (`STABLE=` values at lines 188-189 unchanged). `.github/workflows/tap-dispatch.yml` reads those literal names to feed the homebrew tap; that pipeline is unaffected.
- Updater bundle rename step still normalises spaces to dots and appends `_aarch64` / `_x64`.

## Test plan

- [ ] Merge this PR
- [ ] Delete existing `v0.2.0` tag (locally + on origin) so the tag can be re-pushed to trigger a fresh workflow run against the fixed workflow
- [ ] Re-tag `v0.2.0` on the new main tip (which includes this fix) and push
- [ ] Watch the release workflow through completion; both DMGs + updater bundles + `agent-terminal-{aarch64,x64}.dmg` stable copies must attach to the draft release
- [ ] Publish the draft; verify `tap-dispatch.yml` fires and the homebrew tap picks up v0.2.0