### PR TITLE
perf: share cargo build intermediates across worktrees + pin rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
     timeout-minutes: 30
     env:
       RUST_BACKTRACE: '1'
+      # apps/desktop/.cargo/config.toml points build-dir at a shared
+      # location so local worktrees stop each carrying their own copy of
+      # the dependency graph. A runner is a single ephemeral checkout, so
+      # it gains nothing from that and would instead split intermediates
+      # out of target/, which is the only thing rust-cache below caches
+      # and prunes. Overriding back to target/ keeps CI on the layout
+      # rust-cache expects.
+      CARGO_BUILD_BUILD_DIR: ${{ github.workspace }}/apps/desktop/target
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,12 @@ jobs:
         with:
           bun-version: latest
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned rather than @stable: rust-cache hashes every toolchain the
+      # runner reports into its cache key, so a floating toolchain makes
+      # the key drift whenever the runner image or upstream stable moves,
+      # and every drift is a cold rebuild of the whole dependency graph.
+      # Bump deliberately, same as any other dependency.
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
 
@@ -109,6 +114,24 @@ jobs:
           # under GitHub's 10 GB per-repo cap) but cargo clippy drops to
           # ~10-20s on hit.
           cache-all-crates: true
+          # Pin the toolchain that feeds the cache key.
+          #
+          # rust-cache derives part of its key from `rustup toolchain
+          # list`, which reports every toolchain on the runner, not just
+          # the one this job uses. That set changes as GitHub rolls new
+          # runner images, so identical workflow config can hash to a
+          # different key depending on which image a job lands on, and a
+          # warm cache becomes a coin flip. Pinning the toolchain (see the
+          # dtolnay/rust-toolchain step above) keeps that set stable.
+          #
+          # `add-rust-environment-hash-key: false` looks like the direct
+          # fix and is what upstream BrowserOS went with, but on
+          # rust-cache@v2 that one flag gates BOTH the environment hash
+          # AND the Cargo.lock / Cargo.toml hash (src/config.ts:155-261).
+          # Disabling it yields a key with no lockfile component, so a
+          # dependency bump would silently restore a stale cache. Their
+          # live keys show exactly that shape. Not worth the correctness
+          # hole for a cache hit.
 
       - name: Cache typeshare-cli install
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,13 @@ jobs:
     needs: [changelog]
     runs-on: macos-15
     timeout-minutes: 90
+    env:
+      # apps/desktop/.cargo/config.toml moves intermediates to a shared
+      # dir so local worktrees share one copy. A release runner is a
+      # single ephemeral checkout, and the cache step below plus every
+      # bundle path in this workflow are written against target/, so
+      # override back to the default layout here.
+      CARGO_BUILD_BUILD_DIR: ${{ github.workspace }}/apps/desktop/target
     strategy:
       fail-fast: false
       matrix:

--- a/apps/desktop/.cargo/config.toml
+++ b/apps/desktop/.cargo/config.toml
@@ -6,3 +6,32 @@
 # project-level scripts (codegen, deploy hooks, release automation, etc.).
 [alias]
 xtask = "run --package xtask --"
+
+[build]
+# Keep intermediate artifacts out of the checkout so every worktree on this
+# machine shares one copy instead of each carrying its own.
+#
+# Measured on this workspace: a full target/ is ~3.7G, of which ~781M is the
+# final artifacts and the rest is the dependency graph. With build-dir the
+# graph is written once and each worktree keeps only its 781M, so N worktrees
+# cost 3.7G + N*781M rather than N*3.7G. At three worktrees that is 6.0G
+# instead of 11.1G; at eight, 9.9G instead of 29.6G.
+#
+# Cross-worktree reuse is real, not just a disk trick: a second worktree
+# building against a warm shared dir compiles 1 crate rather than 381, and
+# alternating between worktrees stays at 1 (only the leaf crate, whose path
+# differs, is refingerprinted).
+#
+# {cargo-cache-home} expands to CARGO_HOME. Cargo expands neither ~ nor $HOME
+# and target-dir has no templating, so build-dir is the only form that can be
+# committed and still resolve per-machine.
+#
+# NOTE: cargo finds this file by walking up from the *current directory*, not
+# from --manifest-path. Every cargo invocation in package.json therefore cds
+# into apps/desktop first; a `--manifest-path` call from the repo root would
+# silently skip this file and rebuild the whole graph into its own target/.
+#
+# CI sets CARGO_BUILD_BUILD_DIR to override this back to target/, since a
+# runner is a single ephemeral checkout that gains nothing from sharing, and
+# Swatinem/rust-cache already caches and prunes target/ for us.
+build-dir = "{cargo-cache-home}/build/agent-terminal"

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "check:desktop:tsc": "bun run --filter @agent-terminal/desktop typecheck",
     "check:desktop:test": "bun test apps/desktop/src",
     "check:sidecar:test": "cd apps/desktop/src-tauri/sidecar && bun test",
-    "check:rust:clippy": "cargo clippy --manifest-path apps/desktop/Cargo.toml --all-targets",
-    "check:rust:test": "cargo test --manifest-path apps/desktop/Cargo.toml --all-targets --no-fail-fast -- --test-threads=1",
+    "check:rust:clippy": "cd apps/desktop && cargo clippy --all-targets",
+    "check:rust:test": "cd apps/desktop && cargo test --all-targets --no-fail-fast -- --test-threads=1",
     "check:tauri:build": "cd apps/desktop && bunx tauri build --no-bundle --debug",
     "check:companion": "bun run --filter companion check",
     "check:drift": "cd apps/desktop && cargo xtask regen-protocol && cd ../.. && git diff --exit-code -- apps/companion/src/modules/wss/protocol.gen.ts",
-    "check:fix": "biome check --write --unsafe && cargo clippy --manifest-path apps/desktop/Cargo.toml --all-targets --fix --allow-dirty --allow-staged"
+    "check:fix": "biome check --write --unsafe && cd apps/desktop && cargo clippy --all-targets --fix --allow-dirty --allow-staged"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",


### PR DESCRIPTION
Ports both BrowserOS [#2446](https://github.com/browseros-ai/BrowserOS/pull/2446) and [#2448](https://github.com/browseros-ai/BrowserOS/pull/2448), adapted where this repo's setup differs. Two commits, independently reviewable.

---

## 1. Share cargo build intermediates (`bc446ae`)

Ports #2446's `build-dir` change. The driver here is **local disk**, not build speed.

A full `target/` on this workspace is ~3.7G, of which ~781M is final artifacts and the rest is the compiled dependency graph. Every worktree carried its own copy:

```
4.2G  agent-terminal (main)
5.2G  worktrees/chore/monorepo-phase-2
5.6G  worktrees/perf/rust-cache-optimizations
```

`build-dir` writes the graph once to `{cargo-cache-home}/build` and leaves final artifacts in `target/`, so N worktrees cost `3.7G + N×781M` instead of `N×3.7G`:

| worktrees | before | after | saved |
|---:|---:|---:|---:|
| 2 | 7.4G | 5.3G | 2.1G |
| 3 | 11.1G | 6.0G | 5.1G |
| 5 | 18.5G | 7.6G | 10.9G |
| 8 | 29.6G | 9.9G | 19.7G |

Cross-worktree reuse is real, not only a disk trick. Measured: a second worktree building against a warm shared dir compiles **1 crate rather than 381**, and alternating between worktrees stays at 1 (only the leaf crate, whose absolute path differs, is refingerprinted).

### Two things this required

**Scripts must `cd`, not `--manifest-path`.** Cargo resolves `.cargo/config.toml` by walking up from the *current directory*, not from `--manifest-path`. `check:rust:clippy` and `check:rust:test` passed `--manifest-path` from the repo root, so they would have silently skipped the config and rebuilt the whole graph into their own `target/` — the change would have looked applied while doing nothing. Both now `cd apps/desktop` first, matching `check:tauri:build` and `check:drift` which already did.

**CI overrides it back off.** A runner is a single ephemeral checkout, so it gains nothing from sharing, and leaving `build-dir` active would move intermediates out of `target/` — the only path `Swatinem/rust-cache` caches and prunes — turning every CI run into a cold rebuild. Both workflows set `CARGO_BUILD_BUILD_DIR` back to `target/`.

Caching the shared dir instead (what #2446 does, via `cache-directories`) was the alternative. Rejected: rust-cache never prunes extra `cache-directories` entries, so it grows unbounded. That is what put BrowserOS at 10.35G against a 10G allowance and forced their `rust-cache-bust.yml`. We are at 2.97G and this keeps it there.

### Verified

| | local (no env) | CI-simulated (env set) |
|---|---|---|
| `target/` after clippy | 4.0K | 982M, contains `deps`/`build`/`incremental` |
| shared dir | 4.4G | unchanged |

---

## 2. Pin the rust toolchain (`eb9a5b8`)

This is #2448's *goal*, reached by a different mechanism.

`rust-cache` derives part of its key from `rustup toolchain list`, which reports **every** toolchain on the runner, not only the one the job installs. Runner images ship their own Rust, and that set changes as images roll out, so identical config hashes differently depending on which image a job lands on. Each drift is a cold rebuild.

Pinning `dtolnay/rust-toolchain@stable` → `@1.95.0` stabilises that input.

### Why not `add-rust-environment-hash-key: false`

That is what #2448 does, and it is the more direct-looking fix. Its stated reasoning is *"the lockfile hash still keys the cache, so dependency changes bust it."*

That is not what the flag does on `rust-cache@v2`. One flag gates two separate hashes in `src/config.ts`:

| Lines | Guarded by the flag |
|---|---|
| 128-131 | environment hash (the toolchain drift) |
| 155-261 | **`Cargo.lock` + `Cargo.toml` + `.cargo/config.toml` hash** |

Disabling it drops both. Confirmed against BrowserOS's own live caches after #2448 merged:

```
v0-rust-browseros-agent-Linux-x64          ← no lockfile segment
```

Ours today, for contrast:

```
v0-rust-check-Linux-x64-0bc21b0f-47291b26
                        ^^^^^^^^ env  ^^^^^^^^ lockfile
```

So on their side a dependency bump now restores a stale cache rather than busting it. Worth reporting upstream. Pinning the toolchain stabilises the first segment while keeping the second.

`release.yml` stays on `@stable`: release builds are infrequent and want a fresh compile anyway, so there is no caching payoff to offset the pin's maintenance cost.

---

## Not ported from #2446

- **The warm-cache job** — solves `test.yml` being `pull_request`-only, so `main` never populated a cache PRs could inherit. Our `ci.yml` already runs on `push: [main]` (added in #119).
- **`shared-key`** — needed there because the warm job and test job had different `GITHUB_JOB` names. We have one `check` job.
- **`rust-cache-bust.yml`** — only necessary because they cache the shared build dir. We override it off in CI instead, so nothing accumulates.

## Verified

`bun run check` fully green across all 9: biome, desktop:tsc, desktop:test, sidecar:test, rust:clippy, rust:test, tauri:build, companion (7 sub-checks), drift.

## Test plan

- [ ] CI `Check` job passes
- [ ] Cache key retains both env and lockfile segments
- [ ] CI `target/` contains `deps/` (override active, rust-cache sees intermediates)
- [ ] Locally, a fresh worktree builds against the shared dir rather than cold