### PR TITLE
feat(sidebar): hide/show toggle + Recent view

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,8 +18,7 @@
         "minWidth": 800,
         "minHeight": 500,
         "hiddenTitle": true,
-        "titleBarStyle": "Overlay",
-        "trafficLightPosition": { "x": 15, "y": 12 }
+        "titleBarStyle": "Overlay"
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
         "minWidth": 800,
         "minHeight": 500,
         "hiddenTitle": true,
-        "titleBarStyle": "Overlay"
+        "titleBarStyle": "Overlay",
+        "trafficLightPosition": { "x": 15, "y": 12 }
       }
     ],
     "security": {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,86 +1,39 @@
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core'
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
 import { useStore } from '@nanostores/react'
 import { CommandShortcut } from '@/components/ui/command'
-import {
-  $activeProjectId,
-  $activeTabId,
-  navigateToProject,
-  navigateToTab,
-} from '@/modules/stores/$navigation'
-import {
-  $projects,
-  addProject,
-  reorderProjects,
-} from '@/modules/stores/$projects'
-import { $tabMeta } from '@/modules/stores/$tabMeta'
-import { makeTabKey } from '@/screens/workspace/workspace.helpers'
-import { SidebarProjectRow } from './SidebarProjectRow'
+import { $sidebarView } from '@/modules/stores/$sidebarView'
+import { $sidebarVisible } from '@/modules/stores/$sidebarVisible'
+import { SidebarRecent } from './SidebarRecent'
+import { SidebarViewToggle } from './SidebarViewToggle'
+import { SidebarWorkspaces } from './SidebarWorkspaces'
+
+/* ---------------------------------------------------------------------------
+ * Sidebar — thin composer.
+ *
+ * Renders the sidebar chrome (drag-region header, view toggle, Cmd+P
+ * hint, scroll-clip container with bottom shadow) and swaps the body
+ * between SidebarWorkspaces / SidebarRecent based on `$sidebarView`.
+ *
+ * Returns `null` when `$sidebarVisible` is false — the sidebar is
+ * fully hidden, not a minified icon rail. The reveal affordance
+ * lives in the TabBar (`SidebarRevealButton`) so the user always has
+ * a way back regardless of state.
+ * -------------------------------------------------------------------------*/
 
 export function Sidebar() {
-  const projects = useStore($projects)
+  const visible = useStore($sidebarVisible)
+  const view = useStore($sidebarView)
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  )
-
-  const ordered = [
-    ...projects.filter((p) => p.pinned),
-    ...projects.filter((p) => !p.pinned),
-  ]
-
-  function handleDragEnd(event: DragEndEvent) {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-    const oldIndex = projects.findIndex((p) => p.id === active.id)
-    const newIndex = projects.findIndex((p) => p.id === over.id)
-    if (projects[oldIndex]?.pinned !== projects[newIndex]?.pinned) return
-    reorderProjects(oldIndex, newIndex)
-  }
-
-  function handleAddProject() {
-    const projectId = $activeProjectId.get()
-    const tabId = $activeTabId.get()[projectId]
-    const cwd = tabId
-      ? ($tabMeta.get()[makeTabKey(projectId, tabId)]?.cwd ?? '')
-      : ''
-    const project = addProject(cwd || undefined)
-    navigateToProject(project.id)
-    navigateToTab(project.id, 'shell')
-  }
+  if (!visible) return null
 
   return (
     <div className="flex h-full w-[var(--sidebar-width)] min-w-[var(--sidebar-width)] flex-col border-sidebar-border border-r bg-sidebar">
-      {/* Header — drag region, reserves traffic-light space */}
+      {/* Header — drag region, reserves traffic-light space, hosts the
+          view toggle and the Cmd+P hint. */}
       <div
         data-tauri-drag-region
-        className="flex h-[38px] shrink-0 items-center border-sidebar-border border-b px-3 pl-[78px]"
+        className="flex h-[38px] shrink-0 items-center gap-2 border-sidebar-border border-b pr-3 pl-[78px]"
       >
-        <span
-          className="font-medium text-[12px] text-sidebar-fg"
-          style={{ letterSpacing: '0.01em' }}
-        >
-          Workspaces
-        </span>
-        {/* Ambient ⌘P hint — advertises the tab switcher. Persistent and
-            dim so the eye stops registering it once learned, but visible
-            enough that a new user discovers the chord without holding any
-            modifier. */}
+        <SidebarViewToggle />
         <CommandShortcut
           className="ml-auto opacity-50"
           title="Open the tab switcher (⌘P)"
@@ -89,47 +42,14 @@ export function Sidebar() {
         </CommandShortcut>
       </div>
 
-      {/* Project tree — scrolls vertically; scrollbar hidden, bottom shadow
+      {/* Body — scrolls vertically; scrollbar hidden, bottom shadow
           gives a visual cue when more content exists below. */}
       <div className="relative min-h-0 flex-1 overflow-hidden">
         <div className="h-full overflow-y-auto py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {projects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-1 px-4 py-8 text-center">
-              <p className="text-[12px] text-sidebar-fg opacity-60">
-                No projects yet.
-              </p>
-              <p className="text-[11px] text-sidebar-fg opacity-40">
-                Click below to add your first project.
-              </p>
-            </div>
-          ) : (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={ordered.map((p) => p.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                {ordered.map((p) => (
-                  <SidebarProjectRow key={p.id} project={p} />
-                ))}
-              </SortableContext>
-            </DndContext>
-          )}
-
-          <button
-            type="button"
-            onClick={handleAddProject}
-            className="mx-1.5 mt-1 flex h-[26px] w-[calc(100%-12px)] items-center gap-1.5 rounded-md px-3 text-[12px] text-sidebar-fg opacity-70 hover:bg-sidebar-hover hover:opacity-100"
-          >
-            <span className="text-[13px] leading-none">+</span>
-            <span>New project</span>
-          </button>
+          {view === 'workspaces' ? <SidebarWorkspaces /> : <SidebarRecent />}
         </div>
 
-        {/* Bottom shadow — signals overflowing project rows */}
+        {/* Bottom shadow — signals overflowing content */}
         <div
           className="pointer-events-none absolute right-0 bottom-0 left-0 h-8"
           style={{

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -27,9 +27,9 @@ export function Sidebar() {
   return (
     <div className="flex h-full w-[var(--sidebar-width)] min-w-[var(--sidebar-width)] flex-col border-sidebar-border border-r bg-sidebar">
       {/* Header — drag region hosting the view toggle. Reserves the
-          macOS traffic-light row (~78px) on the left; the Tauri config
-          also sets trafficLightPosition so the buttons vertically
-          centre inside the 38px header instead of sitting near the top. */}
+          macOS traffic-light row (~80px) on the left. Traffic lights
+          keep their default Tauri Overlay placement (looked correct
+          before we started fiddling). */}
       <div
         data-tauri-drag-region
         className="flex h-[38px] shrink-0 items-center justify-end border-sidebar-border border-b pr-3 pl-[80px]"

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { useStore } from '@nanostores/react'
-import { CommandShortcut } from '@/components/ui/command'
 import { $sidebarView } from '@/modules/stores/$sidebarView'
 import { $sidebarVisible } from '@/modules/stores/$sidebarVisible'
 import { SidebarRecent } from './SidebarRecent'
@@ -9,9 +8,9 @@ import { SidebarWorkspaces } from './SidebarWorkspaces'
 /* ---------------------------------------------------------------------------
  * Sidebar — thin composer.
  *
- * Renders the sidebar chrome (drag-region header, view toggle, Cmd+P
- * hint, scroll-clip container with bottom shadow) and swaps the body
- * between SidebarWorkspaces / SidebarRecent based on `$sidebarView`.
+ * Renders the sidebar chrome (drag-region header, view toggle,
+ * scroll-clip container with bottom shadow) and swaps the body between
+ * SidebarWorkspaces / SidebarRecent based on `$sidebarView`.
  *
  * Returns `null` when `$sidebarVisible` is false — the sidebar is
  * fully hidden, not a minified icon rail. The reveal affordance
@@ -27,19 +26,15 @@ export function Sidebar() {
 
   return (
     <div className="flex h-full w-[var(--sidebar-width)] min-w-[var(--sidebar-width)] flex-col border-sidebar-border border-r bg-sidebar">
-      {/* Header — drag region, reserves traffic-light space, hosts the
-          view toggle and the Cmd+P hint. */}
+      {/* Header — drag region hosting the view toggle. Reserves the
+          macOS traffic-light row (~78px) on the left; the Tauri config
+          also sets trafficLightPosition so the buttons vertically
+          centre inside the 38px header instead of sitting near the top. */}
       <div
         data-tauri-drag-region
-        className="flex h-[38px] shrink-0 items-center gap-2 border-sidebar-border border-b pr-3 pl-[78px]"
+        className="flex h-[38px] shrink-0 items-center justify-end border-sidebar-border border-b pr-3 pl-[80px]"
       >
         <SidebarViewToggle />
-        <CommandShortcut
-          className="ml-auto opacity-50"
-          title="Open the tab switcher (⌘P)"
-        >
-          ⌘P
-        </CommandShortcut>
       </div>
 
       {/* Body — scrolls vertically; scrollbar hidden, bottom shadow

--- a/src/components/Sidebar/SidebarRecent.tsx
+++ b/src/components/Sidebar/SidebarRecent.tsx
@@ -100,6 +100,7 @@ export function SidebarRecent() {
                 <TabChip
                   tabId={row.tabKey}
                   density="compact"
+                  showDanger
                   active={row.isCurrent}
                 />
               </button>

--- a/src/components/Sidebar/SidebarRecent.tsx
+++ b/src/components/Sidebar/SidebarRecent.tsx
@@ -1,0 +1,115 @@
+import { useStore } from '@nanostores/react'
+import { useMemo } from 'react'
+import { TabChip } from '@/components/TabChip/TabChip'
+import { buildSwitcherRows } from '@/components/TabSwitcher/tab-switcher.helpers'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import {
+  $activeProjectId,
+  $activeTabId,
+  navigateToTab,
+} from '@/modules/stores/$navigation'
+import { $projects } from '@/modules/stores/$projects'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
+import { $tabRecency, $tabRecencyTimes } from '@/modules/stores/$tabRecency'
+import { MONO_FONT } from '@/screens/workspace/workspace.helpers'
+import { toRecentSidebarRows } from './sidebar.helpers'
+
+/* ---------------------------------------------------------------------------
+ * SidebarRecent — flat recency list across every project.
+ *
+ * Same data source as the Cmd+P palette (`buildSwitcherRows`). The
+ * palette optimizes for filtered search and shows rank / project /
+ * cwd / relative time; the sidebar optimizes for at-a-glance recall
+ * and shows only the tab label + TabChip, with the project name
+ * available on hover via Tooltip.
+ *
+ * Rows never visited during the tracked window are filtered out
+ * (`toRecentSidebarRows`), so this view stays useful when the project
+ * tree is noisy across ten-plus projects.
+ * -------------------------------------------------------------------------*/
+
+export function SidebarRecent() {
+  const projects = useStore($projects)
+  const recency = useStore($tabRecency)
+  const recencyTimes = useStore($tabRecencyTimes)
+  const tabMeta = useStore($tabMeta)
+  const activeProjectId = useStore($activeProjectId)
+  const activeTabIds = useStore($activeTabId)
+
+  const rows = useMemo(
+    () =>
+      toRecentSidebarRows(
+        buildSwitcherRows({
+          projects,
+          recency,
+          recencyTimes,
+          tabMeta,
+          activeProjectId,
+          activeTabIds,
+        }),
+      ),
+    [projects, recency, recencyTimes, tabMeta, activeProjectId, activeTabIds],
+  )
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-1 px-4 py-8 text-center">
+        <p className="text-[12px] text-sidebar-fg opacity-60">
+          No recent tabs yet.
+        </p>
+        <p className="text-[11px] text-sidebar-fg opacity-40">
+          Switch between tabs to build up recency.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <TooltipProvider delay={400}>
+      {rows.map((row) => (
+        <Tooltip key={row.tabKey}>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => {
+                  if (!row.isCurrent) navigateToTab(row.projectId, row.tabId)
+                }}
+                className={cn(
+                  'mx-1.5 flex h-[26px] w-[calc(100%-12px)] items-center gap-2 rounded-md px-3 text-left',
+                  row.isCurrent
+                    ? 'bg-sidebar-active text-sidebar-fg-strong'
+                    : 'text-sidebar-fg hover:bg-sidebar-hover',
+                )}
+              >
+                <span
+                  className={cn(
+                    'flex-1 truncate',
+                    row.isCurrent && 'font-medium',
+                  )}
+                  style={{ fontFamily: MONO_FONT, fontSize: 11.5 }}
+                >
+                  {row.label}
+                </span>
+                <TabChip
+                  tabId={row.tabKey}
+                  density="compact"
+                  active={row.isCurrent}
+                />
+              </button>
+            }
+          />
+          <TooltipContent side="right" sideOffset={6}>
+            {row.projectName}
+          </TooltipContent>
+        </Tooltip>
+      ))}
+    </TooltipProvider>
+  )
+}

--- a/src/components/Sidebar/SidebarRevealButton.tsx
+++ b/src/components/Sidebar/SidebarRevealButton.tsx
@@ -1,0 +1,55 @@
+import { useStore } from '@nanostores/react'
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
+  $sidebarVisible,
+  toggleSidebarVisible,
+} from '@/modules/stores/$sidebarVisible'
+
+/* ---------------------------------------------------------------------------
+ * SidebarRevealButton — always-visible sidebar toggle in the TabBar.
+ *
+ * Rendered as the leftmost child of the TabBar so it stays reachable
+ * regardless of sidebar state:
+ *   - hidden  → click to reveal ("open panel" icon)
+ *   - visible → click to hide   ("close panel" icon)
+ *
+ * The equivalent global hotkey is ⌘B, wired in WorkspaceLayout. Both
+ * paths call `toggleSidebarVisible` so behavior stays in one place.
+ * -------------------------------------------------------------------------*/
+
+export function SidebarRevealButton() {
+  const visible = useStore($sidebarVisible)
+  const label = visible ? 'Hide sidebar' : 'Show sidebar'
+  const Icon = visible ? PanelLeftClose : PanelLeftOpen
+  return (
+    <TooltipProvider delay={400}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              aria-label={label}
+              aria-pressed={visible}
+              onClick={toggleSidebarVisible}
+              // Opt this button out of the parent TabBar's tauri drag region
+              // so clicks toggle instead of moving the window.
+              data-tauri-drag-region={undefined}
+              className="-mb-px flex h-7 w-7 shrink-0 items-center justify-center rounded text-tab-fg hover:bg-sidebar-hover hover:text-tab-fg-active"
+            >
+              <Icon size={14} />
+            </button>
+          }
+        />
+        <TooltipContent side="bottom" sideOffset={4}>
+          {label} (⌘B)
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/components/Sidebar/SidebarViewToggle.tsx
+++ b/src/components/Sidebar/SidebarViewToggle.tsx
@@ -24,7 +24,7 @@ const OPTIONS: Array<{ value: SidebarView; label: string }> = [
 export function SidebarViewToggle() {
   const current = useStore($sidebarView)
   return (
-    <div className="flex h-[22px] items-center gap-0.5 rounded-md bg-sidebar-hover/40 p-0.5">
+    <div className="flex h-[24px] items-center gap-0.5 rounded-md border border-sidebar-border bg-sidebar-active p-0.5">
       {/* No ARIA grouping: each button is self-labelled ("Workspaces" /
           "Recent") and carries its own aria-pressed state, which is what
           a screen reader needs. Adding a group role would just repeat
@@ -38,10 +38,13 @@ export function SidebarViewToggle() {
             aria-pressed={active}
             onClick={() => setSidebarView(opt.value)}
             className={cn(
-              'h-full flex-1 rounded-[4px] px-2 font-medium text-[10.5px] leading-none transition-colors',
+              'h-full flex-1 rounded-[3px] px-2.5 font-medium text-[10.5px] leading-none transition-colors',
+              // Active pill uses --background so it sits visibly above
+              // the sidebar surface AND the inset track, regardless of
+              // theme. shadow-sm reinforces the raised feel.
               active
-                ? 'bg-sidebar text-sidebar-fg-strong shadow-sm'
-                : 'text-sidebar-fg opacity-70 hover:opacity-100',
+                ? 'bg-background text-sidebar-fg-strong shadow-sm'
+                : 'text-sidebar-fg hover:text-sidebar-fg-strong',
             )}
           >
             {opt.label}

--- a/src/components/Sidebar/SidebarViewToggle.tsx
+++ b/src/components/Sidebar/SidebarViewToggle.tsx
@@ -24,19 +24,18 @@ const OPTIONS: Array<{ value: SidebarView; label: string }> = [
 export function SidebarViewToggle() {
   const current = useStore($sidebarView)
   return (
-    <div
-      role="tablist"
-      aria-label="Sidebar view"
-      className="flex h-[22px] items-center gap-0.5 rounded-md bg-sidebar-hover/40 p-0.5"
-    >
+    <div className="flex h-[22px] items-center gap-0.5 rounded-md bg-sidebar-hover/40 p-0.5">
+      {/* No ARIA grouping: each button is self-labelled ("Workspaces" /
+          "Recent") and carries its own aria-pressed state, which is what
+          a screen reader needs. Adding a group role would just repeat
+          what the button names already say. */}
       {OPTIONS.map((opt) => {
         const active = current === opt.value
         return (
           <button
             key={opt.value}
             type="button"
-            role="tab"
-            aria-selected={active}
+            aria-pressed={active}
             onClick={() => setSidebarView(opt.value)}
             className={cn(
               'h-full flex-1 rounded-[4px] px-2 font-medium text-[10.5px] leading-none transition-colors',

--- a/src/components/Sidebar/SidebarViewToggle.tsx
+++ b/src/components/Sidebar/SidebarViewToggle.tsx
@@ -1,0 +1,54 @@
+import { useStore } from '@nanostores/react'
+import { cn } from '@/lib/utils'
+import {
+  $sidebarView,
+  type SidebarView,
+  setSidebarView,
+} from '@/modules/stores/$sidebarView'
+
+/* ---------------------------------------------------------------------------
+ * SidebarViewToggle — segmented Workspaces / Recent switch.
+ *
+ * Two-option toggle rendered inline in the sidebar header. We don't reach
+ * for shadcn Tabs here: adding a full Radix Tabs primitive for two
+ * buttons that don't own their own panel content would be more code and
+ * more indirection than the direct segmented control. The actual panel
+ * swap is done by the Sidebar composer based on `$sidebarView`.
+ * -------------------------------------------------------------------------*/
+
+const OPTIONS: Array<{ value: SidebarView; label: string }> = [
+  { value: 'workspaces', label: 'Workspaces' },
+  { value: 'recent', label: 'Recent' },
+]
+
+export function SidebarViewToggle() {
+  const current = useStore($sidebarView)
+  return (
+    <div
+      role="tablist"
+      aria-label="Sidebar view"
+      className="flex h-[22px] items-center gap-0.5 rounded-md bg-sidebar-hover/40 p-0.5"
+    >
+      {OPTIONS.map((opt) => {
+        const active = current === opt.value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => setSidebarView(opt.value)}
+            className={cn(
+              'h-full flex-1 rounded-[4px] px-2 font-medium text-[10.5px] leading-none transition-colors',
+              active
+                ? 'bg-sidebar text-sidebar-fg-strong shadow-sm'
+                : 'text-sidebar-fg opacity-70 hover:opacity-100',
+            )}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/Sidebar/SidebarWorkspaces.tsx
+++ b/src/components/Sidebar/SidebarWorkspaces.tsx
@@ -1,0 +1,104 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { useStore } from '@nanostores/react'
+import {
+  $activeProjectId,
+  $activeTabId,
+  navigateToProject,
+  navigateToTab,
+} from '@/modules/stores/$navigation'
+import {
+  $projects,
+  addProject,
+  reorderProjects,
+} from '@/modules/stores/$projects'
+import { $tabMeta } from '@/modules/stores/$tabMeta'
+import { makeTabKey } from '@/screens/workspace/workspace.helpers'
+import { SidebarProjectRow } from './SidebarProjectRow'
+
+export function SidebarWorkspaces() {
+  const projects = useStore($projects)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  const ordered = [
+    ...projects.filter((p) => p.pinned),
+    ...projects.filter((p) => !p.pinned),
+  ]
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = projects.findIndex((p) => p.id === active.id)
+    const newIndex = projects.findIndex((p) => p.id === over.id)
+    if (projects[oldIndex]?.pinned !== projects[newIndex]?.pinned) return
+    reorderProjects(oldIndex, newIndex)
+  }
+
+  function handleAddProject() {
+    const projectId = $activeProjectId.get()
+    const tabId = $activeTabId.get()[projectId]
+    const cwd = tabId
+      ? ($tabMeta.get()[makeTabKey(projectId, tabId)]?.cwd ?? '')
+      : ''
+    const project = addProject(cwd || undefined)
+    navigateToProject(project.id)
+    navigateToTab(project.id, 'shell')
+  }
+
+  return (
+    <>
+      {projects.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-1 px-4 py-8 text-center">
+          <p className="text-[12px] text-sidebar-fg opacity-60">
+            No projects yet.
+          </p>
+          <p className="text-[11px] text-sidebar-fg opacity-40">
+            Click below to add your first project.
+          </p>
+        </div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={ordered.map((p) => p.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {ordered.map((p) => (
+              <SidebarProjectRow key={p.id} project={p} />
+            ))}
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <button
+        type="button"
+        onClick={handleAddProject}
+        className="mx-1.5 mt-1 flex h-[26px] w-[calc(100%-12px)] items-center gap-1.5 rounded-md px-3 text-[12px] text-sidebar-fg opacity-70 hover:bg-sidebar-hover hover:opacity-100"
+      >
+        <span className="text-[13px] leading-none">+</span>
+        <span>New project</span>
+      </button>
+    </>
+  )
+}

--- a/src/components/Sidebar/sidebar.helpers.test.ts
+++ b/src/components/Sidebar/sidebar.helpers.test.ts
@@ -4,7 +4,7 @@ import { toRecentSidebarRows } from './sidebar.helpers'
 
 function row(over: Partial<SwitcherRow>): SwitcherRow {
   return {
-    tabKey: 'p1|t1',
+    tabKey: 'p1:t1',
     projectId: 'p1',
     projectName: 'my-app',
     tabId: 't1',
@@ -20,19 +20,19 @@ function row(over: Partial<SwitcherRow>): SwitcherRow {
 describe('toRecentSidebarRows', () => {
   test('keeps only rows with rank > 0 (visited tabs)', () => {
     const input = [
-      row({ tabKey: 'p1|t1', rank: 1 }),
-      row({ tabKey: 'p1|t2', rank: 2 }),
-      row({ tabKey: 'p2|t3', rank: 0 }), // never visited
+      row({ tabKey: 'p1:t1', rank: 1 }),
+      row({ tabKey: 'p1:t2', rank: 2 }),
+      row({ tabKey: 'p2:t3', rank: 0 }), // never visited
     ]
     const out = toRecentSidebarRows(input)
-    expect(out.map((r) => r.tabKey)).toEqual(['p1|t1', 'p1|t2'])
+    expect(out.map((r) => r.tabKey)).toEqual(['p1:t1', 'p1:t2'])
   })
 
   test('preserves the input order (which is recency order)', () => {
     const input = [
-      row({ tabKey: 'p1|zeta', label: 'zeta', rank: 1 }),
-      row({ tabKey: 'p1|alpha', label: 'alpha', rank: 2 }),
-      row({ tabKey: 'p1|middle', label: 'middle', rank: 3 }),
+      row({ tabKey: 'p1:zeta', label: 'zeta', rank: 1 }),
+      row({ tabKey: 'p1:alpha', label: 'alpha', rank: 2 }),
+      row({ tabKey: 'p1:middle', label: 'middle', rank: 3 }),
     ]
     const out = toRecentSidebarRows(input)
     expect(out.map((r) => r.label)).toEqual(['zeta', 'alpha', 'middle'])
@@ -60,8 +60,8 @@ describe('toRecentSidebarRows', () => {
 
   test('propagates isCurrent through', () => {
     const input = [
-      row({ tabKey: 'p1|t1', isCurrent: true }),
-      row({ tabKey: 'p1|t2', isCurrent: false }),
+      row({ tabKey: 'p1:t1', isCurrent: true }),
+      row({ tabKey: 'p1:t2', isCurrent: false }),
     ]
     const out = toRecentSidebarRows(input)
     expect(out[0]?.isCurrent).toBe(true)

--- a/src/components/Sidebar/sidebar.helpers.test.ts
+++ b/src/components/Sidebar/sidebar.helpers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test'
+import type { SwitcherRow } from '@/components/TabSwitcher/tab-switcher.helpers'
+import { toRecentSidebarRows } from './sidebar.helpers'
+
+function row(over: Partial<SwitcherRow>): SwitcherRow {
+  return {
+    tabKey: 'p1|t1',
+    projectId: 'p1',
+    projectName: 'my-app',
+    tabId: 't1',
+    label: 'dev',
+    cwd: undefined,
+    rank: 1,
+    lastActiveAt: 1000,
+    isCurrent: false,
+    ...over,
+  }
+}
+
+describe('toRecentSidebarRows', () => {
+  test('keeps only rows with rank > 0 (visited tabs)', () => {
+    const input = [
+      row({ tabKey: 'p1|t1', rank: 1 }),
+      row({ tabKey: 'p1|t2', rank: 2 }),
+      row({ tabKey: 'p2|t3', rank: 0 }), // never visited
+    ]
+    const out = toRecentSidebarRows(input)
+    expect(out.map((r) => r.tabKey)).toEqual(['p1|t1', 'p1|t2'])
+  })
+
+  test('preserves the input order (which is recency order)', () => {
+    const input = [
+      row({ tabKey: 'p1|zeta', label: 'zeta', rank: 1 }),
+      row({ tabKey: 'p1|alpha', label: 'alpha', rank: 2 }),
+      row({ tabKey: 'p1|middle', label: 'middle', rank: 3 }),
+    ]
+    const out = toRecentSidebarRows(input)
+    expect(out.map((r) => r.label)).toEqual(['zeta', 'alpha', 'middle'])
+  })
+
+  test('exposes projectName separately so the tooltip can render it', () => {
+    const input = [row({ projectName: 'my-app' })]
+    const out = toRecentSidebarRows(input)
+    expect(out[0]?.projectName).toBe('my-app')
+  })
+
+  test('drops rank, lastActiveAt, cwd from the row shape', () => {
+    const input = [row({ rank: 5, lastActiveAt: 12345, cwd: '/tmp/foo' })]
+    const out = toRecentSidebarRows(input)
+    // Row shape check: only these keys, no rank / lastActiveAt / cwd
+    expect(Object.keys(out[0] ?? {}).sort()).toEqual([
+      'isCurrent',
+      'label',
+      'projectId',
+      'projectName',
+      'tabId',
+      'tabKey',
+    ])
+  })
+
+  test('propagates isCurrent through', () => {
+    const input = [
+      row({ tabKey: 'p1|t1', isCurrent: true }),
+      row({ tabKey: 'p1|t2', isCurrent: false }),
+    ]
+    const out = toRecentSidebarRows(input)
+    expect(out[0]?.isCurrent).toBe(true)
+    expect(out[1]?.isCurrent).toBe(false)
+  })
+
+  test('empty input yields empty output', () => {
+    expect(toRecentSidebarRows([])).toEqual([])
+  })
+})

--- a/src/components/Sidebar/sidebar.helpers.ts
+++ b/src/components/Sidebar/sidebar.helpers.ts
@@ -1,0 +1,42 @@
+import type { SwitcherRow } from '@/components/TabSwitcher/tab-switcher.helpers'
+
+/**
+ * Row shape rendered by SidebarRecent. Deliberately narrower than
+ * `SwitcherRow`:
+ *   - `rank` and `lastActiveAt` are dropped, the sidebar does not
+ *     render rank digits or timestamps.
+ *   - `cwd` is dropped, the sidebar row is single-line label + TabChip.
+ *   - `projectName` is kept as a separate field so the hover Tooltip
+ *     can render it independently from the row body.
+ */
+export type SidebarRecentRow = {
+  tabKey: string
+  projectId: string
+  tabId: string
+  label: string
+  projectName: string
+  isCurrent: boolean
+}
+
+/**
+ * Trims the Cmd+P `SwitcherRow` output down to what the sidebar's
+ * Recent view actually renders.
+ *
+ * Also filters to `rank > 0`, only tabs the user has visited during
+ * the tracked window. Tabs the user has never touched clutter the
+ * Recent view (defeats its purpose as a "what was I just doing"
+ * surface). Cmd+P still shows every tab because search needs full
+ * coverage; the sidebar's Recent view has a different job.
+ */
+export function toRecentSidebarRows(rows: SwitcherRow[]): SidebarRecentRow[] {
+  return rows
+    .filter((row) => row.rank > 0)
+    .map((row) => ({
+      tabKey: row.tabKey,
+      projectId: row.projectId,
+      tabId: row.tabId,
+      label: row.label,
+      projectName: row.projectName,
+      isCurrent: row.isCurrent,
+    }))
+}

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -14,6 +14,7 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
 import { Pin, X } from 'lucide-react'
+import { SidebarRevealButton } from '@/components/Sidebar/SidebarRevealButton'
 import { TabChip } from '@/components/TabChip/TabChip'
 import {
   ContextMenu,
@@ -195,6 +196,11 @@ export function TabBar({ project }: { project: Project }) {
       className="flex h-[38px] shrink-0 items-end border-[var(--tab-border)] border-b bg-tab-bar px-2"
       style={{ gap: 2 }}
     >
+      {/* Sidebar reveal / hide toggle — always the leftmost affordance in
+          the TabBar so the user has one stable place to find it in both
+          visible and hidden states. Duplicated by ⌘B. */}
+      <SidebarRevealButton />
+
       {/* Tab strip — content-sized, capped so the add-button is never hidden.
           `shrink-0` keeps it at content width; max-w caps it when tabs overflow. */}
       <div

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -34,6 +34,7 @@ import {
   reorderTabs,
   toggleTabPin,
 } from '@/modules/stores/$projects'
+import { $sidebarVisible } from '@/modules/stores/$sidebarVisible'
 import { $tabMeta } from '@/modules/stores/$tabMeta'
 import {
   MONO_FONT,
@@ -171,6 +172,7 @@ export function TabBar({ project }: { project: Project }) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   )
+  const sidebarVisible = useStore($sidebarVisible)
 
   const orderedTabs = [
     ...project.tabs.filter((t) => t.pinned),
@@ -193,7 +195,14 @@ export function TabBar({ project }: { project: Project }) {
   return (
     <div
       data-tauri-drag-region
-      className="flex h-[38px] shrink-0 items-end border-[var(--tab-border)] border-b bg-tab-bar px-2"
+      className={cn(
+        'flex h-[38px] shrink-0 items-end border-[var(--tab-border)] border-b bg-tab-bar pr-2',
+        // Reserve the ~78px macOS traffic-light row when the TabBar is
+        // the window's top-left component (sidebar hidden). When the
+        // sidebar is visible, the sidebar owns that reservation via its
+        // own pl-[78px], so the TabBar starts at its natural left edge.
+        sidebarVisible ? 'pl-2' : 'pl-[80px]',
+      )}
       style={{ gap: 2 }}
     >
       {/* Sidebar reveal / hide toggle — always the leftmost affordance in

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,8 @@ import { startNotificationsBridge } from '@/modules/notifications/notificationsB
 import { syncNotificationsEnabledToBackend } from '@/modules/notifications/preferences'
 import { initNavigation } from '@/modules/stores/$navigation'
 import { $projects } from '@/modules/stores/$projects'
+import { initSidebarViewFromStorage } from '@/modules/stores/$sidebarView'
+import { initSidebarVisibleFromStorage } from '@/modules/stores/$sidebarVisible'
 import { initTabRecencySubscriber } from '@/modules/stores/$tabRecency.init'
 import { initThemeFromStorage } from '@/modules/stores/$theme'
 import { installMobileOpsListener } from '@/modules/wss-bridge/mobile-ops'
@@ -40,6 +42,8 @@ async function bootstrap() {
 
   initNavigation()
   initThemeFromStorage()
+  initSidebarVisibleFromStorage()
+  initSidebarViewFromStorage()
 
   // Recency tracker subscribes to navigation; must run after initNavigation
   // so the first bump captures the project/tab restored from disk.

--- a/src/modules/stores/$sidebarView.test.ts
+++ b/src/modules/stores/$sidebarView.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import {
+  $sidebarView,
+  initSidebarViewFromStorage,
+  setSidebarView,
+} from '@/modules/stores/$sidebarView'
+
+const KEY = 'agent-terminal:sidebar-view'
+
+function installLocalStorage() {
+  const store = new Map<string, string>()
+  ;(globalThis as typeof globalThis & { localStorage: Storage }).localStorage =
+    {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value)
+      },
+      removeItem: (key: string) => {
+        store.delete(key)
+      },
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    } as Storage
+  return store
+}
+
+describe('$sidebarView', () => {
+  let ls: Map<string, string>
+  beforeEach(() => {
+    ls = installLocalStorage()
+    $sidebarView.set('workspaces')
+  })
+
+  test('defaults to workspaces when nothing is stored', () => {
+    initSidebarViewFromStorage()
+    expect($sidebarView.get()).toBe('workspaces')
+  })
+
+  test('hydrates a stored recent value', () => {
+    ls.set(KEY, 'recent')
+    initSidebarViewFromStorage()
+    expect($sidebarView.get()).toBe('recent')
+  })
+
+  test('ignores a garbage stored value and leaves the atom untouched', () => {
+    ls.set(KEY, 'something-else')
+    $sidebarView.set('recent')
+    initSidebarViewFromStorage()
+    expect($sidebarView.get()).toBe('recent')
+  })
+
+  test('setSidebarView writes through to localStorage', () => {
+    setSidebarView('recent')
+    expect($sidebarView.get()).toBe('recent')
+    expect(ls.get(KEY)).toBe('recent')
+    setSidebarView('workspaces')
+    expect(ls.get(KEY)).toBe('workspaces')
+  })
+})

--- a/src/modules/stores/$sidebarView.ts
+++ b/src/modules/stores/$sidebarView.ts
@@ -1,0 +1,33 @@
+import { atom } from 'nanostores'
+
+/**
+ * Which view the sidebar is currently showing.
+ *
+ * - `workspaces`, the current project → tabs tree (default, matches
+ *   the pre-2026-07 sidebar).
+ * - `recent`, a flat, recency-sorted list of every tab across every
+ *   project. Reuses the Cmd+P data source so ordering is identical.
+ *
+ * Persisted to localStorage so the choice survives restarts.
+ */
+export type SidebarView = 'workspaces' | 'recent'
+
+const KEY = 'agent-terminal:sidebar-view'
+
+export const $sidebarView = atom<SidebarView>('workspaces')
+
+export function initSidebarViewFromStorage() {
+  try {
+    const v = localStorage.getItem(KEY)
+    if (v === 'workspaces' || v === 'recent') {
+      $sidebarView.set(v)
+    }
+  } catch {}
+}
+
+export function setSidebarView(view: SidebarView) {
+  try {
+    localStorage.setItem(KEY, view)
+  } catch {}
+  $sidebarView.set(view)
+}

--- a/src/modules/stores/$sidebarVisible.test.ts
+++ b/src/modules/stores/$sidebarVisible.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import {
+  $sidebarVisible,
+  initSidebarVisibleFromStorage,
+  setSidebarVisible,
+  toggleSidebarVisible,
+} from '@/modules/stores/$sidebarVisible'
+
+const KEY = 'agent-terminal:sidebar-visible'
+
+function installLocalStorage() {
+  const store = new Map<string, string>()
+  ;(globalThis as typeof globalThis & { localStorage: Storage }).localStorage =
+    {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value)
+      },
+      removeItem: (key: string) => {
+        store.delete(key)
+      },
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    } as Storage
+  return store
+}
+
+describe('$sidebarVisible', () => {
+  let ls: Map<string, string>
+  beforeEach(() => {
+    ls = installLocalStorage()
+    $sidebarVisible.set(true) // reset to default before each test
+  })
+
+  test('defaults to true when nothing is stored', () => {
+    initSidebarVisibleFromStorage()
+    expect($sidebarVisible.get()).toBe(true)
+  })
+
+  test('hydrates from a stored "false"', () => {
+    ls.set(KEY, 'false')
+    initSidebarVisibleFromStorage()
+    expect($sidebarVisible.get()).toBe(false)
+  })
+
+  test('hydrates from a stored "true"', () => {
+    ls.set(KEY, 'true')
+    $sidebarVisible.set(false)
+    initSidebarVisibleFromStorage()
+    expect($sidebarVisible.get()).toBe(true)
+  })
+
+  test('ignores a garbage stored value and leaves the atom untouched', () => {
+    ls.set(KEY, 'maybe')
+    $sidebarVisible.set(false)
+    initSidebarVisibleFromStorage()
+    expect($sidebarVisible.get()).toBe(false)
+  })
+
+  test('setSidebarVisible writes through to localStorage', () => {
+    setSidebarVisible(false)
+    expect($sidebarVisible.get()).toBe(false)
+    expect(ls.get(KEY)).toBe('false')
+    setSidebarVisible(true)
+    expect(ls.get(KEY)).toBe('true')
+  })
+
+  test('toggleSidebarVisible flips and persists both ways', () => {
+    $sidebarVisible.set(true)
+    toggleSidebarVisible()
+    expect($sidebarVisible.get()).toBe(false)
+    expect(ls.get(KEY)).toBe('false')
+    toggleSidebarVisible()
+    expect($sidebarVisible.get()).toBe(true)
+    expect(ls.get(KEY)).toBe('true')
+  })
+})

--- a/src/modules/stores/$sidebarVisible.ts
+++ b/src/modules/stores/$sidebarVisible.ts
@@ -1,0 +1,35 @@
+import { atom } from 'nanostores'
+
+/**
+ * Whether the sidebar is currently visible.
+ *
+ * Persisted to localStorage so the choice survives restarts. Toggled by
+ * the reveal button in the TabBar and by the global Cmd+B hotkey.
+ *
+ * Follows the persistence pattern established by `$theme`:
+ *   - `initSidebarVisibleFromStorage()` at app boot to hydrate.
+ *   - `setSidebarVisible()` / `toggleSidebarVisible()` write-through.
+ */
+const KEY = 'agent-terminal:sidebar-visible'
+
+export const $sidebarVisible = atom<boolean>(true)
+
+export function initSidebarVisibleFromStorage() {
+  try {
+    const v = localStorage.getItem(KEY)
+    if (v === 'true' || v === 'false') {
+      $sidebarVisible.set(v === 'true')
+    }
+  } catch {}
+}
+
+export function setSidebarVisible(visible: boolean) {
+  try {
+    localStorage.setItem(KEY, String(visible))
+  } catch {}
+  $sidebarVisible.set(visible)
+}
+
+export function toggleSidebarVisible() {
+  setSidebarVisible(!$sidebarVisible.get())
+}

--- a/src/screens/workspace/WorkspaceLayout.tsx
+++ b/src/screens/workspace/WorkspaceLayout.tsx
@@ -32,6 +32,7 @@ import {
   removeTab,
   restoreTabLabel,
 } from '@/modules/stores/$projects'
+import { toggleSidebarVisible } from '@/modules/stores/$sidebarVisible'
 import { useMetaHeldTracker } from '@/modules/stores/useMetaHeldTracker'
 import { useUpdaterWiring } from '@/modules/updater/useUpdaterWiring'
 import { WorkspaceView } from '@/screens/workspace/WorkspaceView'
@@ -208,6 +209,11 @@ export function WorkspaceLayout() {
     () => getActiveTerminalHandle()?.clear(),
     hotkeyOpts,
   )
+
+  // ⌘B — toggle sidebar visibility. Matches VS Code / Cursor / most
+  // editors' "toggle primary side bar" chord. Same handler as the
+  // reveal button in TabBar so both paths stay in sync.
+  useHotkeys(`${Mod.Meta}+${Keys.B}`, () => toggleSidebarVisible(), hotkeyOpts)
 
   // ⌘A — select all in the active terminal
   useHotkeys(


### PR DESCRIPTION
## Summary
- **Fully hide the sidebar.** New `$sidebarVisible` atom (persisted to `localStorage`) drives a hard hide, not a minified rail. Toggled by a reveal button in the tab chrome and by ⌘B. The reveal button is always the leftmost affordance in the TabBar so there's one stable place to bring the sidebar back in either state.
- **Segmented sidebar with a Recent view.** New `$sidebarView` atom (also persisted) swaps the sidebar body between two panels:
  - `Workspaces` — the existing project → tabs tree, extracted verbatim.
  - `Recent` — a flat, recency-sorted list across every project. Uses the same `buildSwitcherRows` data source as the ⌘P palette so ordering is identical. Rows show the plain tab label plus TabChip; hovering surfaces the workspace name via shadcn Tooltip. Never-visited tabs are filtered out so the view stays useful when the project tree gets noisy across many projects.
- Sidebar is refactored into a thin composer (`SidebarWorkspaces`, `SidebarRecent`, `SidebarViewToggle`, `SidebarRevealButton`) so each concern lives in its own file.

## Test plan
- [ ] ⌘B hides the sidebar; ⌘B shows it again.
- [ ] Reveal button in TabBar hides / shows the sidebar; icon flips between the two states.
- [ ] Sidebar-visible preference persists across reload.
- [ ] Segmented toggle in the sidebar header switches between Workspaces and Recent; choice persists across reload.
- [ ] Recent view lists most-recently-active tabs first, matching ⌘P ordering; only visited tabs appear.
- [ ] Hovering a Recent row shows the workspace name in a tooltip.
- [ ] Clicking a Recent row switches to that project + tab (unless it's already current).
- [ ] Hiding the sidebar reflows the workspace area to full width without layout jank.
- [ ] Type-check clean (`bun run typecheck`).
- [ ] Frontend lint clean (`biome check src/`).
- [ ] Unit tests pass (`bun test src/components/Sidebar src/modules/stores` — 91 pass, 10 new).