### PR TITLE
revert(ci): raw apt-get install (awalsh128 action skipped -dev tree)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,26 +177,26 @@ jobs:
       # dependency compilation — required even for `cargo check`, not just
       # build. Apt list mirrors Tauri 2's prerequisites doc.
       #
-      # awalsh128/cache-apt-pkgs-action caches the installed .deb files
-      # (plus their transitive tree) under the given `version` key and
-      # replays them on cache hit. First cold run installs normally
-      # (~30s of apt-get update + download + dpkg). Subsequent runs
-      # restore from cache in ~2s. Bump `version` when the package list
-      # changes to force a fresh install.
+      # NOTE: previously wrapped in awalsh128/cache-apt-pkgs-action to cut
+      # ~29s of install time, but that action installs the listed packages
+      # without their transitive -dev tree, so libwebkit2gtk-4.1-dev landed
+      # without libglib2.0-dev and glib-sys build.rs failed the whole
+      # Rust/Tauri job with pkg-config errors. Reverted to raw apt-get. If
+      # apt caching is revisited, either enumerate every -dev dep by hand
+      # or move to a Docker image with the deps pre-installed.
       - name: Install Tauri Linux dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: >-
-            libwebkit2gtk-4.1-dev
-            build-essential
-            curl
-            wget
-            file
-            libxdo-dev
-            libssl-dev
-            libayatana-appindicator3-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
             librsvg2-dev
-          version: 1.0
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## What broke

First main-triggered CI run after #119 failed on Rust/Tauri: [run 30907719475](https://github.com/DaniAkash/agent-terminal/actions/runs/30907719475).

\`\`\`
Package glib-2.0 was not found in the pkg-config search path.
The system library \`glib-2.0\` required by crate \`glib-sys\` was not found.
\`\`\`

## Why

\`awalsh128/cache-apt-pkgs-action\` installs the packages listed in \`packages:\` but does not reliably pull their transitive \`-dev\` tree. \`libwebkit2gtk-4.1-dev\` landed without \`libglib2.0-dev\`, so any crate that pkg-configs against glib (glib-sys, gobject-sys, everything downstream) failed the whole job. Raw \`apt-get install libwebkit2gtk-4.1-dev\` pulls the -dev tree transparently, so reverting only this step restores the previous behaviour.

## What's kept from #119

The two changes that matter stay:

- \`push: [main]\` trigger — main now runs the workflow on merge and populates \`refs/heads/main\` caches for future PRs
- PR-only approval gate + \`if: always() && (needs.approve.result == 'success' || == 'skipped')\` guards on downstream jobs

Those are the actual big win. The apt cache attempt was the \~29s cherry on top and turned out to be a regression.

## Follow-up if apt caching is revisited

Two viable paths:
1. Enumerate every -dev dep by hand under the action's \`packages:\` list (fragile, brittle across Ubuntu image refreshes)
2. Move to a Docker container image with the deps pre-installed (bigger lift, robust)

Not doing either now.

## Test plan

- [ ] Merging this triggers a main CI run
- [ ] Rust/Tauri completes successfully this time
- [ ] Post-run cache list shows a fresh \`v0-rust-rust-checks-Linux-x64-*\` under \`refs/heads/main\`
- [ ] Next unrelated PR opened after that shows \`Cache restored\` and a fast Rust/Tauri job (~1 min)