### PR TITLE
feat(agents): add Amp, Kilo, Kimi, and Mastra (registry to 7 agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,16 @@ Always-on context for the focused tab — refreshed every couple of seconds, nev
 | [Claude Code](https://claude.ai/code) | ✅ Supported |
 | [Codex CLI](https://github.com/openai/codex) | ✅ Supported |
 | [opencode](https://github.com/sst/opencode) | ✅ Supported |
+| [Amp](https://ampcode.com) | 🧪 Experimental |
+| [Kilo Code](https://kilo.ai) | 🧪 Experimental |
+| [Kimi CLI](https://www.kimi.com) | 🧪 Experimental |
+| [Mastra](https://mastra.ai) | 🧪 Experimental |
 | [Cursor](https://www.cursor.com) | 🔜 Planned |
+| [GitHub Copilot CLI](https://github.com/features/copilot) | 🔜 Planned |
+| [Factory Droid](https://factory.ai) | 🔜 Planned |
+| [Qoder](https://qoder.com) | 🔜 Planned |
+
+**Status key:** ✅ Supported = primary, well tested. 🧪 Experimental = detection works, still being tested. 🔜 Planned = coming soon.
 
 Want support for another agent? [Open an issue](https://github.com/DaniAkash/agent-terminal/issues/new) or [tell me on X](https://x.com/dani_akash_).
 

--- a/src-tauri/src/agents/amp.rs
+++ b/src-tauri/src/agents/amp.rs
@@ -1,0 +1,63 @@
+//! Amp agent profile.
+//!
+//! Amp reports state via its OSC window title and has no hook integration, so
+//! it is an OSC + floor agent. Signature reference: herdr
+//! `src/detect/manifests/amp.toml` (facts re-implemented fresh).
+
+use super::{is_braille, AgentProfile, OscState, OscView};
+
+fn state_from_osc(view: &OscView) -> Option<OscState> {
+    let title = view.title;
+    if title.contains("Plugin confirmation needed") {
+        return Some(OscState::Blocked);
+    }
+    if title.trim_start().chars().next().is_some_and(is_braille) {
+        return Some(OscState::Working);
+    }
+    if title.contains(" - amp - ") {
+        return Some(OscState::Idle);
+    }
+    None
+}
+
+pub static PROFILE: AgentProfile = AgentProfile {
+    id: "amp",
+    display_name: "Amp",
+    process_names: &["amp"],
+    runtime_wrapped: true,
+    hook: None,
+    osc: Some(state_from_osc),
+};
+
+#[cfg(test)]
+mod tests {
+    use super::state_from_osc;
+    use crate::agents::{OscState, OscView};
+
+    fn view<'a>(title: &'a str) -> OscView<'a> {
+        OscView { title, progress: "" }
+    }
+
+    #[test]
+    fn plugin_confirmation_is_blocked() {
+        assert_eq!(
+            state_from_osc(&view("Plugin confirmation needed")),
+            Some(OscState::Blocked)
+        );
+    }
+
+    #[test]
+    fn braille_title_is_working() {
+        assert_eq!(state_from_osc(&view("\u{2802} amp")), Some(OscState::Working));
+    }
+
+    #[test]
+    fn amp_marker_title_is_idle() {
+        assert_eq!(state_from_osc(&view("~/project - amp - main")), Some(OscState::Idle));
+    }
+
+    #[test]
+    fn unrelated_title_is_unknown() {
+        assert_eq!(state_from_osc(&view("some shell prompt")), None);
+    }
+}

--- a/src-tauri/src/agents/assets/kilo-agent-state.js
+++ b/src-tauri/src/agents/assets/kilo-agent-state.js
@@ -1,0 +1,81 @@
+// Agent Terminal kilo plugin.
+//
+// Reports agent turn state to Agent Terminal's local hook server so the tab
+// badge reflects working / blocked / turn-end. Fire-and-forget: never blocks
+// or throws into kilo.
+//
+// Written by Agent Terminal. Do not edit; reinstalled on launch.
+
+const TAB_ID = process.env.AGENT_TERMINAL_TAB_ID
+const PORT = process.env.AGENT_TERMINAL_HOOK_PORT || "47384"
+
+async function report(event, sessionID) {
+  if (!TAB_ID) return
+  const payload = { agent: "kilo", event, tab_id: TAB_ID }
+  // Only send a session id when known; an empty string would become a shared
+  // key server-side.
+  if (sessionID) payload.session_id = sessionID
+  try {
+    await fetch(`http://127.0.0.1:${PORT}/hook`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(500),
+    })
+  } catch {
+    // one-way notification; ignore transport errors
+  }
+}
+
+function stateFromSessionStatus(status) {
+  if (typeof status !== "string") return null
+  switch (status.toLowerCase()) {
+    case "idle":
+      return "turn_end"
+    case "active":
+    case "busy":
+    case "pending":
+    case "running":
+    case "streaming":
+    case "working":
+      return "working"
+    default:
+      return null
+  }
+}
+
+export const AgentTerminalStatePlugin = async () => {
+  return {
+    "chat.message": async ({ sessionID }) => {
+      await report("working", sessionID)
+    },
+    event: async ({ event }) => {
+      const type = event && event.type
+      const properties = (event && event.properties) || {}
+      const sessionID = properties.sessionID
+      switch (type) {
+        case "session.created":
+        case "session.updated":
+          if (sessionID) await report("session_start", sessionID)
+          break
+        case "session.status": {
+          const state = stateFromSessionStatus(properties.status)
+          if (state) await report(state, sessionID)
+          break
+        }
+        case "tool.execute.before":
+        case "tool.execute.after":
+        case "permission.replied":
+        case "question.replied":
+        case "question.rejected":
+        case "session.compacted":
+          await report("working", sessionID)
+          break
+        case "permission.asked":
+        case "question.asked":
+          await report("blocked", sessionID)
+          break
+      }
+    },
+  }
+}

--- a/src-tauri/src/agents/kilo.rs
+++ b/src-tauri/src/agents/kilo.rs
@@ -1,0 +1,31 @@
+//! Kilo Code agent profile.
+//!
+//! Kilo runs under a JS runtime and loads plugins from `~/.config/kilo/plugin/`,
+//! like opencode. The plugin translates kilo's session lifecycle into our
+//! neutral event vocabulary. No OSC; floor covers exit.
+
+use super::{AgentProfile, EventRole, HookEvent, HookInstall, HookSpec};
+
+static EVENTS: &[HookEvent] = &[
+    HookEvent { name: "session_start", role: EventRole::SessionStart },
+    HookEvent { name: "working", role: EventRole::Working },
+    HookEvent { name: "blocked", role: EventRole::Blocked },
+    HookEvent { name: "turn_end", role: EventRole::Completed },
+];
+
+pub static PROFILE: AgentProfile = AgentProfile {
+    id: "kilo",
+    display_name: "Kilo Code",
+    process_names: &["kilo"],
+    runtime_wrapped: true,
+    hook: Some(HookSpec {
+        install: HookInstall::Plugin {
+            dir_tilde_path: "~/.config/kilo/plugin",
+            install_name: "agent-terminal-state.js",
+            asset: include_str!("assets/kilo-agent-state.js"),
+        },
+        events: EVENTS,
+        timeout_ms: 0,
+    }),
+    osc: None,
+};

--- a/src-tauri/src/agents/kimi.rs
+++ b/src-tauri/src/agents/kimi.rs
@@ -1,0 +1,48 @@
+//! Kimi CLI agent profile.
+//!
+//! Kimi registers hooks in `~/.kimi-code/config.toml` via a managed block of
+//! `[[hooks]]` tables. The action hook script posts a resolved state
+//! (session/working/blocked/idle), which the registry maps to roles. The
+//! lifecycle-event-to-action mapping is referenced from herdr, re-implemented
+//! fresh.
+
+use super::{AgentProfile, EventRole, HookEvent, HookInstall, HookSpec};
+
+/// Actions the hook script posts, mapped to state-engine roles.
+static EVENTS: &[HookEvent] = &[
+    HookEvent { name: "session", role: EventRole::SessionStart },
+    HookEvent { name: "working", role: EventRole::Working },
+    HookEvent { name: "blocked", role: EventRole::Blocked },
+    HookEvent { name: "idle", role: EventRole::Idle },
+];
+
+/// Kimi lifecycle event -> action posted (drives config generation).
+static INSTALL_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "session"),
+    ("UserPromptSubmit", "working"),
+    ("PreToolUse", "working"),
+    ("SubagentStart", "working"),
+    ("PreCompact", "working"),
+    ("PermissionRequest", "blocked"),
+    ("PermissionResult", "working"),
+    ("Stop", "idle"),
+    ("Interrupt", "idle"),
+];
+
+pub static PROFILE: AgentProfile = AgentProfile {
+    id: "kimi",
+    display_name: "Kimi CLI",
+    process_names: &["kimi"],
+    runtime_wrapped: false,
+    hook: Some(HookSpec {
+        install: HookInstall::TomlBlock {
+            config_tilde_path: "~/.kimi-code/config.toml",
+            hooks_dir_tilde_path: "~/.kimi-code/hooks",
+            script_name: "agent-terminal-state",
+            events: INSTALL_EVENTS,
+        },
+        events: EVENTS,
+        timeout_ms: 10_000,
+    }),
+    osc: None,
+};

--- a/src-tauri/src/agents/mastracode.rs
+++ b/src-tauri/src/agents/mastracode.rs
@@ -1,0 +1,51 @@
+//! Mastra agent profile.
+//!
+//! Mastra registers hooks in `~/.mastracode/hooks.json` (flat format: each event
+//! maps to `[{ type: "command", command, timeout }]`). The action hook script
+//! posts a resolved state, which the registry maps to roles. The
+//! lifecycle-event-to-action mapping is referenced from herdr, re-implemented
+//! fresh.
+
+use super::{AgentProfile, EventRole, HookEvent, HookInstall, HookSpec};
+
+/// Actions the hook script posts, mapped to state-engine roles.
+static EVENTS: &[HookEvent] = &[
+    HookEvent { name: "idle", role: EventRole::Idle },
+    HookEvent { name: "working", role: EventRole::Working },
+    HookEvent { name: "blocked", role: EventRole::Blocked },
+    HookEvent { name: "release", role: EventRole::SessionEnd },
+];
+
+/// Mastra lifecycle event -> action posted (drives config generation).
+static INSTALL_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "idle"),
+    ("UserPromptSubmit", "working"),
+    ("AgentStart", "working"),
+    ("PreToolUse", "working"),
+    ("PermissionRequest", "blocked"),
+    ("PermissionResult", "working"),
+    ("SubagentStart", "working"),
+    ("SubagentEnd", "working"),
+    ("Interrupt", "idle"),
+    ("AgentEnd", "idle"),
+    ("Stop", "idle"),
+    ("SessionEnd", "release"),
+];
+
+pub static PROFILE: AgentProfile = AgentProfile {
+    id: "mastracode",
+    display_name: "Mastra",
+    process_names: &["mastracode"],
+    runtime_wrapped: true,
+    hook: Some(HookSpec {
+        install: HookInstall::FlatJson {
+            config_tilde_path: "~/.mastracode/hooks.json",
+            hooks_dir_tilde_path: "~/.mastracode/hooks",
+            script_name: "agent-terminal-state",
+            events: INSTALL_EVENTS,
+        },
+        events: EVENTS,
+        timeout_ms: 10_000,
+    }),
+    osc: None,
+};

--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -186,6 +186,10 @@ mod tests {
         assert_eq!(by_id("claude-code").map(|a| a.display_name), Some("Claude Code"));
         assert_eq!(by_id("codex").map(|a| a.id), Some("codex"));
         assert_eq!(by_id("opencode").map(|a| a.id), Some("opencode"));
+        assert_eq!(by_id("amp").map(|a| a.id), Some("amp"));
+        assert_eq!(by_id("kilo").map(|a| a.display_name), Some("Kilo Code"));
+        assert_eq!(by_id("kimi").map(|a| a.display_name), Some("Kimi CLI"));
+        assert_eq!(by_id("mastracode").map(|a| a.display_name), Some("Mastra"));
         assert!(by_id("nope").is_none());
     }
 
@@ -194,15 +198,19 @@ mod tests {
         assert_eq!(by_process_name("claude").map(|a| a.id), Some("claude-code"));
         assert_eq!(by_process_name("codex").map(|a| a.id), Some("codex"));
         assert_eq!(by_process_name("opencode").map(|a| a.id), Some("opencode"));
+        assert_eq!(by_process_name("amp").map(|a| a.id), Some("amp"));
+        assert_eq!(by_process_name("kilo").map(|a| a.id), Some("kilo"));
+        assert_eq!(by_process_name("kimi").map(|a| a.id), Some("kimi"));
+        assert_eq!(by_process_name("mastracode").map(|a| a.id), Some("mastracode"));
         assert!(by_process_name("bash").is_none());
     }
 
     #[test]
     fn known_process_names_covers_all_agents() {
         let names: HashSet<&str> = known_process_names().collect();
-        assert!(names.contains("claude"));
-        assert!(names.contains("codex"));
-        assert!(names.contains("opencode"));
+        for name in ["claude", "codex", "opencode", "amp", "kilo", "kimi", "mastracode"] {
+            assert!(names.contains(name), "missing process name: {name}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -15,6 +15,7 @@
 //! The state engine fuses the hook and OSC signals with an agent-agnostic
 //! process/prompt floor; see the agent-state mod.
 
+pub mod amp;
 pub mod claude_code;
 pub mod codex;
 pub mod opencode;
@@ -127,6 +128,7 @@ pub static AGENTS: &[&AgentProfile] = &[
     &claude_code::PROFILE,
     &codex::PROFILE,
     &opencode::PROFILE,
+    &amp::PROFILE,
 ];
 
 /// Look up a profile by its stable id (e.g. `"claude-code"`).

--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -60,6 +60,10 @@ pub enum EventRole {
     SessionStart,
     Working,
     Blocked,
+    /// Return to the idle baseline without ending the session. Used by agents
+    /// whose hook reports a resolved `idle` state (Kimi, Mastra) rather than a
+    /// `Stop`-style completion.
+    Idle,
     Completed,
     SessionEnd,
 }

--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -19,6 +19,8 @@ pub mod amp;
 pub mod claude_code;
 pub mod codex;
 pub mod kilo;
+pub mod kimi;
+pub mod mastracode;
 pub mod opencode;
 
 /// Coarse state derivable from an agent's OSC title/progress. Distinct from the
@@ -79,11 +81,31 @@ pub enum HookInstall {
     /// Patch the agent's own settings file with our hook command (Claude,
     /// Codex). The nested matcher+hooks JSON merge lives in `hook_config`.
     NativeConfig { config_tilde_path: &'static str },
-    /// Drop a plugin/extension asset into the agent's plugin dir (opencode).
+    /// Drop a plugin/extension asset into the agent's plugin dir (opencode,
+    /// kilo).
     Plugin {
         dir_tilde_path: &'static str,
         install_name: &'static str,
         asset: &'static str,
+    },
+    /// Register hooks in an agent's TOML config via a managed block of
+    /// `[[hooks]]` tables (Kimi). The action hook script posts the resolved
+    /// state (the second tuple field) as the event.
+    TomlBlock {
+        config_tilde_path: &'static str,
+        hooks_dir_tilde_path: &'static str,
+        script_name: &'static str,
+        /// (agent lifecycle event, action posted).
+        events: &'static [(&'static str, &'static str)],
+    },
+    /// Register hooks in an agent's flat JSON hooks file (Mastra): each event
+    /// maps to `[{ type: "command", command: "...", timeout, ... }]`.
+    FlatJson {
+        config_tilde_path: &'static str,
+        hooks_dir_tilde_path: &'static str,
+        script_name: &'static str,
+        /// (agent lifecycle event, action posted).
+        events: &'static [(&'static str, &'static str)],
     },
 }
 
@@ -135,6 +157,8 @@ pub static AGENTS: &[&AgentProfile] = &[
     &opencode::PROFILE,
     &amp::PROFILE,
     &kilo::PROFILE,
+    &kimi::PROFILE,
+    &mastracode::PROFILE,
 ];
 
 /// Look up a profile by its stable id (e.g. `"claude-code"`).

--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -18,6 +18,7 @@
 pub mod amp;
 pub mod claude_code;
 pub mod codex;
+pub mod kilo;
 pub mod opencode;
 
 /// Coarse state derivable from an agent's OSC title/progress. Distinct from the
@@ -129,6 +130,7 @@ pub static AGENTS: &[&AgentProfile] = &[
     &codex::PROFILE,
     &opencode::PROFILE,
     &amp::PROFILE,
+    &kilo::PROFILE,
 ];
 
 /// Look up a profile by its stable id (e.g. `"claude-code"`).

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -207,8 +207,11 @@ fn toml_basic_string(s: &str) -> String {
 /// appends `block` when no managed block is present. `block` must include the
 /// begin/end markers and a trailing newline.
 fn replace_managed_block(existing: &str, begin: &str, end: &str, block: &str) -> String {
-    if let (Some(b), Some(e)) = (existing.find(begin), existing.find(end)) {
-        if e > b {
+    if let Some(b) = existing.find(begin) {
+        // Find the end marker AFTER the begin marker, so a stray end marker
+        // earlier in unrelated content can't cause a mismatch.
+        if let Some(rel) = existing[b..].find(end) {
+            let e = b + rel;
             let mut tail = e + end.len();
             if existing[tail..].starts_with('\n') {
                 tail += 1;
@@ -243,7 +246,8 @@ async fn install_toml_block(
 
     let mut body = String::new();
     for (event, action) in events {
-        let command = format!("bash {} {}", script_path.display(), action);
+        // Single-quote the path so a home dir with spaces does not split argv.
+        let command = format!("bash '{}' {}", script_path.display(), action);
         body.push_str(&format!(
             "[[hooks]]\nevent = {}\ncommand = {}\ntimeout = 10\n\n",
             toml_basic_string(event),
@@ -291,7 +295,8 @@ async fn install_flat_json(
     {
         let obj = root.as_object_mut().unwrap();
         for (event, action) in events {
-            let command = format!("bash {} {}", script_path.display(), action);
+            // Single-quote the path so a home dir with spaces does not split argv.
+            let command = format!("bash '{}' {}", script_path.display(), action);
             let arr = obj
                 .entry(event.to_string())
                 .or_insert_with(|| Value::Array(vec![]))

--- a/src-tauri/src/hook_config.rs
+++ b/src-tauri/src/hook_config.rs
@@ -115,24 +115,209 @@ pub async fn ensure_hooks_installed() {
             );
         }
     }
-    install_plugin_agents(&home).await;
+    install_registry_hook_agents(&home).await;
 }
 
-/// Installs plugin-based hook integrations (opencode) from the registry.
-///
-/// A plugin is only written when the agent's config directory already exists,
-/// so we never create an agent's config tree for a user who does not have it.
-async fn install_plugin_agents(home: &Path) {
+const TOML_BLOCK_BEGIN: &str = "# >>> agent-terminal hooks";
+const TOML_BLOCK_END: &str = "# <<< agent-terminal hooks";
+
+/// Installs the registry's non-native hook integrations (plugin, TOML block,
+/// flat JSON). Each is only written when the agent's config directory already
+/// exists, so we never create an agent's config tree for a user who does not
+/// have it.
+async fn install_registry_hook_agents(home: &Path) {
     for a in agents::AGENTS {
         let Some(hook) = a.hook.as_ref() else { continue };
-        let HookInstall::Plugin { dir_tilde_path, install_name, asset } = &hook.install else {
-            continue;
+        let result = match &hook.install {
+            HookInstall::NativeConfig { .. } => continue, // handled via AGENT_HOOK_CONFIGS
+            HookInstall::Plugin { dir_tilde_path, install_name, asset } => {
+                install_plugin_asset(&expand_tilde(dir_tilde_path, home), install_name, asset).await
+            }
+            HookInstall::TomlBlock { config_tilde_path, hooks_dir_tilde_path, script_name, events } => {
+                install_toml_block(home, a.id, config_tilde_path, hooks_dir_tilde_path, script_name, events).await
+            }
+            HookInstall::FlatJson { config_tilde_path, hooks_dir_tilde_path, script_name, events } => {
+                install_flat_json(home, a.id, config_tilde_path, hooks_dir_tilde_path, script_name, events).await
+            }
         };
-        let plugin_dir = expand_tilde(dir_tilde_path, home);
-        if let Err(e) = install_plugin_asset(&plugin_dir, install_name, asset).await {
-            eprintln!("[hook_config] failed to install {} plugin: {e}", a.display_name);
+        if let Err(e) = result {
+            eprintln!("[hook_config] failed to install {} hook: {e}", a.display_name);
         }
     }
+}
+
+/// Generates a hook script for agents that report a resolved state as the first
+/// argument (Kimi, Mastra). Unlike `build_hook_script`, it does not read the
+/// agent's JSON from stdin: it emits a well-formed payload from `$1` and the tab
+/// env var alone. Fire-and-forget POST to the hook server.
+fn build_action_hook_script(agent_id: &str) -> String {
+    format!(
+        "#!/bin/sh\n\
+# Written by Agent Terminal. Do not edit; regenerated on each launch.\n\
+# Reports a resolved agent state (passed as $1) to the hook server.\n\
+EVENT=\"$1\"\n\
+case \"$AGENT_TERMINAL_TAB_ID\" in\n\
+  '') TAB_SUFFIX=\"\" ;;\n\
+  *[!A-Za-z0-9:_-]*) TAB_SUFFIX=\"\" ;;\n\
+  *) TAB_SUFFIX=\",\\\"tab_id\\\":\\\"$AGENT_TERMINAL_TAB_ID\\\"\" ;;\n\
+esac\n\
+PAYLOAD=\"{{\\\"agent\\\":\\\"{agent_id}\\\",\\\"event\\\":\\\"$EVENT\\\"${{TAB_SUFFIX}}}}\"\n\
+{{ curl -sf --max-time 5 -X POST http://127.0.0.1:{port}/hook \\\n\
+    -H 'Content-Type: application/json' \\\n\
+    -d \"$PAYLOAD\" \\\n\
+    >/dev/null 2>&1 & }} 2>/dev/null\n\
+exit 0\n",
+        agent_id = agent_id,
+        port = crate::identity::HOOK_PORT,
+    )
+}
+
+/// Writes the action hook script to `hooks_dir/name`, idempotently, chmod +x.
+async fn write_action_script(
+    hooks_dir: &Path,
+    name: &str,
+    agent_id: &str,
+) -> std::io::Result<PathBuf> {
+    tokio::fs::create_dir_all(hooks_dir).await?;
+    let path = hooks_dir.join(name);
+    let content = build_action_hook_script(agent_id);
+    let needs_write = match tokio::fs::read_to_string(&path).await {
+        Ok(existing) => existing != content,
+        Err(_) => true,
+    };
+    if needs_write {
+        tokio::fs::write(&path, &content).await?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&path)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms)?;
+    }
+    Ok(path)
+}
+
+/// Quotes a string as a TOML basic string.
+fn toml_basic_string(s: &str) -> String {
+    format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+/// Replaces the marker-delimited managed block in `existing` with `block`, or
+/// appends `block` when no managed block is present. `block` must include the
+/// begin/end markers and a trailing newline.
+fn replace_managed_block(existing: &str, begin: &str, end: &str, block: &str) -> String {
+    if let (Some(b), Some(e)) = (existing.find(begin), existing.find(end)) {
+        if e > b {
+            let mut tail = e + end.len();
+            if existing[tail..].starts_with('\n') {
+                tail += 1;
+            }
+            return format!("{}{block}{}", &existing[..b], &existing[tail..]);
+        }
+    }
+    if existing.is_empty() {
+        block.to_string()
+    } else if existing.ends_with('\n') {
+        format!("{existing}\n{block}")
+    } else {
+        format!("{existing}\n\n{block}")
+    }
+}
+
+/// Kimi: register hooks as a managed block of `[[hooks]]` tables in config.toml.
+async fn install_toml_block(
+    home: &Path,
+    agent_id: &str,
+    config_tilde: &str,
+    hooks_dir_tilde: &str,
+    script_name: &str,
+    events: &[(&str, &str)],
+) -> std::io::Result<()> {
+    let config_path = expand_tilde(config_tilde, home);
+    match config_path.parent() {
+        Some(dir) if dir.exists() => {}
+        _ => return Ok(()),
+    }
+    let script_path = write_action_script(&expand_tilde(hooks_dir_tilde, home), script_name, agent_id).await?;
+
+    let mut body = String::new();
+    for (event, action) in events {
+        let command = format!("bash {} {}", script_path.display(), action);
+        body.push_str(&format!(
+            "[[hooks]]\nevent = {}\ncommand = {}\ntimeout = 10\n\n",
+            toml_basic_string(event),
+            toml_basic_string(&command),
+        ));
+    }
+    let block = format!("{TOML_BLOCK_BEGIN}\n{body}{TOML_BLOCK_END}\n");
+
+    let existing = tokio::fs::read_to_string(&config_path).await.unwrap_or_default();
+    let updated = replace_managed_block(&existing, TOML_BLOCK_BEGIN, TOML_BLOCK_END, &block);
+    if updated != existing {
+        tokio::fs::write(&config_path, updated).await?;
+    }
+    Ok(())
+}
+
+/// Mastra: register hooks in a flat JSON hooks file, non-destructively.
+async fn install_flat_json(
+    home: &Path,
+    agent_id: &str,
+    config_tilde: &str,
+    hooks_dir_tilde: &str,
+    script_name: &str,
+    events: &[(&str, &str)],
+) -> std::io::Result<()> {
+    let config_path = expand_tilde(config_tilde, home);
+    match config_path.parent() {
+        Some(dir) if dir.exists() => {}
+        _ => return Ok(()),
+    }
+    let script_path = write_action_script(&expand_tilde(hooks_dir_tilde, home), script_name, agent_id).await?;
+
+    let raw = if config_path.exists() {
+        tokio::fs::read_to_string(&config_path).await?
+    } else {
+        "{}".to_string()
+    };
+    let mut root: Value = serde_json::from_str(&raw)
+        .map_err(|e| std::io::Error::other(format!("invalid JSON in {}: {e}", config_path.display())))?;
+    if !root.is_object() {
+        return Err(std::io::Error::other(format!("{} root is not a JSON object", config_path.display())));
+    }
+
+    let mut modified = false;
+    {
+        let obj = root.as_object_mut().unwrap();
+        for (event, action) in events {
+            let command = format!("bash {} {}", script_path.display(), action);
+            let arr = obj
+                .entry(event.to_string())
+                .or_insert_with(|| Value::Array(vec![]))
+                .as_array_mut()
+                .ok_or_else(|| std::io::Error::other(format!("hooks.{event} is not an array")))?;
+            let present = arr.iter().any(|e| {
+                e.get("type").and_then(Value::as_str) == Some("command")
+                    && e.get("command").and_then(Value::as_str) == Some(command.as_str())
+            });
+            if !present {
+                arr.push(serde_json::json!({
+                    "type": "command",
+                    "command": command,
+                    "timeout": 10000,
+                }));
+                modified = true;
+            }
+        }
+    }
+    if modified {
+        let serialized = serde_json::to_string_pretty(&root)?;
+        let tmp = config_path.with_extension(format!("agent-terminal-{}.tmp", std::process::id()));
+        tokio::fs::write(&tmp, format!("{serialized}\n")).await?;
+        tokio::fs::rename(&tmp, &config_path).await?;
+    }
+    Ok(())
 }
 
 /// Writes a plugin `asset` to `plugin_dir/name`, idempotently. Skips entirely
@@ -1020,5 +1205,111 @@ mod tests {
         let mtime_after = fs::metadata(&path).unwrap().modified().unwrap();
 
         assert_eq!(mtime_before, mtime_after, "unchanged asset must not be rewritten");
+    }
+
+    // ── Action hook script ───────────────────────────────────────────────────
+    #[test]
+    fn action_hook_script_is_well_formed() {
+        let s = build_action_hook_script("kimi");
+        assert!(s.contains("\\\"agent\\\":\\\"kimi\\\""), "must bake the agent id");
+        assert!(s.contains("$AGENT_TERMINAL_TAB_ID"), "must read the tab env var");
+        assert!(s.contains(&format!("127.0.0.1:{}", crate::identity::HOOK_PORT)));
+        // Tab suffix carries its own leading comma, so there is no trailing comma.
+        assert!(s.contains(",\\\"tab_id\\\":\\\"$AGENT_TERMINAL_TAB_ID\\\""));
+    }
+
+    // ── Kimi: TOML managed block ─────────────────────────────────────────────
+    fn kimi_events() -> &'static [(&'static str, &'static str)] {
+        &[("SessionStart", "session"), ("UserPromptSubmit", "working"), ("Stop", "idle")]
+    }
+
+    #[tokio::test]
+    async fn toml_block_installs_and_is_idempotent() {
+        let home = temp_dir("toml1");
+        fs::create_dir_all(home.join(".kimi-code")).unwrap(); // agent present
+        let cfg = home.join(".kimi-code/config.toml");
+
+        install_toml_block(&home, "kimi", "~/.kimi-code/config.toml", "~/.kimi-code/hooks", "agent-terminal-state", kimi_events())
+            .await
+            .unwrap();
+
+        let content = fs::read_to_string(&cfg).unwrap();
+        assert!(content.contains(TOML_BLOCK_BEGIN) && content.contains(TOML_BLOCK_END));
+        assert!(content.contains("event = \"UserPromptSubmit\""));
+        assert!(content.contains("working"));
+
+        // Second run must not change the file.
+        let before = content;
+        install_toml_block(&home, "kimi", "~/.kimi-code/config.toml", "~/.kimi-code/hooks", "agent-terminal-state", kimi_events())
+            .await
+            .unwrap();
+        assert_eq!(fs::read_to_string(&cfg).unwrap(), before, "idempotent");
+    }
+
+    #[tokio::test]
+    async fn toml_block_preserves_surrounding_config() {
+        let home = temp_dir("toml2");
+        fs::create_dir_all(home.join(".kimi-code")).unwrap();
+        let cfg = home.join(".kimi-code/config.toml");
+        fs::write(&cfg, "model = \"kimi-k2\"\n").unwrap();
+
+        install_toml_block(&home, "kimi", "~/.kimi-code/config.toml", "~/.kimi-code/hooks", "agent-terminal-state", kimi_events())
+            .await
+            .unwrap();
+
+        let content = fs::read_to_string(&cfg).unwrap();
+        assert!(content.contains("model = \"kimi-k2\""), "existing config preserved");
+        assert!(content.contains(TOML_BLOCK_BEGIN));
+    }
+
+    #[tokio::test]
+    async fn toml_block_skipped_when_agent_absent() {
+        let home = temp_dir("toml3"); // no ~/.kimi-code
+        install_toml_block(&home, "kimi", "~/.kimi-code/config.toml", "~/.kimi-code/hooks", "agent-terminal-state", kimi_events())
+            .await
+            .unwrap();
+        assert!(!home.join(".kimi-code/config.toml").exists(), "must not create the agent tree");
+    }
+
+    // ── Mastra: flat JSON ────────────────────────────────────────────────────
+    fn mastra_events() -> &'static [(&'static str, &'static str)] {
+        &[("SessionStart", "idle"), ("UserPromptSubmit", "working"), ("PermissionRequest", "blocked")]
+    }
+
+    #[tokio::test]
+    async fn flat_json_installs_and_preserves_existing() {
+        let home = temp_dir("flat1");
+        fs::create_dir_all(home.join(".mastracode")).unwrap();
+        let cfg = home.join(".mastracode/hooks.json");
+        fs::write(&cfg, r#"{"CustomEvent":[{"type":"command","command":"other"}]}"#).unwrap();
+
+        install_flat_json(&home, "mastracode", "~/.mastracode/hooks.json", "~/.mastracode/hooks", "agent-terminal-state", mastra_events())
+            .await
+            .unwrap();
+
+        let v: Value = serde_json::from_str(&fs::read_to_string(&cfg).unwrap()).unwrap();
+        // Existing untouched.
+        assert_eq!(v["CustomEvent"][0]["command"].as_str(), Some("other"));
+        // Ours added as flat command entries.
+        let arr = v["UserPromptSubmit"].as_array().unwrap();
+        assert!(arr.iter().any(|e| e["type"] == "command"
+            && e["command"].as_str().unwrap().ends_with(" working")));
+        assert!(v["PermissionRequest"][0]["command"].as_str().unwrap().ends_with(" blocked"));
+    }
+
+    #[tokio::test]
+    async fn flat_json_is_idempotent() {
+        let home = temp_dir("flat2");
+        fs::create_dir_all(home.join(".mastracode")).unwrap();
+        let cfg = home.join(".mastracode/hooks.json");
+
+        install_flat_json(&home, "mastracode", "~/.mastracode/hooks.json", "~/.mastracode/hooks", "agent-terminal-state", mastra_events())
+            .await
+            .unwrap();
+        let before = fs::read_to_string(&cfg).unwrap();
+        install_flat_json(&home, "mastracode", "~/.mastracode/hooks.json", "~/.mastracode/hooks", "agent-terminal-state", mastra_events())
+            .await
+            .unwrap();
+        assert_eq!(fs::read_to_string(&cfg).unwrap(), before, "idempotent");
     }
 }

--- a/src-tauri/src/mod_engine/mods/agent_state.rs
+++ b/src-tauri/src/mod_engine/mods/agent_state.rs
@@ -466,6 +466,11 @@ impl Mod for AgentStateMod {
                 st.awaiting_message = message;
                 st.hook_state = AgentState::Blocked;
             }
+            EventRole::Idle => {
+                st.proc_alive = true;
+                st.awaiting_message = None;
+                st.hook_state = AgentState::Idle;
+            }
             EventRole::SessionEnd => {
                 st.hook_state = AgentState::Idle;
                 st.awaiting_message = None;

--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -104,6 +104,40 @@ function CodexMark({ size }: { size: number }) {
   )
 }
 
+function AmpMark({ size }: { size: number }) {
+  // Amp brand mark (ampcode.com/amp-mark-color.svg) in currentColor.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 21 21"
+      fill="currentColor"
+      style={{ display: 'block' }}
+      aria-hidden="true"
+    >
+      <path d="M3.76879 18.3015L8.49839 13.505L10.2196 20.0399L12.72 19.3561L10.2288 9.86749L0.890876 7.33844L0.22594 9.89331L6.65134 11.6388L1.94138 16.4282L3.76879 18.3015Z" />
+      <path d="M17.4074 12.7414L19.9078 12.0575L17.4167 2.56897L8.07873 0.0399246L7.4138 2.5948L15.2992 4.73685L17.4074 12.7414Z" />
+      <path d="M13.8184 16.3883L16.3188 15.7044L13.8276 6.21588L4.48971 3.68683L3.82477 6.24171L11.7101 8.38376L13.8184 16.3883Z" />
+    </svg>
+  )
+}
+
+function MastraMark({ size }: { size: number }) {
+  // Mastra brand mark (code.mastra.ai/img/mastra.svg) in currentColor.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 34 21"
+      fill="currentColor"
+      style={{ display: 'block' }}
+      aria-hidden="true"
+    >
+      <path d="M4.5 11.7a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9M10.4 0a4.5 4.5 0 0 1 4.4 5.5c-.3 1.4-.6 3 .2 4.2l1.3 1.8.3.2q.2 0 .3-.2l1.3-1.9c.8-1.1.5-2.7.2-4a4.5 4.5 0 1 1 8.8 0c-.3 1.3-.6 2.8 0 4l1.3 2a4.5 4.5 0 1 1-4.3 3.5c.3-1.3.6-2.8 0-4l-1.2-2h-.2L21.5 11c-.8 1.2-.5 2.8-.2 4.2a4.5 4.5 0 1 1-8.8.2q.5-2-.4-3.8l-.9-1.3q-.9-1.1-2.4-1.6A4.5 4.5 0 0 1 10.4 0" />
+    </svg>
+  )
+}
+
 /* ---------------------------------------------------------------------------
  * Per-agent brand colours — fixed (not theme-aware, they are brand colours)
  * -------------------------------------------------------------------------*/
@@ -112,8 +146,10 @@ const BRAND: Record<string, { color: string; glow: string }> = {
   'claude-code': { color: '#D97757', glow: 'rgba(217,119,87,0.55)' },
   codex: { color: '#e6e8eb', glow: 'rgba(230,232,235,0.45)' },
   opencode: { color: '#ebe9e6', glow: 'rgba(235,233,230,0.45)' },
-  kilo: { color: '#cbd5e1', glow: 'rgba(203,213,225,0.45)' },
+  kilo: { color: '#cddc39', glow: 'rgba(205,220,57,0.45)' },
   kimi: { color: '#027aff', glow: 'rgba(2,122,255,0.5)' },
+  amp: { color: '#f34e3f', glow: 'rgba(243,78,63,0.5)' },
+  mastracode: { color: '#e6e8eb', glow: 'rgba(230,232,235,0.45)' },
 }
 
 /**
@@ -127,6 +163,8 @@ const MARKS: Record<string, React.ComponentType<{ size: number }>> = {
   opencode: OpenCodeMark,
   kilo: KiloMark,
   kimi: KimiMark,
+  amp: AmpMark,
+  mastracode: MastraMark,
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -44,6 +44,47 @@ function OpenCodeMark({ size }: { size: number }) {
   )
 }
 
+function KiloMark({ size }: { size: number }) {
+  // Kilo Code brand mark (svgl.app), rendered in currentColor.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="currentColor"
+      style={{ display: 'block' }}
+      aria-hidden="true"
+    >
+      <path d="M23,26v-2h3v-5l-2-2h-4v2h-3v5l2,2h4ZM20,20h3v3h-3v-3Z" />
+      <rect x="12" y="17" width="3" height="3" />
+      <polygon points="26 12 23 12 23 9 20 6 17 6 17 9 20 9 20 12 17 12 17 15 26 15 26 12" />
+      <path d="M0,0v32h32V0H0ZM29,29H3V3h26v26Z" />
+      <polygon points="15 26 15 23 9 23 9 17 6 17 6 23.1875 8.8125 26 15 26" />
+      <rect x="12" y="6" width="3" height="3" />
+      <polygon points="9 12 12 12 12 15 15 15 15 12 12 9 9 9 9 6 6 6 6 15 9 15 9 12" />
+    </svg>
+  )
+}
+
+function KimiMark({ size }: { size: number }) {
+  // Kimi brand mark (svgl.app), reduced to the inner K/M silhouette in
+  // currentColor (the app-icon background and accent dot are dropped).
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 512 512"
+      fill="currentColor"
+      fillRule="evenodd"
+      clipRule="evenodd"
+      style={{ display: 'block' }}
+      aria-hidden="true"
+    >
+      <path d="M321.512 144.254h-50.064l-39.637 90.384h-56.036v-89.99H131v232.868h44.787v-98.103h78.973c13.598 0 26.015-7.927 31.744-20.252v118.355h44.787v-98.103c0-23.342-18.239-42.97-41.523-44.671v-.116h-24.593a45.577 45.577 0 0026.884-24.534l29.453-65.838z" />
+    </svg>
+  )
+}
+
 function CodexMark({ size }: { size: number }) {
   return (
     <svg
@@ -71,6 +112,8 @@ const BRAND: Record<string, { color: string; glow: string }> = {
   'claude-code': { color: '#D97757', glow: 'rgba(217,119,87,0.55)' },
   codex: { color: '#e6e8eb', glow: 'rgba(230,232,235,0.45)' },
   opencode: { color: '#ebe9e6', glow: 'rgba(235,233,230,0.45)' },
+  kilo: { color: '#cbd5e1', glow: 'rgba(203,213,225,0.45)' },
+  kimi: { color: '#027aff', glow: 'rgba(2,122,255,0.5)' },
 }
 
 /**
@@ -82,6 +125,8 @@ const MARKS: Record<string, React.ComponentType<{ size: number }>> = {
   'claude-code': ClaudeMark,
   codex: CodexMark,
   opencode: OpenCodeMark,
+  kilo: KiloMark,
+  kimi: KimiMark,
 }
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds four more agents to the registry, taking supported agents from three to seven: **Amp**, **Kilo Code**, **Kimi CLI**, and **Mastra**.

## How each integrates

- **Amp**: reports state via its OSC window title, so it reuses the OSC signature path with no hook (Plugin confirmation needed = blocked, Braille = working, idle marker = idle).
- **Kilo Code**: loads plugins from its plugin directory like opencode, so it reuses the plugin install path with a fresh plugin that maps kilo's session lifecycle to our working/blocked/turn-end vocabulary.
- **Kimi CLI**: registers hooks as a managed block of tables in its TOML config. New install format.
- **Mastra**: registers flat command hooks in its JSON hooks file. New install format.

Kimi and Mastra do not use the nested settings format the existing agents use, so this adds two install variants and a stdin-free hook script that posts a resolved state which the registry maps to roles. A new idle role covers agents that report a resolved idle rather than a completion. All config edits are idempotent, non-destructive, and only run when the agent's config directory already exists.

## UI

Kilo and Kimi get branded glyphs (brand marks reduced to a single-colour silhouette). Amp and Mastra render via the existing fallback glyph for now.

## Tests

Per-agent unit tests (OSC signatures, registry lookups and uniqueness across seven agents) plus install tests for the two new formats (idempotency, preservation of surrounding config, and skip-when-absent).

## Notes

- The hook event mappings and config formats for the new agents, and Amp's OSC signature, are reconstructed from a proven reference implementation and each agent's own config format. They should be confirmed against live installs before being relied on in production. The agent-agnostic process/prompt floor keeps all four correct (running/idle, never stuck) in the meantime.
- The frontend event contract is unchanged.
