### PR TITLE
feat(companion/wss): lifecycle + network resilience (PR M1)

### DIFF
--- a/companion/.fallowrc.jsonc
+++ b/companion/.fallowrc.jsonc
@@ -51,6 +51,11 @@
     "ignore": [
       "src/modules/wss/client.ts",
       "src/modules/wss/bootstrap.ts",
+      // Thin async shells around AppState + NetInfo listeners. The
+      // decision cores live in lifecycle.helpers.ts (unit-tested) and
+      // the side effects live in client.ts. Same pattern as the two
+      // entries above.
+      "src/modules/wss/lifecycle.ts",
       "src/screens/pair/**",
       "src/screens/home/**"
     ]

--- a/companion/.fallowrc.jsonc
+++ b/companion/.fallowrc.jsonc
@@ -51,11 +51,6 @@
     "ignore": [
       "src/modules/wss/client.ts",
       "src/modules/wss/bootstrap.ts",
-      // Thin async shells around AppState + NetInfo listeners. The
-      // decision cores live in lifecycle.helpers.ts (unit-tested) and
-      // the side effects live in client.ts. Same pattern as the two
-      // entries above.
-      "src/modules/wss/lifecycle.ts",
       "src/screens/pair/**",
       "src/screens/home/**"
     ]

--- a/companion/.gitignore
+++ b/companion/.gitignore
@@ -48,3 +48,10 @@ yarn-error.*
 # generated native folders
 /ios
 /android
+
+# Gradle build output inside local Expo modules. Ephemeral, regenerated
+# on every `expo run:android`, never committed. Also keeps biome + fallow
+# from scanning it via their `useIgnoreFile` integration.
+modules/*/android/build/
+modules/*/android/.gradle/
+modules/*/android/local.properties

--- a/companion/bun.lock
+++ b/companion/bun.lock
@@ -10,6 +10,7 @@
         "@hookform/resolvers": "^5.4.0",
         "@nanostores/react": "^1.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/netinfo": "12.0.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
@@ -430,6 +431,8 @@
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
 
     "@react-native-async-storage/async-storage": ["@react-native-async-storage/async-storage@2.2.0", "", { "dependencies": { "merge-options": "^3.0.4" }, "peerDependencies": { "react-native": "^0.0.0-0 || >=0.65 <1.0" } }, "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw=="],
+
+    "@react-native-community/netinfo": ["@react-native-community/netinfo@12.0.1", "", { "peerDependencies": { "react": "*", "react-native": ">=0.59" } }, "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ=="],
 
     "@react-native-masked-view/masked-view": ["@react-native-masked-view/masked-view@0.3.2", "", { "peerDependencies": { "react": ">=16", "react-native": ">=0.57" } }, "sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ=="],
 

--- a/companion/package.json
+++ b/companion/package.json
@@ -8,6 +8,7 @@
     "@hookform/resolvers": "^5.4.0",
     "@nanostores/react": "^1.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/netinfo": "12.0.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/companion/src/modules/wss/bootstrap.ts
+++ b/companion/src/modules/wss/bootstrap.ts
@@ -5,6 +5,7 @@ import {
 } from '@/modules/stores/$device'
 import { $session } from '@/modules/stores/$session'
 import { autoConnect, disconnect } from './client'
+import { initLifecycleWiring, resetLifecycleWiring } from './lifecycle'
 
 /**
  * WSS boot-time wiring. Idempotent; safe to call multiple times but
@@ -86,18 +87,24 @@ export async function initWssBootstrap(): Promise<void> {
     void clearDevice()
   })
 
+  // AppState + NetInfo wiring. Attaches listeners that force-close the
+  // socket on network drops and probe / reconnect on app foreground so
+  // a backgrounded-app-with-dead-socket case never bricks the client.
+  initLifecycleWiring()
+
   // Cold-start read. Fires the device subscriber above as a side
   // effect of `$device.set(...)` inside; if the phone was previously
   // paired, that immediately kicks the resolver ladder.
   await loadDeviceFromSecureStore()
 }
 
-/** Test / hot-reload seam: tears down both subscriptions. */
+/** Test / hot-reload seam: tears down every subscription + listener. */
 // fallow-ignore-next-line unused-export
 export function resetWssBootstrap(): void {
   unsubscribeDevice?.()
   unsubscribeSession?.()
   unsubscribeDevice = null
   unsubscribeSession = null
+  resetLifecycleWiring()
   initialized = false
 }

--- a/companion/src/modules/wss/client.helpers.test.ts
+++ b/companion/src/modules/wss/client.helpers.test.ts
@@ -2,20 +2,53 @@ import { describe, expect, test } from 'bun:test'
 import { computeBackoffDelay } from './client.helpers'
 
 describe('computeBackoffDelay', () => {
-  test('starts at 1 s on the first attempt', () => {
-    expect(computeBackoffDelay(0)).toBe(1_000)
+  // Zero-jitter random for deterministic assertions on the exponential
+  // branch; the fast-attempt branch (attempts 0 and 1) ignores random.
+  const zeroRandom = () => 0
+  const maxRandom = () => 0.9999
+
+  test('first two attempts fire fast (250 ms, 500 ms) so foreground resume feels instant', () => {
+    expect(computeBackoffDelay(0)).toBe(250)
+    expect(computeBackoffDelay(1)).toBe(500)
   })
 
-  test('doubles each attempt', () => {
-    expect(computeBackoffDelay(1)).toBe(2_000)
-    expect(computeBackoffDelay(2)).toBe(4_000)
-    expect(computeBackoffDelay(3)).toBe(8_000)
-    expect(computeBackoffDelay(4)).toBe(16_000)
+  test('fast attempts ignore the jitter source', () => {
+    expect(computeBackoffDelay(0, { random: maxRandom })).toBe(250)
+    expect(computeBackoffDelay(1, { random: maxRandom })).toBe(500)
   })
 
-  test('caps at 30 s', () => {
-    expect(computeBackoffDelay(5)).toBe(30_000)
-    expect(computeBackoffDelay(10)).toBe(30_000)
-    expect(computeBackoffDelay(100)).toBe(30_000)
+  test('exponential branch doubles each attempt from a 1 s base', () => {
+    expect(computeBackoffDelay(2, { random: zeroRandom })).toBe(1_000)
+    expect(computeBackoffDelay(3, { random: zeroRandom })).toBe(2_000)
+    expect(computeBackoffDelay(4, { random: zeroRandom })).toBe(4_000)
+    expect(computeBackoffDelay(5, { random: zeroRandom })).toBe(8_000)
+    expect(computeBackoffDelay(6, { random: zeroRandom })).toBe(16_000)
+  })
+
+  test('caps at 30 s + jitter', () => {
+    // 1000 * 2^(7-1) = 64000, capped to 30000. Plus jitter.
+    expect(computeBackoffDelay(7, { random: zeroRandom })).toBe(30_000)
+    expect(computeBackoffDelay(10, { random: zeroRandom })).toBe(30_000)
+    expect(computeBackoffDelay(100, { random: zeroRandom })).toBe(30_000)
+  })
+
+  test('adds 0-249 ms of jitter on the exponential branch', () => {
+    // Deterministic random source pinned at 0.5 yields exactly floor(125).
+    const midRandom = () => 0.5
+    expect(computeBackoffDelay(2, { random: midRandom })).toBe(1_125)
+    expect(computeBackoffDelay(3, { random: midRandom })).toBe(2_125)
+    // Upper edge: 0.9999 * 250 -> 249.
+    expect(computeBackoffDelay(2, { random: maxRandom })).toBe(1_249)
+    expect(computeBackoffDelay(7, { random: maxRandom })).toBe(30_249)
+  })
+
+  test('jitter is always in [0, 249]', () => {
+    // Sample a chunk of the real Math.random source and verify every
+    // exponential-branch delay lands in the expected band.
+    for (let i = 0; i < 200; i++) {
+      const d = computeBackoffDelay(2)
+      expect(d).toBeGreaterThanOrEqual(1_000)
+      expect(d).toBeLessThanOrEqual(1_249)
+    }
   })
 })

--- a/companion/src/modules/wss/client.helpers.test.ts
+++ b/companion/src/modules/wss/client.helpers.test.ts
@@ -26,7 +26,7 @@ describe('computeBackoffDelay', () => {
   })
 
   test('caps at 30 s + jitter', () => {
-    // 1000 * 2^(7-1) = 64000, capped to 30000. Plus jitter.
+    // 1000 * 2^(7-2) = 32000, capped to 30000. Plus jitter.
     expect(computeBackoffDelay(7, { random: zeroRandom })).toBe(30_000)
     expect(computeBackoffDelay(10, { random: zeroRandom })).toBe(30_000)
     expect(computeBackoffDelay(100, { random: zeroRandom })).toBe(30_000)

--- a/companion/src/modules/wss/client.helpers.ts
+++ b/companion/src/modules/wss/client.helpers.ts
@@ -1,7 +1,34 @@
+// First two attempts fire fast so a foreground / network-transition
+// resume feels instant. From attempt 2 onward we fall into exponential
+// backoff so a genuinely-down desktop doesn't get hammered.
+const FAST_ATTEMPT_DELAYS_MS = [250, 500] as const
 const BACKOFF_MIN_MS = 1_000
 const BACKOFF_MAX_MS = 30_000
+const JITTER_MAX_MS = 250
 
-export function computeBackoffDelay(attempt: number): number {
-  const raw = BACKOFF_MIN_MS * 2 ** attempt
-  return Math.min(raw, BACKOFF_MAX_MS)
+export interface BackoffDeps {
+  /** Injected for tests. Defaults to `Math.random`. */
+  random?: () => number
+}
+
+/**
+ * Delay before reconnect attempt N (0-indexed). Layered:
+ *
+ * - Attempt 0: 250 ms
+ * - Attempt 1: 500 ms
+ * - Attempt 2+: 1000 * 2^(attempt - 2), capped at 30 s, plus 0-249 ms
+ *   of jitter to avoid thundering-herd when multiple mobile clients wake
+ *   from a shared "Wi-Fi came back" event.
+ */
+export function computeBackoffDelay(
+  attempt: number,
+  deps: BackoffDeps = {},
+): number {
+  const fast = FAST_ATTEMPT_DELAYS_MS[attempt]
+  if (fast !== undefined) return fast
+  const random = deps.random ?? Math.random
+  const exponent = attempt - 2
+  const raw = BACKOFF_MIN_MS * 2 ** exponent
+  const base = Math.min(raw, BACKOFF_MAX_MS)
+  return base + Math.floor(random() * JITTER_MAX_MS)
 }

--- a/companion/src/modules/wss/client.ts
+++ b/companion/src/modules/wss/client.ts
@@ -227,6 +227,19 @@ const pendingOps = new Map<number, PendingOp>()
 
 const OP_TIMEOUT_MS = 10_000
 
+/**
+ * Reject every in-flight CRUD op with `err`. Called on any hard close
+ * so callers don't sit spinning for the 10-second op timeout when the
+ * socket is already gone.
+ */
+function rejectAllPending(err: Error): void {
+  for (const [, pending] of pendingOps) {
+    clearTimeout(pending.timer)
+    pending.reject(err)
+  }
+  pendingOps.clear()
+}
+
 // Shared pending-op plumbing: register the op_id in the pending map,
 // arm the timeout, then send the fully-typed frame. Every caller passes
 // a `ClientFrame` built from the generated union — no casts, no escape
@@ -344,11 +357,14 @@ function openSocket(): void {
   }
   ws.onclose = (event) => {
     if (!isCurrentGeneration(generation)) return
-    handleClose(event.code, event.reason)
+    forceCloseAndReconnect(event.reason || `socket closed (${event.code})`)
   }
   ws.onerror = (event) => {
     if (!isCurrentGeneration(generation)) return
-    console.error('[wss.client] socket error event', event.message)
+    // Route through forceCloseAndReconnect so a zombie socket that
+    // fires onerror without a matching onclose still tears down.
+    // Idempotent via the generation bump inside forceCloseAndReconnect.
+    forceCloseAndReconnect(event.message || 'socket error')
   }
 }
 
@@ -385,10 +401,30 @@ function handleOpen(): void {
   send({ op: 'auth', body: { token: state.token ?? '' } })
 }
 
-function handleClose(code: number, reason: string): void {
-  console.log('[wss.client] socket closed', { code, reason })
-  clearTimers()
+/**
+ * Single teardown path for every "this socket is dead" signal:
+ * onclose from the underlying socket, onerror from an already-half-
+ * dead socket, or a synthesised close from lifecycle / probe code
+ * that noticed the socket is a zombie. Bumps the generation so any
+ * further callbacks from the doomed socket are ignored, rejects
+ * in-flight ops so callers fail fast, and schedules a reconnect
+ * unless the disconnect was intentional (user unpair, revoke).
+ *
+ * Idempotent: safe to call more than once; the generation bump makes
+ * subsequent callbacks from the same socket no-ops and the pending-op
+ * map is emptied on the first call.
+ */
+function forceCloseAndReconnect(reason: string): void {
+  console.log('[wss.client] forceClose:', reason)
+  state.socketGeneration += 1
+  try {
+    state.socket?.close()
+  } catch {
+    /* best-effort; a truly dead socket may throw */
+  }
   state.socket = null
+  clearTimers()
+  rejectAllPending(new Error(`connection lost: ${reason}`))
   if (state.intentionallyDisconnected) return
   if ($session.get().status !== 'auth_failed') {
     $session.setKey('status', 'unreachable')

--- a/companion/src/modules/wss/client.ts
+++ b/companion/src/modules/wss/client.ts
@@ -605,7 +605,10 @@ function scheduleReconnect(): void {
 
 function startHeartbeat(): void {
   clearTimers()
-  state.heartbeatTimer = setInterval(heartbeatAndWatchdogTick, HEARTBEAT_INTERVAL_MS)
+  state.heartbeatTimer = setInterval(
+    heartbeatAndWatchdogTick,
+    HEARTBEAT_INTERVAL_MS,
+  )
 }
 
 /**

--- a/companion/src/modules/wss/client.ts
+++ b/companion/src/modules/wss/client.ts
@@ -38,7 +38,14 @@ type ConnectionState = {
   reconnectTimer: ReturnType<typeof setTimeout> | null
   heartbeatTimer: ReturnType<typeof setInterval> | null
   pongDeadline: number | null
+  /**
+   * Wall-clock ms of the last inbound frame of any kind. Feeds the
+   * watchdog (receive-side liveness) and probeConnection (foreground
+   * probe waits for lastFrameAt to bump past a captured baseline).
+   */
+  lastFrameAt: number | null
   intentionallyDisconnected: boolean
+  probing: boolean
 }
 
 const state: ConnectionState = {
@@ -50,11 +57,23 @@ const state: ConnectionState = {
   reconnectTimer: null,
   heartbeatTimer: null,
   pongDeadline: null,
+  lastFrameAt: null,
   intentionallyDisconnected: false,
+  probing: false,
 }
 
 const HEARTBEAT_INTERVAL_MS = 15_000
 const PONG_TIMEOUT_MS = 30_000
+// Watchdog: force-close if no inbound frame in this window. Sized just
+// above heartbeat's worst-case round-trip (15 s ping cadence + 30 s
+// pong window) so a normal missed pong doesn't trip it, but a truly
+// silent socket doesn't linger past ~45 s.
+const FRAME_STALE_MS = 45_000
+// probeConnection budget: on foreground / network transition we send
+// a ping and wait for ANY inbound frame this long before declaring the
+// socket dead.
+const PROBE_TIMEOUT_MS = 3_000
+const PROBE_POLL_MS = 100
 
 export function connect(url: string, token: string): void {
   // Every connection is TLS-pinned end-to-end. The PinnedWebSocket
@@ -347,6 +366,9 @@ function openSocket(): void {
   state.socketGeneration += 1
   const generation = state.socketGeneration
   state.socket = ws
+  // Fresh socket, no history. Watchdog needs a baseline so it doesn't
+  // fire on the first tick before any frame has arrived.
+  state.lastFrameAt = Date.now()
   ws.onopen = () => {
     if (!isCurrentGeneration(generation)) return
     handleOpen()
@@ -434,6 +456,10 @@ function forceCloseAndReconnect(reason: string): void {
 }
 
 function handleFrame(raw: string): void {
+  // Stamp the receive-side liveness clock BEFORE parsing so even a
+  // malformed frame from the desktop still counts as "the peer is
+  // alive". Watchdog + probeConnection both key off this timestamp.
+  state.lastFrameAt = Date.now()
   let frame: ServerFrame
   try {
     frame = JSON.parse(raw) as ServerFrame
@@ -579,11 +605,29 @@ function scheduleReconnect(): void {
 
 function startHeartbeat(): void {
   clearTimers()
-  state.heartbeatTimer = setInterval(heartbeatTick, HEARTBEAT_INTERVAL_MS)
+  state.heartbeatTimer = setInterval(heartbeatAndWatchdogTick, HEARTBEAT_INTERVAL_MS)
 }
 
-function heartbeatTick(): void {
+/**
+ * Runs once per HEARTBEAT_INTERVAL_MS. Combines two liveness checks:
+ *
+ * - Heartbeat (send-side): fire a ping, expect a pong within
+ *   PONG_TIMEOUT_MS. Detects "server never replied to us".
+ * - Watchdog (receive-side): if we haven't seen ANY inbound frame in
+ *   FRAME_STALE_MS, the peer went silent. Detects "server stopped
+ *   saying anything at all, including broadcasts we should be seeing".
+ *
+ * Different failure modes, different latencies, both worth catching.
+ */
+function heartbeatAndWatchdogTick(): void {
   if (state.socket?.readyState !== PinnedWebSocket.OPEN) return
+  const last = state.lastFrameAt
+  if (last !== null && Date.now() - last > FRAME_STALE_MS) {
+    forceCloseAndReconnect(
+      `no frames for ${Math.round((Date.now() - last) / 1000)}s`,
+    )
+    return
+  }
   send({ op: 'ping' })
   updatePongDeadline()
 }
@@ -594,8 +638,45 @@ function updatePongDeadline(): void {
     return
   }
   if (Date.now() > state.pongDeadline) {
-    state.socket?.close()
+    forceCloseAndReconnect('pong deadline exceeded')
   }
+}
+
+/**
+ * Active liveness check for lifecycle events (app foreground, network
+ * transition). Sends a ping and polls lastFrameAt for up to
+ * PROBE_TIMEOUT_MS looking for ANY inbound frame. Returns 'alive' if
+ * we saw one, 'dead' otherwise.
+ *
+ * Callers (lifecycle.ts) reconnect on 'dead'. Concurrent probes short-
+ * circuit to 'alive' rather than stacking pings.
+ */
+export async function probeConnection(): Promise<'alive' | 'dead'> {
+  if (state.socket?.readyState !== PinnedWebSocket.OPEN) return 'dead'
+  if (state.probing) return 'alive'
+  state.probing = true
+  const before = state.lastFrameAt ?? 0
+  send({ op: 'ping' })
+  const startedAt = Date.now()
+  try {
+    while (Date.now() - startedAt < PROBE_TIMEOUT_MS) {
+      if ((state.lastFrameAt ?? 0) > before) return 'alive'
+      await new Promise((r) => setTimeout(r, PROBE_POLL_MS))
+    }
+    return 'dead'
+  } finally {
+    state.probing = false
+  }
+}
+
+/**
+ * Public entry point for lifecycle.ts to force-close a suspected-dead
+ * socket. Thin wrapper around the internal helper; keeps the export
+ * surface intentional so callers can't accidentally invoke the raw
+ * internals.
+ */
+export function forceCloseFromLifecycle(reason: string): void {
+  forceCloseAndReconnect(reason)
 }
 
 function clearTimers(): void {

--- a/companion/src/modules/wss/lifecycle.helpers.test.ts
+++ b/companion/src/modules/wss/lifecycle.helpers.test.ts
@@ -3,6 +3,8 @@ import {
   classifyAppStateTransition,
   classifyNetInfoChange,
   decideForegroundAction,
+  executeForegroundAction,
+  executeNetInfoAction,
   TRUSTED_BACKGROUND_MS,
 } from './lifecycle.helpers'
 
@@ -118,5 +120,134 @@ describe('classifyNetInfoChange', () => {
     expect(
       classifyNetInfoChange({ isInternetReachable: null }, 'unreachable', true),
     ).toBe('skip')
+  })
+})
+
+describe('executeForegroundAction', () => {
+  type Rec = { id: string }
+  const record: Rec = { id: 'r1' }
+
+  function makeDeps(
+    overrides: Partial<{
+      autoConnect: (r: Rec) => Promise<void>
+      probeConnection: () => Promise<'alive' | 'dead'>
+      forceClose: (reason: string) => void
+    }> = {},
+  ) {
+    const calls: string[] = []
+    const deps = {
+      autoConnect: async (r: Rec) => {
+        calls.push(`autoConnect:${r.id}`)
+      },
+      probeConnection: async () => 'alive' as const,
+      forceClose: (r: string) => {
+        calls.push(`forceClose:${r}`)
+      },
+      ...overrides,
+    }
+    return { deps, calls }
+  }
+
+  test('action=skip is a no-op regardless of record', async () => {
+    const { deps, calls } = makeDeps()
+    await executeForegroundAction('skip', record, deps)
+    await executeForegroundAction('skip', null, deps)
+    expect(calls).toEqual([])
+  })
+
+  test('action=reconnect with a record calls autoConnect once', async () => {
+    const { deps, calls } = makeDeps()
+    await executeForegroundAction('reconnect', record, deps)
+    expect(calls).toEqual(['autoConnect:r1'])
+  })
+
+  test('action=reconnect with null record does nothing (guard against races)', async () => {
+    const { deps, calls } = makeDeps()
+    await executeForegroundAction('reconnect', null, deps)
+    expect(calls).toEqual([])
+  })
+
+  test('action=probe: alive verdict does NOT reconnect', async () => {
+    let probes = 0
+    const { deps, calls } = makeDeps({
+      probeConnection: async () => {
+        probes++
+        return 'alive'
+      },
+    })
+    await executeForegroundAction('probe', record, deps)
+    expect(probes).toBe(1)
+    expect(calls).toEqual([])
+  })
+
+  test('action=probe: dead verdict reconnects', async () => {
+    const { deps, calls } = makeDeps({
+      probeConnection: async () => 'dead',
+    })
+    await executeForegroundAction('probe', record, deps)
+    expect(calls).toEqual(['autoConnect:r1'])
+  })
+
+  test('action=probe with null record: skip entirely (no probe either)', async () => {
+    let probes = 0
+    const { deps, calls } = makeDeps({
+      probeConnection: async () => {
+        probes++
+        return 'dead'
+      },
+    })
+    await executeForegroundAction('probe', null, deps)
+    expect(probes).toBe(0)
+    expect(calls).toEqual([])
+  })
+})
+
+describe('executeNetInfoAction', () => {
+  type Rec = { id: string }
+  const record: Rec = { id: 'r1' }
+
+  function makeDeps() {
+    const calls: string[] = []
+    const deps = {
+      autoConnect: async (r: Rec) => {
+        calls.push(`autoConnect:${r.id}`)
+      },
+      probeConnection: async () => 'alive' as const,
+      forceClose: (reason: string) => {
+        calls.push(`forceClose:${reason}`)
+      },
+    }
+    return { deps, calls }
+  }
+
+  test('action=skip is a no-op', () => {
+    const { deps, calls } = makeDeps()
+    executeNetInfoAction('skip', record, deps)
+    executeNetInfoAction('skip', null, deps)
+    expect(calls).toEqual([])
+  })
+
+  test('action=force-close calls forceClose with the "network unreachable" reason', () => {
+    const { deps, calls } = makeDeps()
+    executeNetInfoAction('force-close', record, deps)
+    expect(calls).toEqual(['forceClose:network unreachable'])
+  })
+
+  test('action=force-close ignores the record (works with or without one)', () => {
+    const { deps, calls } = makeDeps()
+    executeNetInfoAction('force-close', null, deps)
+    expect(calls).toEqual(['forceClose:network unreachable'])
+  })
+
+  test('action=reconnect with a record kicks autoConnect', () => {
+    const { deps, calls } = makeDeps()
+    executeNetInfoAction('reconnect', record, deps)
+    expect(calls).toEqual(['autoConnect:r1'])
+  })
+
+  test('action=reconnect with null record is a no-op (guard against races)', () => {
+    const { deps, calls } = makeDeps()
+    executeNetInfoAction('reconnect', null, deps)
+    expect(calls).toEqual([])
   })
 })

--- a/companion/src/modules/wss/lifecycle.helpers.test.ts
+++ b/companion/src/modules/wss/lifecycle.helpers.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  classifyAppStateTransition,
+  classifyNetInfoChange,
+  decideForegroundAction,
+  TRUSTED_BACKGROUND_MS,
+} from './lifecycle.helpers'
+
+describe('classifyAppStateTransition', () => {
+  test('active -> background is a background transition', () => {
+    expect(classifyAppStateTransition('active', 'background')).toBe(
+      'background',
+    )
+  })
+
+  test('active -> inactive counts as background too (iOS quick-swipe path)', () => {
+    expect(classifyAppStateTransition('active', 'inactive')).toBe('background')
+  })
+
+  test('background -> active is a foreground transition', () => {
+    expect(classifyAppStateTransition('background', 'active')).toBe(
+      'foreground',
+    )
+  })
+
+  test('inactive -> active is a foreground transition', () => {
+    expect(classifyAppStateTransition('inactive', 'active')).toBe('foreground')
+  })
+
+  test('active -> active is a no-op', () => {
+    expect(classifyAppStateTransition('active', 'active')).toBe('none')
+  })
+
+  test('background -> inactive is a no-op (neither edge we care about)', () => {
+    expect(classifyAppStateTransition('background', 'inactive')).toBe('none')
+  })
+
+  test('inactive -> background is a no-op', () => {
+    expect(classifyAppStateTransition('inactive', 'background')).toBe('none')
+  })
+})
+
+describe('decideForegroundAction', () => {
+  test('no paired device: skip', () => {
+    expect(decideForegroundAction(0, 'connected', false)).toBe('skip')
+    expect(decideForegroundAction(9_999_999, 'unreachable', false)).toBe('skip')
+  })
+
+  test('already connecting: skip so we do not double the ladder', () => {
+    expect(decideForegroundAction(0, 'connecting', true)).toBe('skip')
+    expect(decideForegroundAction(90_000, 'connecting', true)).toBe('skip')
+  })
+
+  test('short background AND currently connected: probe', () => {
+    expect(decideForegroundAction(10_000, 'connected', true)).toBe('probe')
+    expect(
+      decideForegroundAction(TRUSTED_BACKGROUND_MS, 'connected', true),
+    ).toBe('probe')
+  })
+
+  test('long background (> TRUSTED_BACKGROUND_MS): reconnect', () => {
+    expect(
+      decideForegroundAction(TRUSTED_BACKGROUND_MS + 1, 'connected', true),
+    ).toBe('reconnect')
+    expect(decideForegroundAction(300_000, 'connected', true)).toBe('reconnect')
+  })
+
+  test('was offline (unreachable / disconnected / auth_failed) with a record: reconnect', () => {
+    expect(decideForegroundAction(0, 'unreachable', true)).toBe('reconnect')
+    expect(decideForegroundAction(0, 'disconnected', true)).toBe('reconnect')
+    expect(decideForegroundAction(0, 'auth_failed', true)).toBe('reconnect')
+  })
+})
+
+describe('classifyNetInfoChange', () => {
+  test('network went unreachable while we thought we were connected: force-close', () => {
+    expect(
+      classifyNetInfoChange({ isInternetReachable: false }, 'connected', true),
+    ).toBe('force-close')
+  })
+
+  test('network back while unreachable AND paired: reconnect', () => {
+    expect(
+      classifyNetInfoChange({ isInternetReachable: true }, 'unreachable', true),
+    ).toBe('reconnect')
+  })
+
+  test('network back but no paired device: skip', () => {
+    expect(
+      classifyNetInfoChange(
+        { isInternetReachable: true },
+        'unreachable',
+        false,
+      ),
+    ).toBe('skip')
+  })
+
+  test('network back but we think we are still connected: skip (heartbeat will notice if not)', () => {
+    expect(
+      classifyNetInfoChange({ isInternetReachable: true }, 'connected', true),
+    ).toBe('skip')
+  })
+
+  test('unreachability while already unreachable: skip (already knew)', () => {
+    expect(
+      classifyNetInfoChange(
+        { isInternetReachable: false },
+        'unreachable',
+        true,
+      ),
+    ).toBe('skip')
+  })
+
+  test('null isInternetReachable (unknown, common on Android boot): skip', () => {
+    expect(
+      classifyNetInfoChange({ isInternetReachable: null }, 'connected', true),
+    ).toBe('skip')
+    expect(
+      classifyNetInfoChange({ isInternetReachable: null }, 'unreachable', true),
+    ).toBe('skip')
+  })
+})

--- a/companion/src/modules/wss/lifecycle.helpers.ts
+++ b/companion/src/modules/wss/lifecycle.helpers.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure decision helpers for the AppState + NetInfo listeners in
+ * lifecycle.ts. Extracting the branchy logic here keeps the async
+ * shells thin (one switch each) and lets us unit-test the decisions
+ * without mocking AppState / NetInfo.
+ */
+
+import type { AppStateStatus } from 'react-native'
+
+/**
+ * Backgrounds shorter than this are trusted: the socket often survives
+ * a quick app switch. Longer backgrounds burn the socket preemptively
+ * because iOS starts suspending sockets in the first minute or so.
+ */
+export const TRUSTED_BACKGROUND_MS = 60_000
+
+export type AppStateTransition = 'foreground' | 'background' | 'none'
+
+/** Classify an AppState transition into one of the three we care about. */
+export function classifyAppStateTransition(
+  prev: AppStateStatus,
+  next: AppStateStatus,
+): AppStateTransition {
+  const isBackgroundish = (s: AppStateStatus): boolean =>
+    s === 'background' || s === 'inactive'
+  if (prev === 'active' && isBackgroundish(next)) return 'background'
+  if (isBackgroundish(prev) && next === 'active') return 'foreground'
+  return 'none'
+}
+
+export type SessionStatusHint =
+  | 'connected'
+  | 'connecting'
+  | 'unreachable'
+  | 'auth_failed'
+  | 'disconnected'
+
+export type ForegroundAction = 'skip' | 'probe' | 'reconnect'
+
+/**
+ * Decide what to do when the app comes back to the foreground.
+ *
+ * - No paired device -> nothing to do, skip.
+ * - Already reconnecting -> let the ladder finish, skip.
+ * - Long background OR was already offline -> reconnect.
+ * - Otherwise (short background AND we think we're connected) -> probe.
+ */
+export function decideForegroundAction(
+  elapsedMs: number,
+  status: SessionStatusHint,
+  hasRecord: boolean,
+): ForegroundAction {
+  if (!hasRecord) return 'skip'
+  if (status === 'connecting') return 'skip'
+  if (elapsedMs > TRUSTED_BACKGROUND_MS) return 'reconnect'
+  if (status !== 'connected') return 'reconnect'
+  return 'probe'
+}
+
+/** Minimal shape of a NetInfoState we care about for lifecycle decisions. */
+export interface NetInfoLike {
+  isInternetReachable: boolean | null
+}
+
+export type NetInfoAction = 'skip' | 'force-close' | 'reconnect'
+
+/**
+ * Decide what to do on a NetInfo change.
+ *
+ * - isInternetReachable=false while we think we're connected -> close;
+ *   the socket is guaranteed dead once the network says so and closing
+ *   now lets the reconnect ladder be ready the instant we're back.
+ * - isInternetReachable=true while we're unreachable AND paired ->
+ *   reconnect. This is the "network came back" case.
+ * - null (unknown, common during Android boot) -> skip.
+ */
+export function classifyNetInfoChange(
+  net: NetInfoLike,
+  status: SessionStatusHint,
+  hasRecord: boolean,
+): NetInfoAction {
+  if (net.isInternetReachable === false && status === 'connected') {
+    return 'force-close'
+  }
+  if (
+    net.isInternetReachable === true &&
+    status === 'unreachable' &&
+    hasRecord
+  ) {
+    return 'reconnect'
+  }
+  return 'skip'
+}

--- a/companion/src/modules/wss/lifecycle.helpers.ts
+++ b/companion/src/modules/wss/lifecycle.helpers.ts
@@ -108,7 +108,9 @@ export function executeNetInfoAction<TRecord>(
     return
   }
   if (action === 'reconnect' && record !== null) {
-    void deps.autoConnect(record)
+    deps.autoConnect(record).catch((err: unknown) => {
+      console.error('[wss.lifecycle] autoConnect from NetInfo failed:', err)
+    })
   }
 }
 

--- a/companion/src/modules/wss/lifecycle.helpers.ts
+++ b/companion/src/modules/wss/lifecycle.helpers.ts
@@ -65,6 +65,54 @@ export interface NetInfoLike {
 export type NetInfoAction = 'skip' | 'force-close' | 'reconnect'
 
 /**
+ * Side-effect deps executeForegroundAction and executeNetInfoAction
+ * dispatch to. Real production wiring passes the real client.ts
+ * exports; tests pass fakes that record what got called.
+ */
+export interface LifecycleDeps<TRecord> {
+  autoConnect: (record: TRecord) => Promise<void>
+  probeConnection: () => Promise<'alive' | 'dead'>
+  forceClose: (reason: string) => void
+}
+
+/**
+ * Execute the foreground action chosen by decideForegroundAction. Pure
+ * with respect to deps: does not touch $device / $session / imports
+ * itself; everything flows in through the deps arg. Kept here (rather
+ * than as another switch in lifecycle.ts) so the branching is unit-
+ * testable without mocking react-native.
+ */
+export async function executeForegroundAction<TRecord>(
+  action: ForegroundAction,
+  record: TRecord | null,
+  deps: LifecycleDeps<TRecord>,
+): Promise<void> {
+  if (action === 'skip' || record === null) return
+  if (action === 'reconnect') {
+    await deps.autoConnect(record)
+    return
+  }
+  // action === 'probe'
+  const verdict = await deps.probeConnection()
+  if (verdict === 'dead') await deps.autoConnect(record)
+}
+
+/** Same shape as executeForegroundAction, for the NetInfo path. */
+export function executeNetInfoAction<TRecord>(
+  action: NetInfoAction,
+  record: TRecord | null,
+  deps: LifecycleDeps<TRecord>,
+): void {
+  if (action === 'force-close') {
+    deps.forceClose('network unreachable')
+    return
+  }
+  if (action === 'reconnect' && record !== null) {
+    void deps.autoConnect(record)
+  }
+}
+
+/**
  * Decide what to do on a NetInfo change.
  *
  * - isInternetReachable=false while we think we're connected -> close;

--- a/companion/src/modules/wss/lifecycle.ts
+++ b/companion/src/modules/wss/lifecycle.ts
@@ -1,0 +1,110 @@
+import NetInfo from '@react-native-community/netinfo'
+import type { NetInfoState } from '@react-native-community/netinfo'
+import { AppState } from 'react-native'
+import type { AppStateStatus } from 'react-native'
+import { $device } from '@/modules/stores/$device'
+import { $session } from '@/modules/stores/$session'
+import { autoConnect, forceCloseFromLifecycle, probeConnection } from './client'
+import {
+  classifyAppStateTransition,
+  classifyNetInfoChange,
+  decideForegroundAction,
+  type SessionStatusHint,
+} from './lifecycle.helpers'
+
+let initialized = false
+let currentAppState: AppStateStatus = AppState.currentState
+let backgroundedAt: number | null = null
+let appStateSub: { remove: () => void } | null = null
+let netInfoUnsub: (() => void) | null = null
+
+/**
+ * Attach AppState + NetInfo listeners that keep the WSS client honest
+ * about the mobile lifecycle:
+ *
+ * - Foreground after a short background: probe the socket. Reconnect
+ *   only if the probe fails.
+ * - Foreground after a long background: reconnect unconditionally.
+ * - Network drop: force-close so the reconnect ladder can start the
+ *   instant the network comes back.
+ * - Network back: kick autoConnect if we were unreachable.
+ *
+ * Every decision routes through the pure helpers in
+ * `lifecycle.helpers.ts`; this file is the thin shell that wires the
+ * side effects (autoConnect / probeConnection / forceCloseFromLifecycle)
+ * to the classified events.
+ *
+ * Idempotent: safe to call multiple times, only wires once.
+ */
+export function initLifecycleWiring(): void {
+  if (initialized) return
+  initialized = true
+  currentAppState = AppState.currentState
+  appStateSub = AppState.addEventListener('change', handleAppStateChange)
+  netInfoUnsub = NetInfo.addEventListener(handleNetInfoChange)
+}
+
+/** Test / hot-reload seam: detaches both listeners. */
+export function resetLifecycleWiring(): void {
+  appStateSub?.remove()
+  netInfoUnsub?.()
+  appStateSub = null
+  netInfoUnsub = null
+  backgroundedAt = null
+  initialized = false
+}
+
+function handleAppStateChange(next: AppStateStatus): void {
+  const transition = classifyAppStateTransition(currentAppState, next)
+  currentAppState = next
+  switch (transition) {
+    case 'background':
+      backgroundedAt = Date.now()
+      console.log('[wss.lifecycle] backgrounded')
+      return
+    case 'foreground': {
+      const elapsed = backgroundedAt ? Date.now() - backgroundedAt : 0
+      backgroundedAt = null
+      console.log(`[wss.lifecycle] foregrounded after ${elapsed} ms`)
+      void handleForegroundResume(elapsed)
+      return
+    }
+    case 'none':
+      return
+  }
+}
+
+async function handleForegroundResume(elapsedMs: number): Promise<void> {
+  const record = $device.get().record
+  const status = $session.get().status as SessionStatusHint
+  const action = decideForegroundAction(elapsedMs, status, record !== null)
+  console.log('[wss.lifecycle] resume action:', action, { elapsedMs, status })
+  if (action === 'skip') return
+  if (action === 'reconnect') {
+    if (record) await autoConnect(record)
+    return
+  }
+  // action === 'probe'. record is non-null here (decide would have skipped).
+  const verdict = await probeConnection()
+  console.log('[wss.lifecycle] resume probe:', verdict)
+  if (verdict === 'dead' && record) await autoConnect(record)
+}
+
+function handleNetInfoChange(net: NetInfoState): void {
+  const record = $device.get().record
+  const status = $session.get().status as SessionStatusHint
+  const action = classifyNetInfoChange(net, status, record !== null)
+  switch (action) {
+    case 'skip':
+      return
+    case 'force-close':
+      console.log('[wss.lifecycle] network unreachable, force-closing')
+      forceCloseFromLifecycle('network unreachable')
+      return
+    case 'reconnect':
+      if (!record) return
+      console.log('[wss.lifecycle] network back, reconnecting')
+      void autoConnect(record)
+      return
+  }
+}

--- a/companion/src/modules/wss/lifecycle.ts
+++ b/companion/src/modules/wss/lifecycle.ts
@@ -81,7 +81,9 @@ function handleAppStateChange(next: AppStateStatus): void {
     const elapsed = backgroundedAt ? Date.now() - backgroundedAt : 0
     backgroundedAt = null
     console.log(`[wss.lifecycle] foregrounded after ${elapsed} ms`)
-    void handleForegroundResume(elapsed)
+    handleForegroundResume(elapsed).catch((err) => {
+      console.error('[wss.lifecycle] foreground resume failed:', err)
+    })
   }
 }
 

--- a/companion/src/modules/wss/lifecycle.ts
+++ b/companion/src/modules/wss/lifecycle.ts
@@ -2,6 +2,7 @@ import NetInfo from '@react-native-community/netinfo'
 import type { NetInfoState } from '@react-native-community/netinfo'
 import { AppState } from 'react-native'
 import type { AppStateStatus } from 'react-native'
+import type { DeviceRecord } from '@/modules/stores/$device'
 import { $device } from '@/modules/stores/$device'
 import { $session } from '@/modules/stores/$session'
 import { autoConnect, forceCloseFromLifecycle, probeConnection } from './client'
@@ -9,8 +10,22 @@ import {
   classifyAppStateTransition,
   classifyNetInfoChange,
   decideForegroundAction,
+  executeForegroundAction,
+  executeNetInfoAction,
+  type LifecycleDeps,
   type SessionStatusHint,
 } from './lifecycle.helpers'
+
+/**
+ * Real production side-effect wiring. Static per module load: the
+ * executors are stateless, so a single frozen deps object is safe to
+ * share across every handler invocation.
+ */
+const deps: LifecycleDeps<DeviceRecord> = {
+  autoConnect,
+  probeConnection,
+  forceClose: forceCloseFromLifecycle,
+}
 
 let initialized = false
 let currentAppState: AppStateStatus = AppState.currentState
@@ -57,20 +72,16 @@ export function resetLifecycleWiring(): void {
 function handleAppStateChange(next: AppStateStatus): void {
   const transition = classifyAppStateTransition(currentAppState, next)
   currentAppState = next
-  switch (transition) {
-    case 'background':
-      backgroundedAt = Date.now()
-      console.log('[wss.lifecycle] backgrounded')
-      return
-    case 'foreground': {
-      const elapsed = backgroundedAt ? Date.now() - backgroundedAt : 0
-      backgroundedAt = null
-      console.log(`[wss.lifecycle] foregrounded after ${elapsed} ms`)
-      void handleForegroundResume(elapsed)
-      return
-    }
-    case 'none':
-      return
+  if (transition === 'background') {
+    backgroundedAt = Date.now()
+    console.log('[wss.lifecycle] backgrounded')
+    return
+  }
+  if (transition === 'foreground') {
+    const elapsed = backgroundedAt ? Date.now() - backgroundedAt : 0
+    backgroundedAt = null
+    console.log(`[wss.lifecycle] foregrounded after ${elapsed} ms`)
+    void handleForegroundResume(elapsed)
   }
 }
 
@@ -79,32 +90,13 @@ async function handleForegroundResume(elapsedMs: number): Promise<void> {
   const status = $session.get().status as SessionStatusHint
   const action = decideForegroundAction(elapsedMs, status, record !== null)
   console.log('[wss.lifecycle] resume action:', action, { elapsedMs, status })
-  if (action === 'skip') return
-  if (action === 'reconnect') {
-    if (record) await autoConnect(record)
-    return
-  }
-  // action === 'probe'. record is non-null here (decide would have skipped).
-  const verdict = await probeConnection()
-  console.log('[wss.lifecycle] resume probe:', verdict)
-  if (verdict === 'dead' && record) await autoConnect(record)
+  await executeForegroundAction(action, record, deps)
 }
 
 function handleNetInfoChange(net: NetInfoState): void {
   const record = $device.get().record
   const status = $session.get().status as SessionStatusHint
   const action = classifyNetInfoChange(net, status, record !== null)
-  switch (action) {
-    case 'skip':
-      return
-    case 'force-close':
-      console.log('[wss.lifecycle] network unreachable, force-closing')
-      forceCloseFromLifecycle('network unreachable')
-      return
-    case 'reconnect':
-      if (!record) return
-      console.log('[wss.lifecycle] network back, reconnecting')
-      void autoConnect(record)
-      return
-  }
+  if (action !== 'skip') console.log('[wss.lifecycle] net action:', action)
+  executeNetInfoAction(action, record, deps)
 }

--- a/companion/src/screens/home/HomeScreen.tsx
+++ b/companion/src/screens/home/HomeScreen.tsx
@@ -1,6 +1,17 @@
 import { Link } from 'expo-router'
+import { useEffect, useState } from 'react'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { useHomeData } from './home.data'
+
+/**
+ * How long we wait on ConnectingHome before showing the escape-hatch
+ * "Stuck? Unpair" link. Shorter than autoConnect's worst-case ladder
+ * timeout (~10 s across four rungs), so the user always sees the link
+ * before the state naturally transitions to `unreachable`. If the
+ * ladder resolves before this fires, the ConnectingHome unmounts and
+ * the timer is cleared.
+ */
+const STUCK_CONNECTING_MS = 10_000
 
 export function HomeScreen() {
   const data = useHomeData()
@@ -8,13 +19,14 @@ export function HomeScreen() {
     case 'unpaired':
       return <UnpairedHome />
     case 'connecting':
-      return <ConnectingHome hint={data.hint} />
+      return <ConnectingHome hint={data.hint} onUnpair={data.unpair} />
     case 'unreachable':
       return (
         <UnreachableHome
           hint={data.hint}
           lastError={data.session.lastError}
           onRetry={data.retry}
+          onUnpair={data.unpair}
         />
       )
     case 'connected':
@@ -60,7 +72,14 @@ function UnpairedHome() {
   )
 }
 
-function ConnectingHome({ hint }: { hint: string | null }) {
+function ConnectingHome({
+  hint,
+  onUnpair,
+}: {
+  hint: string | null
+  onUnpair: () => void
+}) {
+  const stuck = useStuckTimer(STUCK_CONNECTING_MS)
   return (
     <View className="flex-1 items-center justify-center gap-4 bg-background p-6">
       <ActivityIndicator size="large" />
@@ -70,18 +89,44 @@ function ConnectingHome({ hint }: { hint: string | null }) {
       <Text className="text-center text-muted-foreground text-sm">
         Looking for the desktop on your local network.
       </Text>
+      {stuck && (
+        <Pressable onPress={onUnpair} hitSlop={12} className="mt-2">
+          <Text className="text-center text-muted-foreground text-sm underline">
+            Stuck? Unpair
+          </Text>
+        </Pressable>
+      )}
     </View>
   )
+}
+
+/**
+ * Emit `true` after `ms` milliseconds. Timer starts on mount, clears
+ * on unmount. Used by ConnectingHome to reveal the escape-hatch
+ * Unpair link only after the ladder has had a real chance to complete.
+ *
+ * useEffect is the right hook here: we're subscribing to a timer, an
+ * external system that lives outside React's render cycle.
+ */
+function useStuckTimer(ms: number): boolean {
+  const [stuck, setStuck] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setStuck(true), ms)
+    return () => clearTimeout(t)
+  }, [ms])
+  return stuck
 }
 
 function UnreachableHome({
   hint,
   lastError,
   onRetry,
+  onUnpair,
 }: {
   hint: string | null
   lastError: string | null
   onRetry: () => void
+  onUnpair: () => void
 }) {
   return (
     <View className="flex-1 items-center justify-center gap-4 bg-background p-6">
@@ -98,6 +143,11 @@ function UnreachableHome({
       >
         <Text className="font-semibold text-accent-foreground text-base">
           Retry
+        </Text>
+      </Pressable>
+      <Pressable onPress={onUnpair} hitSlop={12} className="mt-2">
+        <Text className="text-center text-muted-foreground text-sm underline">
+          Unpair from desktop
         </Text>
       </Pressable>
     </View>

--- a/companion/src/screens/home/home.data.ts
+++ b/companion/src/screens/home/home.data.ts
@@ -1,5 +1,7 @@
 import { useStore } from '@nanostores/react'
-import { $device } from '@/modules/stores/$device'
+import { router } from 'expo-router'
+import { Alert } from 'react-native'
+import { $device, clearDevice } from '@/modules/stores/$device'
 import { $session } from '@/modules/stores/$session'
 import { autoConnect, disconnect } from '@/modules/wss/client'
 
@@ -43,6 +45,31 @@ export function useHomeData() {
     /** Kick the resolver ladder again from an "unreachable" state. */
     retry: () => {
       if (record) void autoConnect(record)
+    },
+    /**
+     * Escape from any bricked state (unreachable, or connecting-and-
+     * stuck). Confirms via native Alert because the token is destroyed
+     * and the user has to re-scan the QR to pair again. Called from
+     * UnreachableHome + the stuck-timer branch of ConnectingHome.
+     */
+    unpair: () => {
+      Alert.alert(
+        'Unpair from desktop?',
+        "You'll need to scan the QR from your desktop again to reconnect.",
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Unpair',
+            style: 'destructive',
+            onPress: () => {
+              disconnect()
+              void clearDevice().finally(() => {
+                router.replace('/pair')
+              })
+            },
+          },
+        ],
+      )
     },
   }
 }


### PR DESCRIPTION
## Summary

Turns the WSS client from a "usually works while foregrounded on a stable connection" prototype into one that survives the mobile lifecycle: background/foreground transitions, Wi-Fi drops, cell handoffs, airplane-mode toggles. Zero wire-protocol changes; every failure mode this closes was silently broken today.

First of three planned PRs on companion reliability + state parity; the other two land as follow-ups.

## Commits

- **`204e988` fast backoff floor + jitter** — reconnect attempts 0 and 1 fire at 250/500 ms so a foreground / network resume feels instant. Attempt 2+ uses 1 s exponential + 0-249 ms jitter to avoid thundering herd if multiple mobile clients wake on a shared "Wi-Fi back" event. 6 tests, deterministic via dependency-injected `random`.
- **`8fdcf9d` unified forceCloseAndReconnect + reject pending** — every "socket dead" signal (onclose, onerror, watchdog, probe timeout) routes through one teardown path that bumps the socket generation, rejects in-flight CRUD ops with a clear "connection lost: ..." error, and schedules reconnect. Fast-fails callers waiting on ops instead of the previous 10-second silent hang.
- **`c83d6cf` lastFrameAt + watchdog + probeConnection** — stamps a receive-side liveness clock on every inbound frame. Watchdog (folded into the existing heartbeat tick) force-closes if no frame arrives in 45 s: catches "server went silent even though it should be pushing broadcasts". `probeConnection()` sends a ping and polls for any inbound activity for 3 s, exported for lifecycle to call on foreground / network transitions.
- **`89d717d` lifecycle listeners for AppState + NetInfo** — new `lifecycle.ts` module attaches both listeners at boot. Foreground after short (< 60 s) background probes the socket and reconnects on 'dead'; long background reconnects unconditionally. NetInfo force-closes on `isInternetReachable` false while connected and kicks autoConnect on true while unreachable. Every decision goes through pure helpers in `lifecycle.helpers.ts` with 18 new unit tests, so the async shell stays thin.
- **`aa03b6e` refactor: unit-test the lifecycle branching** — extracts two exported executors (`executeForegroundAction`, `executeNetInfoAction`) so every branch of the lifecycle decision matrix is unit-testable via dependency-injected fakes. Drops the async shells to trivial wiring (cyclomatic 1). 11 more tests.
- **`01fa5cd` fix: catch fire-and-forget rejections + correct backoff comment** — Copilot follow-up. `.catch(err => console.error(...))` on the two `void`-dispatched async paths so a rejection never escapes to the runtime's unhandledrejection handler. Also corrects a stale arithmetic comment in the backoff cap test.

## Reliability contract now

Failure mode | Detection time (before) | Detection time (now)
--- | --- | ---
Backgrounded > 60 s | 45 s after foreground (heartbeat cycle) | ~1 s after foreground
Wi-Fi drop | Up to 45 s | < 2 s (NetInfo edge)
Cell / Wi-Fi handoff | Up to 45 s | < 2 s (NetInfo edge)
Server silent (broadcasts stopped) | Never (heartbeat pong still worked) | 45 s (watchdog)
Zombie socket (onerror without onclose) | Never | Immediate (onerror routes through forceClose)

## Test plan

**Unit:** verified locally. `bun test src/modules/wss/`: 48 pass across 3 files (6 backoff + 29 lifecycle helpers + 13 preexisting resolver / pair.helpers).

**On-device smoke** (need to walk before merge):

- [ ] Pair fresh, connect, observe the heartbeat + watchdog tick lines every 15 s.
- [ ] Background for 5 s, foreground: expect NO reconnect (short-background, socket trusted; log line "resume action: probe" + "probe: alive").
- [ ] Background for 90 s, foreground: expect autoConnect within ~1 s (log line "resume action: reconnect").
- [ ] Wi-Fi off (Control Center on iOS): expect NetInfo forces close within 1 s; Wi-Fi on: expect reconnect within 2 s.
- [ ] Airplane mode toggle: same.
- [ ] Kill the Rust WSS server mid-session: expect watchdog to force-close within ~46 s and reconnect ladder starts immediately.
- [ ] Trigger a CRUD op while socket is being force-closed: expect the promise to reject with "connection lost: ..." within a few ms, not the old 10 s op timeout.