### PR TITLE
perf(ci): save-always on typeshare-cli cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,12 @@ jobs:
         with:
           path: ~/.cargo/bin/typeshare
           key: typeshare-cli-1.13.4-${{ runner.os }}
+          # Persist the cache even when a later step in this job fails.
+          # Without this, actions/cache's post-step no-ops on job failure,
+          # so any red run leaves the cache empty and the next run rebuilds
+          # typeshare-cli from source again (~90s). save-always keeps that
+          # from happening.
+          save-always: true
       - name: Install typeshare-cli
         if: ${{ !cancelled() }}
         run: |


### PR DESCRIPTION
## Summary

The typeshare-cli install cache was configured but never populated because \`actions/cache@v4\`'s post-step normally skips the save when any earlier step in the job fails. That means every red js-checks run left the cache empty and the next run rebuilt typeshare-cli from source (~90s of CI time). Recent failing runs on PRs #95, #115, and others hit exactly this loop.

\`save-always: true\` forces the post-step to save regardless of job outcome, so the cache stays populated across transient failures.

## Evidence

Job [30898592898](https://github.com/DaniAkash/agent-terminal/actions/runs/30898592898/job/91982421740?pr=95) on PR #95 shows:

\`\`\`
Cache not found for input keys: typeshare-cli-1.13.4-Linux
...
   Compiling typeshare-cli v1.13.4
    Finished \`release\` profile [optimized] target(s) in 47.39s
\`\`\`

47 seconds of compile + the earlier download/resolve makes the full install stretch to ~90s per run.

## Test plan

- [ ] First run after merge: cache miss (as expected), typeshare-cli builds from source, `save-always: true` saves the binary to the cache regardless of any other check outcome
- [ ] Second run: \`Cache restored successfully\` on the typeshare-cli step, install step is a no-op via the \`command -v typeshare\` guard