### PR TITLE
feat(companion): follow system light/dark theme

### DIFF
--- a/companion/.fallowrc.jsonc
+++ b/companion/.fallowrc.jsonc
@@ -19,14 +19,16 @@
   // react-native-web is required by expo/dom's `.web.tsx` files that
   // Metro pulls in when bundling `'use dom'` components. No source
   // file directly imports it; the bundler wires it transparently.
-  // expo-build-properties + expo-dev-client are autolinked / config-
-  // plugin loaded, so nothing imports them directly. @expo/config-
-  // plugins is a transitive Expo dep required from the local Gradle
-  // wrapper plugin (a build-time module fallow does not scan).
+  // expo-build-properties + expo-dev-client + expo-system-ui are
+  // autolinked / config-plugin loaded, so nothing imports them
+  // directly. @expo/config-plugins is a transitive Expo dep required
+  // from the local Gradle wrapper plugin (a build-time module fallow
+  // does not scan).
   "ignoreDependencies": [
     "react-native-web",
     "expo-build-properties",
     "expo-dev-client",
+    "expo-system-ui",
     "@expo/config-plugins"
   ],
   "rules": {

--- a/companion/app.json
+++ b/companion/app.json
@@ -9,7 +9,7 @@
     },
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "ios": {
       "bundleIdentifier": "com.daniakash.agent-terminal.companion.dev",
       "supportsTablet": true,

--- a/companion/bun.lock
+++ b/companion/bun.lock
@@ -23,6 +23,7 @@
         "expo-router": "~56.2.13",
         "expo-secure-store": "~56.0.4",
         "expo-status-bar": "~56.0.4",
+        "expo-system-ui": "~56.0.5",
         "js-base64": "^3.8.0",
         "nanostores": "^1.4.0",
         "react": "19.2.3",
@@ -1072,6 +1073,8 @@
     "expo-status-bar": ["expo-status-bar@56.0.4", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA=="],
 
     "expo-symbols": ["expo-symbols@56.0.6", "", { "dependencies": { "@expo-google-fonts/material-symbols": "^0.4.1", "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "expo": "*", "expo-font": "*", "react": "*", "react-native": "*" } }, "sha512-BrA81DjcNafdj7gXVhdrExb9LtUiSVyOf/NavyMmDAHgHMY1GqeR5cnn1PSAZeYKnSgQhee/H89XUpAxtog5hg=="],
+
+    "expo-system-ui": ["expo-system-ui@56.0.5", "", { "dependencies": { "@react-native/normalize-colors": "0.85.3", "debug": "^4.3.2" }, "peerDependencies": { "expo": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-n1MmnUArV4cc3gVed9fGtluPme00PE9axKVx+NHbKxHFMam5l4GcOI7PxbYKFNx8o7WA1LRD7eLW33agmZrxGg=="],
 
     "expo-updates-interface": ["expo-updates-interface@56.0.2", "", { "peerDependencies": { "expo": "*" } }, "sha512-eWTwSZ9y8vrULG2oBn2TQSSIwBGSq/TxGJ3jY6tuVS2FWH/ASRIiKs3zkUZTRoC3ZuV2alz0mUClYV7nNrFx8g=="],
 

--- a/companion/global.css
+++ b/companion/global.css
@@ -1,3 +1,9 @@
+/* biome-ignore-all lint/suspicious/noDuplicateCustomProperties: uniwind
+ * `@variant light` and `@variant dark` blocks intentionally redefine
+ * the same custom-property names; they are mutually exclusive at
+ * runtime. Suppressing this rule file-wide so the theme variables can
+ * live where uniwind expects them.
+ */
 @import 'tailwindcss';
 @import 'uniwind';
 
@@ -20,37 +26,47 @@
   --radius-lg: var(--radius);
 }
 
-:root {
-  --background: #ffffff;
-  --foreground: rgba(20, 22, 25, 0.9);
-  --card: var(--background);
-  --card-foreground: var(--foreground);
-  --muted: rgba(0, 0, 0, 0.03);
-  --muted-foreground: rgba(0, 0, 0, 0.55);
-  --accent: oklch(0.55 0.18 225);
-  --accent-foreground: #ffffff;
-  --accent-soft: oklch(0.55 0.18 225 / 0.1);
-  --border: rgba(0, 0, 0, 0.08);
-  --input: rgba(0, 0, 0, 0.08);
-  --destructive: #c23648;
-  --success: #2e8b3d;
-  --radius: 0.5rem;
-}
-
-@media (prefers-color-scheme: dark) {
+/*
+ * Uniwind theme variables. Uniwind does not evaluate
+ * `@media (prefers-color-scheme: dark)` in imported CSS. It swaps
+ * variables per active theme via `@variant light`/`@variant dark`
+ * inside `@layer theme`. The active theme is chosen by
+ * `Uniwind.setTheme('system')`, wired at app boot in `_layout.tsx`.
+ */
+@layer theme {
   :root {
-    --background: #0e0f10;
-    --foreground: rgba(230, 232, 235, 0.92);
-    --card: var(--background);
-    --card-foreground: var(--foreground);
-    --muted: rgba(255, 255, 255, 0.04);
-    --muted-foreground: rgba(255, 255, 255, 0.55);
-    --accent: oklch(0.68 0.15 225);
-    --accent-foreground: #000000;
-    --accent-soft: oklch(0.68 0.15 225 / 0.14);
-    --border: rgba(255, 255, 255, 0.08);
-    --input: rgba(255, 255, 255, 0.08);
-    --destructive: #f7768e;
-    --success: #9ece6a;
+    --radius: 0.5rem;
+
+    @variant light {
+      --background: #ffffff;
+      --foreground: rgba(20, 22, 25, 0.9);
+      --card: var(--background);
+      --card-foreground: var(--foreground);
+      --muted: rgba(0, 0, 0, 0.03);
+      --muted-foreground: rgba(0, 0, 0, 0.55);
+      --accent: oklch(0.55 0.18 225);
+      --accent-foreground: #ffffff;
+      --accent-soft: oklch(0.55 0.18 225 / 0.1);
+      --border: rgba(0, 0, 0, 0.08);
+      --input: rgba(0, 0, 0, 0.08);
+      --destructive: #c23648;
+      --success: #2e8b3d;
+    }
+
+    @variant dark {
+      --background: #0e0f10;
+      --foreground: rgba(230, 232, 235, 0.92);
+      --card: var(--background);
+      --card-foreground: var(--foreground);
+      --muted: rgba(255, 255, 255, 0.04);
+      --muted-foreground: rgba(255, 255, 255, 0.55);
+      --accent: oklch(0.68 0.15 225);
+      --accent-foreground: #000000;
+      --accent-soft: oklch(0.68 0.15 225 / 0.14);
+      --border: rgba(255, 255, 255, 0.08);
+      --input: rgba(255, 255, 255, 0.08);
+      --destructive: #f7768e;
+      --success: #9ece6a;
+    }
   }
 }

--- a/companion/package.json
+++ b/companion/package.json
@@ -21,6 +21,7 @@
     "expo-router": "~56.2.13",
     "expo-secure-store": "~56.0.4",
     "expo-status-bar": "~56.0.4",
+    "expo-system-ui": "~56.0.5",
     "js-base64": "^3.8.0",
     "nanostores": "^1.4.0",
     "react": "19.2.3",

--- a/companion/src/app/_layout.tsx
+++ b/companion/src/app/_layout.tsx
@@ -3,7 +3,16 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet'
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { useEffect } from 'react'
+import { Uniwind } from 'uniwind'
 import { initWssBootstrap } from '@/modules/wss/bootstrap'
+
+// Follow the OS light/dark preference. Uniwind ignores
+// `@media (prefers-color-scheme)` in CSS; the active theme is chosen
+// via this API. `'system'` re-evaluates on every OS setting change
+// (Appearance.addChangeListener under the hood) so no other wiring
+// is needed. Called at module load so the first render already sees
+// the right theme instead of flashing light then swapping.
+Uniwind.setTheme('system')
 
 // ActionSheetProvider wraps any component that uses useActionSheet()
 // from @expo/react-native-action-sheet (Phase B long-press menus on
@@ -28,10 +37,10 @@ export default function RootLayout() {
     void initWssBootstrap()
   }, [])
   return (
-    // biome-ignore lint/complexity/noUselessFragments: ActionSheetProvider
-    // uses React.Children.only internally, so the sibling StatusBar +
-    // Stack must be wrapped as a single fragment child.
     <ActionSheetProvider>
+      {/* biome-ignore lint/complexity/noUselessFragments: ActionSheetProvider */}
+      {/* uses React.Children.only internally, so the sibling StatusBar + */}
+      {/* Stack must be wrapped as a single fragment child. */}
       <>
         <StatusBar style="auto" />
         <Stack>


### PR DESCRIPTION
## Summary

Companion was locked to the light palette regardless of OS setting. Fix layered across three pieces:

- **`app.json`** used to hardcode `userInterfaceStyle: 'light'`, which pinned RN's `Appearance` API to always report light. Flipped to `'automatic'` so `Appearance` reports the true OS setting.
- **`expo-system-ui`** (56.0.5) added via `bunx expo install`. Android requires this module for `userInterfaceStyle: automatic` to actually take effect; without it Expo prebuild warns and Android silently falls back to light.
- **`global.css`** was authored with `@media (prefers-color-scheme: dark)`, which uniwind does not evaluate. Rewrote using uniwind's supported `@variant light` / `@variant dark` blocks inside `@layer theme`. Same color values, same variable names, same Tailwind class surface (`bg-background`, `text-foreground`, etc.), just in the shape uniwind understands.
- **`_layout.tsx`** now calls `Uniwind.setTheme('system')` at module load so the first render already knows the active theme. `adaptiveThemes: true` (uniwind's default) means the theme then re-evaluates on every OS setting change via `Appearance.addChangeListener` under the hood.

`StatusBar style='auto'` was already correct and stays in place.

## Fallow

Added `expo-system-ui` to the existing `ignoreDependencies` list next to `expo-dev-client`. Same class of "autolinked by Expo's build pipeline, no source file imports it".

## Test plan

- [x] Verified on Pixel 7 Pro: toggling Android's Settings → Display → Dark theme flips the companion palette live (no restart).
- [x] Verify iOS Simulator: toggling Simulator's dark-mode via Cmd+Shift+A does the same.
- [x] Verify all screens (Home, Projects, Tab, Pair) render both palettes correctly.

## Notes

- This is a native config change (userInterfaceStyle lands in Info.plist + AndroidManifest at prebuild time), so anyone updating their local dev client needs to rerun `bunx expo prebuild --clean && bunx expo run:ios/android` once. Metro alone won't pick it up.
- Root cause was NOT the CSS (both palettes were correctly authored) — it was the tooling mismatch: media queries vs uniwind's `@variant`, and RN's userInterfaceStyle lock.