### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agent-terminal"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-terminal",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-terminal"
-version = "0.2.0"
+version = "0.3.0"
 description = "Agent Terminal — a mouse-first project-scoped terminal workspace"
 authors = ["DaniAkash"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agent Terminal",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.daniakash.agent-terminal",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Version bump 0.2.0 → 0.3.0 across the four release-tracked files (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock`), matching the pattern used for v0.2.0 in #98.

## Highlights since v0.2.0

**Desktop**
- Sidebar hide/show toggle (⌘B + reveal button in TabBar) with a new segmented Workspaces / Recent view inside the sidebar (#109)
- Recursive descendant walk for port detection: `bun dev` and friends spawned deep inside an agent subtree now surface in the status bar (#107)
- TabChip composite consolidates per-tab iconography (agent glyph + running dot + danger badge) into one component (#108)
- Agent registry Tier 1: Amp, Kilo, Kimi, Mastra join the built-ins (registry to 7 agents) (#104)

**Companion (mobile)**
- expo-router navigation chrome follows the system light/dark theme + companion palette (#106)
- System-theme following on the companion app (#105)
- WSS lifecycle + network resilience: reconnect backoff, foreground/background transitions, mDNS-aware resolver (#103)

**Fixes / infra**
- Biome cleanups on main: kilo hook style + AgentGlyph file-size cap (#110)

Full range: [v0.2.0...chore/release-v0.3.0](https://github.com/DaniAkash/agent-terminal/compare/v0.2.0...chore/release-v0.3.0)

## Cutting the release (after this PR merges)

Follows the recipe in `.github/workflows/release.yml`:

1. Merge this PR to main.
2. From latest main: `git tag v0.3.0 && git push origin main --tags`.
3. Wait ~15 min while the tag-triggered workflow builds both per-arch signed + notarized `.dmg`s and creates a DRAFT release.
4. Review + publish the draft from the [Releases page](https://github.com/DaniAkash/agent-terminal/releases).

## Test plan

- [ ] CI green on this PR
- [ ] After merge + tag push, the release workflow completes both matrix builds
- [ ] Draft release has both x86_64 and aarch64 `.dmg` assets attached
- [ ] `latest.json` updater manifest is included and correctly signed