### PR TITLE
chore(ci): add dependabot for bun apps + cargo workspace + github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,101 @@
+# Weekly dependency PRs across every package.json, the Cargo workspace, and
+# the GitHub Actions workflows. Major bumps are opt-in only via security
+# advisories; the routine queue is minor + patch grouped so it stays
+# actionable. A security update that requires a major bump still gets opened
+# by Dependabot: `ignore` rules do not apply to security updates.
+#
+# Directory coverage:
+#   bun            -> /, /companion, /website, /src-tauri/sidecar (4 apps)
+#   cargo          -> / (workspace root; picks up src-tauri + xtask)
+#   github-actions -> / (all workflows under .github/workflows/)
+
+version: 2
+
+updates:
+  # Bun-managed JavaScript apps: desktop frontend (Tauri React), companion
+  # (Expo React Native), website (marketing), and src-tauri/sidecar
+  # (headless xterm host). Shared cadence + ignore + group policy.
+  - package-ecosystem: "bun"
+    directories:
+      - "/"
+      - "/companion"
+      - "/website"
+      - "/src-tauri/sidecar"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+
+  # Cargo workspace: root Cargo.toml aggregates src-tauri + xtask. Dependabot
+  # walks the workspace natively so a single entry rooted at `/` is enough.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+
+  # GitHub Actions bumps for release.yml, ci.yml, tap-dispatch.yml. Lower PR
+  # cap since the surface area is small.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` covering every package manager the repo touches. Modeled on the BrowserOS config Dani pointed at, tuned for agent-terminal's four bun apps plus the Cargo workspace.

**Coverage**

| Ecosystem | Directories | PR cap | Commit prefix |
|---|---|---|---|
| `bun` | `/`, `/companion`, `/website`, `/src-tauri/sidecar` | 10 | `chore(deps)` |
| `cargo` | `/` (workspace root, includes `src-tauri` + `xtask`) | 10 | `chore(deps)` |
| `github-actions` | `/` (all `.github/workflows/*.yml`) | 5 | `chore(ci)` |

**Policy**

- Schedule: weekly, Monday 09:00 Asia/Kolkata.
- Cooldown: 3 days (a hot-fix release doesn't immediately drown the queue).
- Ignore: `version-update:semver-major` on `*`. Routine major bumps stay opt-in and manual; security advisories still open regardless.
- Grouping: `minor` + `patch` collapsed into one `minor-and-patch` PR per ecosystem per directory.
- Labels: `dependencies` on everything, plus `rust` on cargo PRs and `github-actions` on workflow PRs so filtering is one click.

## Notes / decisions

- **Cargo runs at the workspace root only.** Dependabot walks the workspace tree natively via the root `Cargo.toml` + `Cargo.lock`, so a single entry covers `src-tauri` and `xtask` without duplicate entries.
- **Bun uses `directories:` (plural) with 4 paths.** Keeps the policy in one place; each directory still produces its own grouped PR each week.
- **No per-package `ignore` pins yet.** BrowserOS pins `@ricky0123/vad-web` because 0.x patches are breaking. Nothing in agent-terminal currently has that shape (base-ui, tauri, expo, react all use semver majors for breaking changes, so the blanket major-ignore handles them). Easy to add later if a specific dep starts churning.
- **No dependabot config existed before this PR** so nothing is being replaced.

## Test plan

- [ ] PR CI passes (dependabot config is validated as part of the checkout / no build steps needed)
- [ ] After merge, `Dependabot` tab in repo settings shows the config parsed cleanly (no red "Config parsing error")
- [ ] Next Monday 09:00 IST, first wave of PRs opens against the branches above with the expected labels + prefixes