### PR TITLE
fix(release): pin the tauri build runner instead of detecting it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,22 @@ jobs:
           # projectPath. Cargo output lands at <projectPath>/target/ from
           # here because Cargo.toml also lives at apps/desktop/.
           projectPath: apps/desktop
+          # Pin the build runner instead of letting tauri-action detect it.
+          #
+          # Detection picks a package manager by walking up from projectPath
+          # looking for a lockfile, then runs `<pm> run tauri`. In this
+          # monorepo the only lockfile is the root bun.lock while projectPath
+          # is apps/desktop, and the v0 action resolved that to npm and ran
+          # `npm run tauri build`, which fails because apps/desktop has no
+          # `tauri` script:
+          #
+          #   npm error Missing script: "tauri"
+          #   npm error workspace @agent-terminal/desktop
+          #
+          # Setting tauriScript skips detection entirely and runs exactly
+          # this command, which is also what `bun run tauri:build` does
+          # locally, so CI and laptop agree.
+          tauriScript: bunx tauri
           args: --target ${{ matrix.target }}
 
       - name: Add stable-named DMG copies

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "apps/desktop": {
       "name": "@agent-terminal/desktop",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
The v0.3.1 release build failed on both arches. Despite surfacing next to the signing env block, it is not a signing failure:

```
npm error Missing script: "tauri"
npm error workspace @agent-terminal/desktop@0.3.1
npm error location /Users/runner/work/agent-terminal/agent-terminal/apps/desktop
Command "npm ["run","tauri","build","--","--target","x86_64-apple-darwin"]" failed with exit code 1
```

It never reached signing. [Failed run](https://github.com/DaniAkash/agent-terminal/actions/runs/33514096665)

## Cause

`tauri-action` chooses a package manager by walking up from `projectPath` for a lockfile, then runs `<pm> run tauri` (`src/runner.ts`, `getRunner`).

Before the monorepo migration, `projectPath` defaulted to the repo root where `bun.lock` lives, so it selected **bun** — and `bun tauri` runs the binary directly without needing a matching npm script. That is why v0.3.0 shipped fine.

The migration set `projectPath: apps/desktop`, which has no lockfile of its own because the workspace deliberately keeps a single one at the root. The pinned `@v0` action resolved that to **npm** and ran `npm run tauri build`. `apps/desktop/package.json` has no `tauri` script, so it aborted immediately.

This was latent in the migration and could only surface on a real tag, since `release.yml` runs on nothing else.

## Fix

```yaml
tauriScript: bunx tauri
```

`tauriScript` skips detection entirely ("`tauriScript` set. Skipping cli verification.") and runs the command verbatim, so the build no longer depends on where lockfiles happen to sit.

It is also the exact invocation the local script already uses:

| | command |
|---|---|
| local `bun run tauri:build` | `cd apps/desktop && bunx tauri build` |
| CI after this change | `bunx tauri build --target <triple>` (cwd `apps/desktop`) |

So CI and a laptop now run identical commands instead of two paths that can drift.

### Why not add a `tauri` script to apps/desktop/package.json

That would also have worked, and was the smaller diff. Rejected because it leaves the build dependent on lockfile placement: if a lockfile ever appears in `apps/desktop`, or the root one moves, detection silently switches package manager again and the failure mode returns in a different shape. Pinning the runner removes the variable rather than satisfying it.

## Verified

- `bunx tauri --version` from `apps/desktop` resolves to `tauri-cli 2.11.4`
- `bunx tauri build --help` accepts `-t, --target <TARGET>`
- `bun run check` green across all nine

## Test plan

- [ ] CI green
- [ ] After merge, delete and re-push the `v0.3.1` tag to retrigger the release
- [ ] Build reaches signing and notarization on both arches
- [ ] Draft carries all six assets at their existing basenames, plus `latest.json`
- [ ] `latest.json` publishes to `release-manifest` with an unchanged schema

## Note

The v0.3.1 tag already exists and points at a commit without this fix. It will need deleting and re-pushing after merge, since the release workflow only fires on tag push.