### PR TITLE
perf(ci): warm caches on main pushes + cache Tauri apt packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,12 @@ jobs:
         with:
           path: ~/.cargo/bin/typeshare
           key: typeshare-cli-1.13.4-${{ runner.os }}
+          # Persist the cache even when a later step in this job fails.
+          # Without this, actions/cache's post-step no-ops on job failure,
+          # so any red run leaves the cache empty and the next run rebuilds
+          # typeshare-cli from source again (~90s). save-always keeps that
+          # from happening.
+          save-always: true
       - name: Install typeshare-cli
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,9 @@
-# PR CI, gated behind manual approval.
+# PR CI, gated behind manual approval. Also runs on push to main so the
+# per-branch caches (Swatinem rust-cache, typeshare-cli, apt-pkgs) get
+# populated under `refs/heads/main`. GitHub Actions cache scope only lets
+# a PR restore caches from its own ref or its base branch, so without a
+# main cache every new PR pays the cold-compile cost on its first run
+# (~5 min of cargo check + test).
 #
 # One-time setup (otherwise the `approve` gate is a no-op):
 #   Repo Settings → Environments → New environment → name `ci-approval`
@@ -17,6 +22,11 @@ on:
     branches:
       - main
       - feat/desktop-sidecar-substrate
+  push:
+    # Cache-warming trigger only. Main pushes go through PR review already,
+    # so re-running the same checks is defensive, not a second gate.
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
@@ -28,6 +38,10 @@ permissions:
 
 jobs:
   approve:
+    # PR-only gate. On push to main, the merge itself is the review, so
+    # the approval step is skipped and downstream jobs run unconditionally
+    # via their `if:` guards.
+    if: github.event_name == 'pull_request'
     name: Wait for manual approval
     runs-on: ubuntu-latest
     environment: ci-approval
@@ -42,6 +56,10 @@ jobs:
   js-checks:
     name: JS / TypeScript
     needs: approve
+    # Runs when approve succeeds (PR path) or is skipped (push-to-main
+    # path). always() is required so the job evaluates its condition
+    # instead of inheriting `skipped` from a skipped dependency.
+    if: always() && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -147,6 +165,7 @@ jobs:
   rust-checks:
     name: Rust / Tauri
     needs: approve
+    if: always() && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -157,19 +176,27 @@ jobs:
       # tauri-runtime-wry's build script links against WebKitGTK during
       # dependency compilation — required even for `cargo check`, not just
       # build. Apt list mirrors Tauri 2's prerequisites doc.
+      #
+      # awalsh128/cache-apt-pkgs-action caches the installed .deb files
+      # (plus their transitive tree) under the given `version` key and
+      # replays them on cache hit. First cold run installs normally
+      # (~30s of apt-get update + download + dpkg). Subsequent runs
+      # restore from cache in ~2s. Bump `version` when the package list
+      # changes to force a fresh install.
       - name: Install Tauri Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            libwebkit2gtk-4.1-dev
+            build-essential
+            curl
+            wget
+            file
+            libxdo-dev
+            libssl-dev
+            libayatana-appindicator3-dev
             librsvg2-dev
+          version: 1.0
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -219,6 +246,7 @@ jobs:
   companion-checks:
     name: Companion (Expo)
     needs: approve
+    if: always() && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

Two changes to eliminate cold-cache PR runs. Direct follow-up to #118 (\`save-always\` on the typeshare cache): that fixed the cache from being lost, this fixes the cache from being empty in the first place.

## 1. Trigger CI on push to main

GitHub Actions cache scope only lets a PR restore caches from its own ref or its base branch. So a PR can only inherit a cache that main actually saved. Today main never runs the workflow (the trigger is \`pull_request\` only), which is why the repo has ~14 caches under \`refs/pull/*/merge\` but **zero** under \`refs/heads/main\`. Every new PR therefore pays ~5 min of cold cargo check + test on its first run.

This PR adds:

\`\`\`yaml
on:
  push:
    branches: [main]
\`\`\`

Every merge to main now runs the workflow, saves the rust-cache + typeshare binary + apt packages under \`refs/heads/main\`, and subsequent PRs restore from there.

The manual-approval gate stays PR-only via \`if: github.event_name == 'pull_request'\` on the approve job. Downstream jobs pick up on push via \`if: always() && (needs.approve.result == 'success' || == 'skipped')\`. \`always()\` is needed so the job evaluates its own condition instead of inheriting \`skipped\` from a skipped dependency.

## 2. Cache Tauri Linux apt packages

Swaps the raw \`sudo apt-get install\` for \`awalsh128/cache-apt-pkgs-action@v1\`. The action caches the .deb archives + the resolved transitive tree under the given \`version\` key and replays them on cache hit. Cold run still installs normally (~30s). Warm run restores in ~2s.

## Expected impact on cold-start PR CI

| Step | Before | After (warm cache) |
|---|---|---|
| Install Tauri Linux deps | 29s | ~2s |
| cargo check | 2m14s | ~5-10s |
| cargo test --lib | 2m40s | ~10-20s |
| typeshare-cli install | ~90s | ~2s |

**Rust/Tauri job total:** ~6 min → ~1 min on warm-cache PRs.

## Cost

One extra CI run per merge to main. Amortised across every new PR that then inherits the cache, this is a huge net win as long as PR volume > 0.

## Test plan

- [ ] After merge, next push to main triggers the workflow and Rust/Tauri runs to completion
- [ ] Main gets \`refs/heads/main\` caches for rust-cache, typeshare-cli, and apt-pkgs
- [ ] Next PR opened after that shows \`Cache restored successfully\` in each of the three cache steps
- [ ] Rust/Tauri job on that PR completes in ~1 min instead of ~6 min