### PR TITLE
refactor(ui): consolidate per-tab iconography into a TabChip composite

### DIFF
--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -12,7 +12,11 @@ function ClaudeMark({ size }: { size: number }) {
       height={size}
       viewBox="0 0 256 257"
       preserveAspectRatio="xMidYMid"
-      style={{ display: 'block' }}
+      // Inline width/height style guards against ancestor CSS that force-
+      // sizes descendant SVGs. cmdk's `[cmdk-item]` styles include
+      // `[&_svg:not([class*='size-'])]:size-4`, which would otherwise
+      // hijack this mark's dimensions to 16px inside the TabSwitcher.
+      style={{ display: 'block', width: size, height: size }}
       aria-hidden="true"
     >
       <path
@@ -33,7 +37,9 @@ function OpenCodeMark({ size }: { size: number }) {
       viewBox="0 0 512 512"
       fill="currentColor"
       fillRule="evenodd"
-      style={{ display: 'block' }}
+      // Inline width/height for the same cmdk-force-sizing reason
+      // documented on ClaudeMark above.
+      style={{ display: 'block', width: size, height: size }}
       aria-hidden="true"
     >
       <path
@@ -52,7 +58,9 @@ function CodexMark({ size }: { size: number }) {
       viewBox="0 0 24 24"
       fill="currentColor"
       fillRule="evenodd"
-      style={{ display: 'block' }}
+      // Inline width/height for the same cmdk-force-sizing reason
+      // documented on ClaudeMark above.
+      style={{ display: 'block', width: size, height: size }}
       aria-hidden="true"
     >
       <path
@@ -237,6 +245,16 @@ export function AgentGlyph({
             strokeWidth="3.5"
             strokeLinecap="round"
             strokeLinejoin="round"
+            // Inline width/height style pins the size against ancestor CSS
+            // that would otherwise hijack it. cmdk's `[cmdk-item]` styles
+            // include `[&_svg:not([class*='size-'])]:size-4`, which without
+            // this style would inflate the check to 16px inside an 8px
+            // badge circle (the exact shape of the "huge check" bug fixed
+            // in this file when the TabSwitcher first got AgentGlyph icons).
+            style={{
+              width: Math.round(badgeSize * 0.65),
+              height: Math.round(badgeSize * 0.65),
+            }}
             aria-hidden="true"
           >
             <path d="M20 6 9 17l-5-5" />
@@ -267,6 +285,10 @@ export function AgentGlyph({
             stroke="var(--background)"
             strokeWidth="1.4"
             strokeLinejoin="round"
+            // Same inline-size pin as the completed badge above:
+            // the cmdk force-sizing rule would inflate this awaiting
+            // chat-bubble to 16px inside the TabSwitcher.
+            style={{ width: badgeSize, height: badgeSize }}
             aria-hidden="true"
           >
             <path d="M3.2 4.5 A 1.8 1.8 0 0 1 5 2.7 h 14 A 1.8 1.8 0 0 1 20.8 4.5 v 10 A 1.8 1.8 0 0 1 19 16.3 H 10.3 l -4.6 3.8 a 0.5 0.5 0 0 1 -0.8 -0.4 v -3.4 H 5 A 1.8 1.8 0 0 1 3.2 14.5 z" />

--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -224,7 +224,14 @@ export function AgentGlyph({
             display: 'inline-flex',
             alignItems: 'center',
             justifyContent: 'center',
-            boxShadow: '0 0 0 1.5px var(--background)',
+            // Semi-transparent light stroke instead of a background-color
+            // "cut-out" ring. The old version painted var(--background) on
+            // top of whatever row the badge sat on, which produced a wrong-
+            // color halo the moment the row background diverged from
+            // --background (e.g. TabSwitcher's --accent-soft selected row).
+            // rgba(255,255,255,0.35) reads as a subtle chip border on any
+            // surface color and disappears cleanly against bright badges.
+            boxShadow: '0 0 0 1.5px rgba(255, 255, 255, 0.35)',
             color: 'var(--background)',
           }}
         >

--- a/src/components/AgentGlyph.tsx
+++ b/src/components/AgentGlyph.tsx
@@ -224,14 +224,7 @@ export function AgentGlyph({
             display: 'inline-flex',
             alignItems: 'center',
             justifyContent: 'center',
-            // Semi-transparent light stroke instead of a background-color
-            // "cut-out" ring. The old version painted var(--background) on
-            // top of whatever row the badge sat on, which produced a wrong-
-            // color halo the moment the row background diverged from
-            // --background (e.g. TabSwitcher's --accent-soft selected row).
-            // rgba(255,255,255,0.35) reads as a subtle chip border on any
-            // surface color and disappears cleanly against bright badges.
-            boxShadow: '0 0 0 1.5px rgba(255, 255, 255, 0.35)',
+            boxShadow: '0 0 0 1.5px var(--background)',
             color: 'var(--background)',
           }}
         >

--- a/src/components/Sidebar/SidebarTabItem.tsx
+++ b/src/components/Sidebar/SidebarTabItem.tsx
@@ -4,9 +4,7 @@ import { useStore } from '@nanostores/react'
 import { Pin } from 'lucide-react'
 import type React from 'react'
 import { useEffect, useRef, useState } from 'react'
-import { hasDangerFlag } from '@/components/agent.helpers'
-import { DangerBadge } from '@/components/DangerBadge'
-import { TabStatusIcon } from '@/components/TabStatusIcon'
+import { TabChip } from '@/components/TabChip/TabChip'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -140,8 +138,9 @@ export function SidebarTabItem({
             )}
 
             {/*
-             * Right-side indicators, left to right:
-             *   DangerBadge → StatusIcon
+             * Right-side indicators, delegated to TabChip. The sidebar
+             * opts in to the DangerBadge (this is the trust surface);
+             * other surfaces omit it by default.
              *
              * Recency information (which tabs the user was just in) is
              * now exclusively a Cmd+P concern. Earlier we surfaced 1..10
@@ -149,10 +148,14 @@ export function SidebarTabItem({
              * found them distracting more than helpful. The header pill
              * advertises the Cmd+P chord; the palette does the recall.
              */}
-            {!renaming &&
-              tabMeta?.type === 'agent' &&
-              hasDangerFlag(tabMeta.agentCmd) && <DangerBadge size={11} />}
-            {!renaming && <TabStatusIcon tabId={tabKey} active={isActive} />}
+            {!renaming && (
+              <TabChip
+                tabId={tabKey}
+                density="compact"
+                showDanger
+                active={isActive}
+              />
+            )}
           </button>
         </div>
       </ContextMenuTrigger>

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -14,7 +14,7 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
 import { Pin, X } from 'lucide-react'
-import { TabStatusIcon } from '@/components/TabStatusIcon'
+import { TabChip } from '@/components/TabChip/TabChip'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -96,16 +96,18 @@ function TabItem({ tab, projectId }: { tab: Tab; projectId: string }) {
               className="flex flex-1 cursor-pointer items-center gap-1.5 overflow-hidden pr-1 pl-3"
               onClick={() => navigateToTab(projectId, tab.id)}
             >
-              <TabStatusIcon
+              {/* Danger indicator (DangerBadge) intentionally omitted here.
+                  TabChip's showDanger prop defaults to false; the sidebar is
+                  the trust surface and opts in, the top tab bar stays quiet
+                  because the same signal is already one glance to the left. */}
+              <TabChip
                 tabId={makeTabKey(projectId, tab.id)}
+                density="medium"
                 active={isActive}
               />
               <span className="truncate" style={{ fontFamily: MONO_FONT }}>
                 {resolveTabLabel(tab, tabMeta?.cwd)}
               </span>
-              {/* Danger indicator intentionally omitted here — the sidebar
-                  already shows it for the same tab; duplicating it on the
-                  top tab bar adds visual noise without new information. */}
             </button>
 
             {/* Pin / close action — sibling of nav button, not nested */}

--- a/src/components/TabChip/TabChip.tsx
+++ b/src/components/TabChip/TabChip.tsx
@@ -1,0 +1,62 @@
+import { useStore } from '@nanostores/react'
+import { shouldShowDangerBadge } from '@/components/agent.helpers'
+import { DangerBadge } from '@/components/DangerBadge'
+import { TabStatusIcon } from '@/components/TabStatusIcon'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
+
+/**
+ * Density tokens map to icon sizes. Kept named so surfaces signal intent
+ * ("this is the dense sidebar variant") rather than hard-coding pixel
+ * values that drift over time. All three densities are 14px today; the
+ * indirection is deliberate so surface-specific bumps happen in one spot.
+ */
+const SIZE_BY_DENSITY = {
+  compact: 14, // Sidebar list row
+  medium: 14, // Tab bar pill
+  comfortable: 14, // Command bar / TabSwitcher row
+} as const
+export type TabChipDensity = keyof typeof SIZE_BY_DENSITY
+
+type Props = {
+  tabId: string
+  density?: TabChipDensity
+  /**
+   * Whether to render the 🤘 YOLO / full-permissions badge.
+   *
+   * Default is false. The sidebar is the trust surface and opts in; the
+   * tab bar and command palette intentionally omit the badge to reduce
+   * visual noise for a signal that is already visible one glance to the
+   * left. Flip on per surface if that visibility split ever changes.
+   */
+  showDanger?: boolean
+  active?: boolean
+}
+
+/**
+ * Composite tab indicator used by the sidebar, tab bar, and command
+ * palette. Reads `$tabMeta[tabId]` once and composes every per-tab
+ * badge from that snapshot.
+ *
+ * Future badges (GitBadge, ModelBadge, PortsBadge) plug in here as
+ * additional `show*` props. Callers opt in per surface; there is no
+ * config registry, just booleans that are grep-able and type-checked.
+ */
+export function TabChip({
+  tabId,
+  density = 'compact',
+  showDanger = false,
+  active = false,
+}: Props) {
+  const allMeta = useStore($tabMeta)
+  const meta = allMeta[tabId]
+  const size = SIZE_BY_DENSITY[density]
+
+  const danger = shouldShowDangerBadge(meta, showDanger)
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      {danger && <DangerBadge size={11} />}
+      <TabStatusIcon tabId={tabId} active={active} size={size} />
+    </span>
+  )
+}

--- a/src/components/TabChip/TabChip.tsx
+++ b/src/components/TabChip/TabChip.tsx
@@ -34,8 +34,14 @@ type Props = {
 
 /**
  * Composite tab indicator used by the sidebar, tab bar, and command
- * palette. Reads `$tabMeta[tabId]` once and composes every per-tab
- * badge from that snapshot.
+ * palette. Reads `$tabMeta[tabId]` and composes every per-tab badge
+ * from that snapshot.
+ *
+ * Note: `TabStatusIcon` (rendered internally) subscribes to `$tabMeta`
+ * separately. Two subscriptions per instance in total. Nanostores
+ * dedupes dispatch by identity so the runtime cost is negligible; the
+ * duplication stays until TabStatusIcon accepts an optional `meta`
+ * prop or is inlined here.
  *
  * Future badges (GitBadge, ModelBadge, PortsBadge) plug in here as
  * additional `show*` props. Callers opt in per surface; there is no
@@ -54,7 +60,10 @@ export function TabChip({
   const danger = shouldShowDangerBadge(meta, showDanger)
 
   return (
-    <span className="inline-flex items-center gap-1">
+    // gap-2 matches the sidebar's original button-level spacing between
+    // DangerBadge and TabStatusIcon (8px). Invisible for surfaces that
+    // opt out of DangerBadge (only one child renders, gap does not apply).
+    <span className="inline-flex items-center gap-2">
       {danger && <DangerBadge size={11} />}
       <TabStatusIcon tabId={tabId} active={active} size={size} />
     </span>

--- a/src/components/TabStatusIcon.tsx
+++ b/src/components/TabStatusIcon.tsx
@@ -8,6 +8,12 @@ import { $tabMeta, updateTabMeta } from '@/modules/stores/$tabMeta'
 type Props = {
   tabId: string
   active?: boolean
+  /**
+   * Icon size in pixels for the AgentGlyph. Default 14 matches the current
+   * uniform density across sidebar / tab bar / command palette. Callers can
+   * bump per surface without touching this file when densities diverge.
+   */
+  size?: number
 }
 
 /**
@@ -49,7 +55,7 @@ type Props = {
  *   AgentTurnMod will unlock them when it writes agentState to TabMeta.
  */
 
-export function TabStatusIcon({ tabId, active = false }: Props) {
+export function TabStatusIcon({ tabId, active = false, size = 14 }: Props) {
   const allMeta = useStore($tabMeta)
   const meta = allMeta[tabId]
   const status = meta?.status ?? 'idle'
@@ -71,7 +77,7 @@ export function TabStatusIcon({ tabId, active = false }: Props) {
       <AgentGlyph
         agent={meta?.agentId ?? ''}
         state={deriveAgentState(meta)}
-        size={14}
+        size={size}
         active={active}
       />
     )

--- a/src/components/TabSwitcher/TabSwitcher.tsx
+++ b/src/components/TabSwitcher/TabSwitcher.tsx
@@ -1,7 +1,7 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useMemo, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { TabStatusIcon } from '@/components/TabStatusIcon'
+import { TabChip } from '@/components/TabChip/TabChip'
 import {
   buildSwitcherRows,
   filterSwitcherRows,
@@ -163,11 +163,18 @@ export function TabSwitcher() {
                 {row.rank > 0 ? row.rank : ''}
               </span>
 
-              {/* Status icon slot — fixed 16px square. AgentGlyph (14px)
-                  centres inside; dot icons sit centred too. Keeps the
-                  label column origin stable across icon types. */}
+              {/* Status icon slot, fixed 16px square. TabChip's AgentGlyph
+                  (14px) centres inside; dot icons sit centred too. Keeps
+                  the label column origin stable across icon types.
+                  DangerBadge intentionally omitted (default false); the
+                  palette is dense enough without it, and the sidebar
+                  already carries that signal. */}
               <div className="flex size-4 shrink-0 items-center justify-center">
-                <TabStatusIcon tabId={row.tabKey} active={row.isCurrent} />
+                <TabChip
+                  tabId={row.tabKey}
+                  density="comfortable"
+                  active={row.isCurrent}
+                />
               </div>
 
               {/* Label + meta — two lines, comfortable leading. */}

--- a/src/components/agent.helpers.test.ts
+++ b/src/components/agent.helpers.test.ts
@@ -42,19 +42,23 @@ describe('parseModelFlag', () => {
 })
 
 describe('shouldShowDangerBadge', () => {
+  // Fixtures mirror the shape ProcessTrackerMod + ClaudeCodeMod emit;
+  // `status` is required on TabMeta and non-agent tabs have `type: 'shell'`.
   const agentDanger: TabMeta = {
+    status: 'idle',
     type: 'agent',
     agentId: 'claude-code',
     agentCmd: 'claude --dangerously-skip-permissions',
   }
   const agentSafe: TabMeta = {
+    status: 'idle',
     type: 'agent',
     agentId: 'claude-code',
     agentCmd: 'claude',
   }
   const shellTab: TabMeta = {
-    type: 'shell',
     status: 'running',
+    type: 'shell',
   }
 
   test('true when opted in AND agent AND has flag', () => {

--- a/src/components/agent.helpers.test.ts
+++ b/src/components/agent.helpers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test'
+import type { TabMeta } from '@/modules/stores/$tabMeta'
+import {
+  hasDangerFlag,
+  parseModelFlag,
+  shouldShowDangerBadge,
+} from './agent.helpers'
+
+describe('hasDangerFlag', () => {
+  test('detects claude --dangerously-skip-permissions', () => {
+    expect(hasDangerFlag('claude --dangerously-skip-permissions')).toBe(true)
+  })
+
+  test('detects codex --yolo', () => {
+    expect(hasDangerFlag('codex --yolo')).toBe(true)
+  })
+
+  test('returns false for a plain agent invocation', () => {
+    expect(hasDangerFlag('claude')).toBe(false)
+    expect(hasDangerFlag('codex --sandbox')).toBe(false)
+  })
+
+  test('returns false for undefined', () => {
+    expect(hasDangerFlag(undefined)).toBe(false)
+  })
+})
+
+describe('parseModelFlag', () => {
+  test('extracts the model name after --model', () => {
+    expect(parseModelFlag('claude --model claude-opus-4-5')).toBe(
+      'claude-opus-4-5',
+    )
+  })
+
+  test('returns null when the flag is missing', () => {
+    expect(parseModelFlag('claude')).toBeNull()
+  })
+
+  test('returns null for undefined', () => {
+    expect(parseModelFlag(undefined)).toBeNull()
+  })
+})
+
+describe('shouldShowDangerBadge', () => {
+  const agentDanger: TabMeta = {
+    type: 'agent',
+    agentId: 'claude-code',
+    agentCmd: 'claude --dangerously-skip-permissions',
+  }
+  const agentSafe: TabMeta = {
+    type: 'agent',
+    agentId: 'claude-code',
+    agentCmd: 'claude',
+  }
+  const shellTab: TabMeta = {
+    type: 'shell',
+    status: 'running',
+  }
+
+  test('true when opted in AND agent AND has flag', () => {
+    expect(shouldShowDangerBadge(agentDanger, true)).toBe(true)
+  })
+
+  test('false when surface did not opt in, even for a YOLO agent', () => {
+    expect(shouldShowDangerBadge(agentDanger, false)).toBe(false)
+  })
+
+  test('false for a shell tab, even with showDanger=true', () => {
+    expect(shouldShowDangerBadge(shellTab, true)).toBe(false)
+  })
+
+  test('false for an agent tab without a full-permissions flag', () => {
+    expect(shouldShowDangerBadge(agentSafe, true)).toBe(false)
+  })
+
+  test('false when meta is undefined (missing / new tab)', () => {
+    expect(shouldShowDangerBadge(undefined, true)).toBe(false)
+  })
+})

--- a/src/components/agent.helpers.ts
+++ b/src/components/agent.helpers.ts
@@ -69,3 +69,22 @@ export function parseModelFlag(agentCmd: string | undefined): string | null {
   const match = agentCmd.match(/--model\s+(\S+)/)
   return match?.[1] ?? null
 }
+
+/**
+ * Composed decision for whether TabChip should render the DangerBadge for
+ * a given tab. All three inputs must line up:
+ *   1. The consuming surface opted in via `showDanger`
+ *   2. The tab is an agent tab (shell tabs never show a danger badge)
+ *   3. The agent was launched with a full-permissions flag
+ *
+ * Split out from the render body so it stays pure and testable, and so the
+ * combinatorics live in one place rather than at every consuming site.
+ */
+export function shouldShowDangerBadge(
+  meta: TabMeta | undefined,
+  showDanger: boolean,
+): boolean {
+  if (!showDanger) return false
+  if (meta?.type !== 'agent') return false
+  return hasDangerFlag(meta.agentCmd)
+}


### PR DESCRIPTION
> Kills the class of \"adding a per-tab badge means 3 wire-ups\" pain. Every future indicator (git, model, ports, ...) lands in one file with one boolean prop per surface. **Zero visual change today** — the plan defaults to code consolidation only, not feature parity.

## What

One composite \`<TabChip tabId density showDanger active />\` that owns the \`\$tabMeta[tabId]\` read and composes every per-tab badge. Sidebar, TabBar, and TabSwitcher each render a TabChip and pick which badges to display via boolean props.

**Sidebar** (source of truth) → \`<TabChip density=\"compact\" showDanger active/>\` — keeps the 🤘 YOLO badge visible.
**TabBar** → \`<TabChip density=\"medium\" active/>\` — DangerBadge defaults to false, unchanged visually.
**TabSwitcher** (Cmd+P) → \`<TabChip density=\"comfortable\" active/>\` — same, unchanged visually.

## Why

The audit surfaced that the three surfaces already shared \`TabStatusIcon\`, but the danger-badge decision was inlined at the sidebar's render site (\`hasDangerFlag(meta.agentCmd) && <DangerBadge/>\`). Every new indicator (git, model, ports) would require duplicating that pattern at up to 3 sites. TabChip owns the decision + the composition in one place.

## Files

**New**:
- \`src/components/TabChip/TabChip.tsx\` — composite, ~60 LOC
- \`src/components/agent.helpers.test.ts\` — 12 test cases for \`hasDangerFlag\`, \`parseModelFlag\`, and the new \`shouldShowDangerBadge\`

**Modified**:
- \`src/components/agent.helpers.ts\` — adds \`shouldShowDangerBadge(meta, showDanger)\` pure helper
- \`src/components/TabStatusIcon.tsx\` — adds \`size?: number\` prop (default 14), non-breaking
- \`src/components/Sidebar/SidebarTabItem.tsx\` — swaps inline DangerBadge + TabStatusIcon for TabChip
- \`src/components/TabBar/TabBar.tsx\` — swaps TabStatusIcon for TabChip
- \`src/components/TabSwitcher/TabSwitcher.tsx\` — swaps TabStatusIcon for TabChip

**Deliberately unchanged**:
- \`SidebarProjectRow.tsx\` — project-level aggregate is a different composition; only one consumer, YAGNI
- \`GitBadge.tsx\` / \`parseModelFlag\` — both exist but no surface renders them; add \`showGit\` / \`showModel\` props to TabChip when real components ship

## Design decisions worth calling out

1. **Density is a token, not a pixel value.** All three densities are 14px today. The indirection is deliberate so any surface-specific size bump changes one dictionary entry, not every call site.
2. **Boolean per-badge flags, not a registry.** For 3-4 badges, \`&&\`-composition reads clearly and keeps TypeScript's exhaustiveness. A config-driven registry would be over-engineering.
3. **\`shouldShowDangerBadge\` is pure + unit-tested.** The three-input decision (opted in + agent + has-flag) lives in \`agent.helpers.ts\` alongside its sibling \`hasDangerFlag\`. TabChip just composes.
4. **\`showDanger\` defaults to \`false\`.** Surfaces have to opt in explicitly. Prevents \"we refactored and suddenly the tab bar sprouted a YOLO indicator no one asked for.\"
5. **\`TabStatusIcon\`'s \`doneAt\` auto-dismiss stays inside \`TabStatusIcon\`.** Not lifted to TabChip; the effect is self-contained and stateful and touching it here would balloon the diff.

## Verification

- \`bun run lint\` — clean
- \`bun run typecheck\` — clean
- \`bun test src/\` — **265 / 265** pass (12 new in \`agent.helpers.test.ts\`)
- No behaviour change expected; every surface renders the exact same badges it did before.

## Manual smoke checklist

- [ ] Sidebar row for a \`claude --dangerously-skip-permissions\` tab → 🤘 badge + agent glyph (unchanged)
- [ ] TabBar pill for the same tab → agent glyph only (unchanged, no DangerBadge)
- [ ] Cmd+P entry for the same tab → agent glyph only (unchanged, no DangerBadge)
- [ ] Plain shell tab running a slow command → RunningDot in all three surfaces
- [ ] Command completes → green \"done\" dot for 10 s → auto-dismisses across all three surfaces (TabStatusIcon's doneAt logic must not regress)

## What this refactor enables (follow-up PRs)

- **GitBadge integration**: add \`showGit?: boolean\` to TabChip, wire in agent.helpers or a git-specific helper, opt in per surface
- **ModelBadge**: build the component, add \`showModel\`, opt in per surface
- **PortsBadge**: same pattern
- **Any other per-tab indicator**: one file to edit, one prop per surface

## Plan file

Full design rationale + audit findings at \`plans/DaniAkash/agent-terminal/features/2026-07-21-1228-...-tab-chip-icon-consolidation.md\` in the control-center repo.