### PR TITLE
fix(agent-state): stop Claude's settled OSC title vetoing the working state

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agent-terminal"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-terminal/desktop",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-terminal"
-version = "0.3.1"
+version = "0.3.2"
 description = "Agent Terminal — a mouse-first project-scoped terminal workspace"
 authors = ["DaniAkash"]
 edition = "2021"

--- a/apps/desktop/src-tauri/src/agents/amp.rs
+++ b/apps/desktop/src-tauri/src/agents/amp.rs
@@ -27,6 +27,7 @@ pub static PROFILE: AgentProfile = AgentProfile {
     runtime_wrapped: true,
     hook: None,
     osc: Some(state_from_osc),
+    interrupt_ends_turn: false,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/agents/claude_code.rs
+++ b/apps/desktop/src-tauri/src/agents/claude_code.rs
@@ -68,6 +68,7 @@ pub static PROFILE: AgentProfile = AgentProfile {
         timeout_ms: 10_000,
     }),
     osc: Some(state_from_osc),
+    interrupt_ends_turn: true,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/agents/claude_code.rs
+++ b/apps/desktop/src-tauri/src/agents/claude_code.rs
@@ -10,7 +10,15 @@ use super::{is_braille, AgentProfile, EventRole, HookEvent, HookInstall, HookSpe
 /// facts re-implemented fresh):
 /// - a Braille-prefixed title is the animated spinner → Working,
 /// - OSC 9 progress `4;0;` is Claude's explicit idle marker → Idle,
-/// - any other settled (non-Braille) title means the prompt is showing → Idle.
+/// - anything else → no opinion.
+///
+/// Both positive signals are absent from Claude 2.x, which paints one static
+/// title for the life of the session and emits no OSC 9 at all. A settled title
+/// therefore carries no liveness information, so this returns None rather than
+/// inferring Idle from it. Inferring Idle made the fused state machine stale
+/// every hook-reported Working back to Idle after OSC_STALE, which suppressed
+/// the in-progress badge for every Claude tab. The two positive branches stay
+/// so the detector self-heals if either signal returns.
 ///
 /// Claude does not surface "blocked" via OSC; that comes from the hook channel.
 fn state_from_osc(view: &OscView) -> Option<OscState> {
@@ -19,9 +27,6 @@ fn state_from_osc(view: &OscView) -> Option<OscState> {
         return Some(OscState::Working);
     }
     if view.progress.starts_with("4;0;") {
-        return Some(OscState::Idle);
-    }
-    if first.is_some() {
         return Some(OscState::Idle);
     }
     None
@@ -127,10 +132,12 @@ mod tests {
     }
 
     #[test]
-    fn settled_title_is_idle() {
-        // U+2733 static glyph (not Braille) → prompt showing.
-        assert_eq!(state_from_osc(&view("\u{2733} Claude", "")), Some(OscState::Idle));
-        assert_eq!(state_from_osc(&view("~/project", "")), Some(OscState::Idle));
+    fn settled_title_yields_no_opinion() {
+        // "✳ Claude Code" (U+2733, not Braille) is the only title Claude 2.x
+        // ever sets, and it never changes. Reading Idle out of it vetoed the
+        // hook channel's Working state and hid the in-progress badge outright.
+        assert_eq!(state_from_osc(&view("\u{2733} Claude Code", "")), None);
+        assert_eq!(state_from_osc(&view("~/project", "")), None);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/agents/claude_code.rs
+++ b/apps/desktop/src-tauri/src/agents/claude_code.rs
@@ -34,7 +34,7 @@ fn state_from_osc(view: &OscView) -> Option<OscState> {
 
 static EVENTS: &[HookEvent] = &[
     HookEvent { name: "SessionStart", role: EventRole::SessionStart },
-    HookEvent { name: "UserPromptSubmit", role: EventRole::Working },
+    HookEvent { name: "UserPromptSubmit", role: EventRole::TurnStart },
     // PreToolUse is Working, except tool_name == "AskUserQuestion", which the
     // engine intercepts to stash the question text (see EventRole docs).
     HookEvent { name: "PreToolUse", role: EventRole::Working },
@@ -46,7 +46,6 @@ static EVENTS: &[HookEvent] = &[
     HookEvent { name: "PostToolUseFailure", role: EventRole::Working },
     // A subagent finishing returns control to the parent, which is still
     // working. Without this the parent can look idle mid-turn.
-    HookEvent { name: "SubagentStop", role: EventRole::Working },
     // Two blocked signals on purpose. PermissionRequest is what current
     // builds emit when a prompt is waiting; Notification is the older
     // spelling. Both are registered so the badge is correct across
@@ -91,11 +90,10 @@ mod tests {
             got,
             vec![
                 ("SessionStart", EventRole::SessionStart),
-                ("UserPromptSubmit", EventRole::Working),
+                ("UserPromptSubmit", EventRole::TurnStart),
                 ("PreToolUse", EventRole::Working),
                 ("PostToolUse", EventRole::Working),
                 ("PostToolUseFailure", EventRole::Working),
-                ("SubagentStop", EventRole::Working),
                 ("PermissionRequest", EventRole::Blocked),
                 ("Notification", EventRole::Blocked),
                 ("Stop", EventRole::Completed),

--- a/apps/desktop/src-tauri/src/agents/codex.rs
+++ b/apps/desktop/src-tauri/src/agents/codex.rs
@@ -44,6 +44,7 @@ pub static PROFILE: AgentProfile = AgentProfile {
         timeout_ms: 5_000,
     }),
     osc: Some(state_from_osc),
+    interrupt_ends_turn: false,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/agents/codex.rs
+++ b/apps/desktop/src-tauri/src/agents/codex.rs
@@ -28,7 +28,7 @@ fn state_from_osc(view: &OscView) -> Option<OscState> {
 
 static EVENTS: &[HookEvent] = &[
     HookEvent { name: "SessionStart", role: EventRole::SessionStart },
-    HookEvent { name: "UserPromptSubmit", role: EventRole::Working },
+    HookEvent { name: "UserPromptSubmit", role: EventRole::TurnStart },
     HookEvent { name: "PermissionRequest", role: EventRole::Blocked },
     HookEvent { name: "Stop", role: EventRole::Completed },
 ];

--- a/apps/desktop/src-tauri/src/agents/kilo.rs
+++ b/apps/desktop/src-tauri/src/agents/kilo.rs
@@ -28,4 +28,5 @@ pub static PROFILE: AgentProfile = AgentProfile {
         timeout_ms: 0,
     }),
     osc: None,
+    interrupt_ends_turn: false,
 };

--- a/apps/desktop/src-tauri/src/agents/kilo.rs
+++ b/apps/desktop/src-tauri/src/agents/kilo.rs
@@ -8,7 +8,7 @@ use super::{AgentProfile, EventRole, HookEvent, HookInstall, HookSpec};
 
 static EVENTS: &[HookEvent] = &[
     HookEvent { name: "session_start", role: EventRole::SessionStart },
-    HookEvent { name: "working", role: EventRole::Working },
+    HookEvent { name: "working", role: EventRole::TurnStart },
     HookEvent { name: "blocked", role: EventRole::Blocked },
     HookEvent { name: "turn_end", role: EventRole::Completed },
 ];

--- a/apps/desktop/src-tauri/src/agents/kimi.rs
+++ b/apps/desktop/src-tauri/src/agents/kimi.rs
@@ -45,4 +45,5 @@ pub static PROFILE: AgentProfile = AgentProfile {
         timeout_ms: 10_000,
     }),
     osc: None,
+    interrupt_ends_turn: false,
 };

--- a/apps/desktop/src-tauri/src/agents/kimi.rs
+++ b/apps/desktop/src-tauri/src/agents/kimi.rs
@@ -11,7 +11,7 @@ use super::{AgentProfile, EventRole, HookEvent, HookInstall, HookSpec};
 /// Actions the hook script posts, mapped to state-engine roles.
 static EVENTS: &[HookEvent] = &[
     HookEvent { name: "session", role: EventRole::SessionStart },
-    HookEvent { name: "working", role: EventRole::Working },
+    HookEvent { name: "working", role: EventRole::TurnStart },
     HookEvent { name: "blocked", role: EventRole::Blocked },
     HookEvent { name: "idle", role: EventRole::Idle },
 ];

--- a/apps/desktop/src-tauri/src/agents/mastracode.rs
+++ b/apps/desktop/src-tauri/src/agents/mastracode.rs
@@ -48,4 +48,5 @@ pub static PROFILE: AgentProfile = AgentProfile {
         timeout_ms: 10_000,
     }),
     osc: None,
+    interrupt_ends_turn: false,
 };

--- a/apps/desktop/src-tauri/src/agents/mastracode.rs
+++ b/apps/desktop/src-tauri/src/agents/mastracode.rs
@@ -11,7 +11,7 @@ use super::{AgentProfile, EventRole, HookEvent, HookInstall, HookSpec};
 /// Actions the hook script posts, mapped to state-engine roles.
 static EVENTS: &[HookEvent] = &[
     HookEvent { name: "idle", role: EventRole::Idle },
-    HookEvent { name: "working", role: EventRole::Working },
+    HookEvent { name: "working", role: EventRole::TurnStart },
     HookEvent { name: "blocked", role: EventRole::Blocked },
     HookEvent { name: "release", role: EventRole::SessionEnd },
 ];

--- a/apps/desktop/src-tauri/src/agents/mod.rs
+++ b/apps/desktop/src-tauri/src/agents/mod.rs
@@ -60,6 +60,13 @@ pub(crate) fn is_braille(c: char) -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventRole {
     SessionStart,
+    /// Opens a turn. Always moves the tab to working, including out of
+    /// `Completed`, since a new turn supersedes the previous one's result.
+    TurnStart,
+    /// Mid-turn progress. Re-asserts working, but must never resurrect a turn
+    /// that already reported `Completed`: agents can emit trailing progress
+    /// events after their stop event, and honouring those repainted a finished
+    /// tab as busy underneath its own completion tick.
     Working,
     Blocked,
     /// Return to the idle baseline without ending the session. Used by agents

--- a/apps/desktop/src-tauri/src/agents/mod.rs
+++ b/apps/desktop/src-tauri/src/agents/mod.rs
@@ -137,6 +137,11 @@ pub struct AgentProfile {
     /// OSC title/progress signature, if the agent emits state via OSC. `None`
     /// for agents that do not (opencode).
     pub osc: Option<fn(&OscView) -> Option<OscState>>,
+    /// True if a lone ESC or Ctrl-C ends the current turn without the agent
+    /// firing its completion event, making the keypress the only signal that
+    /// the turn is over. Opt-in per agent: an agent that does report its own
+    /// cancellation must stay `false` so its hook stays the sole authority.
+    pub interrupt_ends_turn: bool,
 }
 
 impl AgentProfile {

--- a/apps/desktop/src-tauri/src/agents/opencode.rs
+++ b/apps/desktop/src-tauri/src/agents/opencode.rs
@@ -9,7 +9,7 @@ use super::{AgentProfile, EventRole, HookEvent, HookInstall, HookSpec};
 
 static EVENTS: &[HookEvent] = &[
     HookEvent { name: "session_start", role: EventRole::SessionStart },
-    HookEvent { name: "working", role: EventRole::Working },
+    HookEvent { name: "working", role: EventRole::TurnStart },
     HookEvent { name: "blocked", role: EventRole::Blocked },
     HookEvent { name: "turn_end", role: EventRole::Completed },
 ];

--- a/apps/desktop/src-tauri/src/agents/opencode.rs
+++ b/apps/desktop/src-tauri/src/agents/opencode.rs
@@ -29,4 +29,5 @@ pub static PROFILE: AgentProfile = AgentProfile {
         timeout_ms: 0,
     }),
     osc: None,
+    interrupt_ends_turn: false,
 };

--- a/apps/desktop/src-tauri/src/hook_config.rs
+++ b/apps/desktop/src-tauri/src/hook_config.rs
@@ -887,7 +887,7 @@ mod tests {
 
         let v = read_json(&config_path);
         let hooks = v["hooks"].as_object().unwrap();
-        assert_eq!(hooks.len(), 10, "should have exactly 10 event keys");
+        assert_eq!(hooks.len(), 9, "should have exactly 9 event keys");
 
         let expected = [
             "SessionStart",
@@ -895,7 +895,6 @@ mod tests {
             "PreToolUse",
             "PostToolUse",
             "PostToolUseFailure",
-            "SubagentStop",
             "PermissionRequest",
             "Notification",
             "Stop",

--- a/apps/desktop/src-tauri/src/mod_engine/mods/agent_state.rs
+++ b/apps/desktop/src-tauri/src/mod_engine/mods/agent_state.rs
@@ -488,6 +488,19 @@ impl Mod for AgentStateMod {
                 st.prompt_returned = false;
                 st.hook_state = AgentState::Idle;
             }
+            EventRole::TurnStart => {
+                st.proc_alive = true;
+                st.prompt_returned = false;
+                st.pending_question = None;
+                st.completed_message = None;
+                st.hook_state = AgentState::Working;
+            }
+            // Trailing progress after a turn reported Completed is stale: the
+            // agent can emit it late (Claude fires SubagentStop seconds after
+            // Stop, and hook delivery is not ordered). Honouring it repainted a
+            // finished tab as busy while its completion tick was still showing.
+            // Only a TurnStart reopens a finished turn.
+            EventRole::Working if st.hook_state == AgentState::Completed => {}
             EventRole::Working => {
                 st.proc_alive = true;
                 st.prompt_returned = false;
@@ -878,6 +891,60 @@ this line is not json at all
         let bytes = b"\x1b]0;\xe2\xa0\x82 Claude\x07";
         let h = CtxHarness::new();
         m.on_output(bytes, &h.ctx("proj:tab-1"));
+        assert_eq!(drain_states(&mut rx), vec!["in-progress"]);
+    }
+
+    #[tokio::test]
+    async fn trailing_progress_does_not_reopen_a_completed_turn() {
+        // Observed in the wild: Claude fired SubagentStop 8.5s after Stop. With
+        // that mapped to progress the tab flipped back to in-progress while the
+        // completion tick was still on screen, so it pulsed and showed a green
+        // check at once.
+        let mut m = AgentStateMod::new();
+        let mut rx = register_tab(&mut m, "proj:tab-1");
+        m.on_hook_event(&payload("claude-code", "SessionStart", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("claude-code", "UserPromptSubmit", Some("proj:tab-1"), Some("s-y")));
+        assert_eq!(drain_states(&mut rx), vec!["idle", "in-progress"]);
+
+        m.on_hook_event(&payload("claude-code", "Stop", Some("proj:tab-1"), Some("s-y")));
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(drain_states(&mut rx), vec!["completed"]);
+
+        // Late progress from the finished turn must be ignored.
+        m.on_hook_event(&payload("claude-code", "PostToolUse", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("claude-code", "PreToolUse", Some("proj:tab-1"), Some("s-y")));
+        assert!(drain_states(&mut rx).is_empty(), "completed tab must stay completed");
+    }
+
+    #[tokio::test]
+    async fn a_new_prompt_reopens_a_completed_turn() {
+        // The guard must not strand the tab: the next turn has to start.
+        let mut m = AgentStateMod::new();
+        let mut rx = register_tab(&mut m, "proj:tab-1");
+        m.on_hook_event(&payload("claude-code", "SessionStart", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("claude-code", "UserPromptSubmit", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("claude-code", "Stop", Some("proj:tab-1"), Some("s-y")));
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(drain_states(&mut rx), vec!["idle", "in-progress", "completed"]);
+
+        m.on_hook_event(&payload("claude-code", "UserPromptSubmit", Some("proj:tab-1"), Some("s-y")));
+        assert_eq!(drain_states(&mut rx), vec!["in-progress"]);
+    }
+
+    #[tokio::test]
+    async fn single_signal_agents_still_start_their_next_turn() {
+        // opencode's only progress event doubles as its turn start, so it is
+        // TurnStart. If it were a mid-turn heartbeat the guard would strand the
+        // tab in completed forever after turn_end.
+        let mut m = AgentStateMod::new();
+        let mut rx = register_tab(&mut m, "proj:tab-1");
+        m.on_hook_event(&payload("opencode", "session_start", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("opencode", "working", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("opencode", "turn_end", Some("proj:tab-1"), Some("s-y")));
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(drain_states(&mut rx), vec!["idle", "in-progress", "completed"]);
+
+        m.on_hook_event(&payload("opencode", "working", Some("proj:tab-1"), Some("s-y")));
         assert_eq!(drain_states(&mut rx), vec!["in-progress"]);
     }
 

--- a/apps/desktop/src-tauri/src/mod_engine/mods/agent_state.rs
+++ b/apps/desktop/src-tauri/src/mod_engine/mods/agent_state.rs
@@ -643,7 +643,10 @@ mod tests {
         // detector inferred Idle from that static title instead, this case took
         // the OSC_STALE branch and the in-progress badge never rendered.
         let now = Instant::now();
-        let i = inputs(AgentState::Working, None, true, false, now);
+        // Past OSC_STALE (1.5s) and well under PTY_SILENCE (20s): the window
+        // where the old permanent-Idle detector used to stale Working away.
+        let active = now - Duration::from_secs(5);
+        let i = inputs(AgentState::Working, None, true, false, active);
         assert_eq!(effective_state(&i, now), AgentState::Working);
     }
 

--- a/apps/desktop/src-tauri/src/mod_engine/mods/agent_state.rs
+++ b/apps/desktop/src-tauri/src/mod_engine/mods/agent_state.rs
@@ -205,6 +205,15 @@ fn effective_state(i: &Inputs, now: Instant) -> AgentState {
     i.hook
 }
 
+/// A lone ESC or Ctrl-C: the user reaching for "stop".
+///
+/// Matched as an exact single byte on purpose. Navigation keys arrive as
+/// multi-byte escape sequences (arrow keys send `ESC [ A`), so requiring the
+/// lone byte keeps ordinary cursor movement from reading as a cancel.
+fn is_interrupt_key(data: &[u8]) -> bool {
+    matches!(data, [0x1b] | [0x03])
+}
+
 /// Recompute the effective state and, if it changed, push it to the frontend
 /// and fire a notification. Shared by the sync callbacks and the reconcile tick.
 fn reconcile(
@@ -348,6 +357,36 @@ impl Mod for AgentStateMod {
 
         st.recompute_osc(now);
         reconcile(&mut st, &handle.emitter, &self.notifications, now);
+    }
+
+    /// Cancellation channel. Agents flagged `interrupt_ends_turn` abandon a turn
+    /// on ESC without firing their completion event, so the keypress is the only
+    /// evidence the turn ended. Releases to Idle rather than Completed: a
+    /// cancelled turn produced no result and must not show as finished.
+    ///
+    /// Guessing wrong is self-correcting, since the next hook event restores
+    /// Working. A missed cancellation is not: it pins the tab to Working until
+    /// the next prompt.
+    fn on_input(&mut self, data: &[u8], ctx: &ModContext) {
+        if !is_interrupt_key(data) {
+            return;
+        }
+        let Some(handle) = self.tabs.get(ctx.tab_id) else { return };
+        let mut st = handle.state.lock().unwrap();
+        if st.hook_state != AgentState::Working {
+            return;
+        }
+        let ends_turn = st
+            .agent_id
+            .as_deref()
+            .and_then(agents::by_id)
+            .is_some_and(|p| p.interrupt_ends_turn);
+        if !ends_turn {
+            return;
+        }
+        st.hook_state = AgentState::Idle;
+        st.pending_question = None;
+        reconcile(&mut st, &handle.emitter, &self.notifications, Instant::now());
     }
 
     fn on_agent_detected(&mut self, agent: &str, _cwd: &str, _cmd: &str, ctx: &ModContext) {
@@ -840,6 +879,78 @@ this line is not json at all
         let h = CtxHarness::new();
         m.on_output(bytes, &h.ctx("proj:tab-1"));
         assert_eq!(drain_states(&mut rx), vec!["in-progress"]);
+    }
+
+    #[test]
+    fn interrupt_key_releases_a_cancelled_turn() {
+        // Claude does not fire Stop when the user interrupts, so without this
+        // channel the tab pulses as in-progress until the next prompt.
+        let mut m = AgentStateMod::new();
+        let mut rx = register_tab(&mut m, "proj:tab-1");
+        m.on_hook_event(&payload("claude-code", "SessionStart", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("claude-code", "UserPromptSubmit", Some("proj:tab-1"), Some("s-y")));
+        assert_eq!(drain_states(&mut rx), vec!["idle", "in-progress"]);
+
+        let h = CtxHarness::new();
+        m.on_input(b"\x1b", &h.ctx("proj:tab-1"));
+        assert_eq!(drain_states(&mut rx), vec!["idle"]);
+    }
+
+    #[test]
+    fn ctrl_c_also_releases_a_cancelled_turn() {
+        let mut m = AgentStateMod::new();
+        let mut rx = register_tab(&mut m, "proj:tab-1");
+        m.on_hook_event(&payload("claude-code", "SessionStart", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("claude-code", "UserPromptSubmit", Some("proj:tab-1"), Some("s-y")));
+        assert_eq!(drain_states(&mut rx), vec!["idle", "in-progress"]);
+
+        let h = CtxHarness::new();
+        m.on_input(b"\x03", &h.ctx("proj:tab-1"));
+        assert_eq!(drain_states(&mut rx), vec!["idle"]);
+    }
+
+    #[test]
+    fn arrow_keys_are_not_a_cancel() {
+        // ESC [ A and friends must not read as an interrupt, or ordinary cursor
+        // movement would clear a live turn.
+        let mut m = AgentStateMod::new();
+        let mut rx = register_tab(&mut m, "proj:tab-1");
+        m.on_hook_event(&payload("claude-code", "SessionStart", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("claude-code", "UserPromptSubmit", Some("proj:tab-1"), Some("s-y")));
+        assert_eq!(drain_states(&mut rx), vec!["idle", "in-progress"]);
+
+        let h = CtxHarness::new();
+        for seq in [&b"\x1b[A"[..], b"\x1b[B", b"\x1bOP", b"hello"] {
+            m.on_input(seq, &h.ctx("proj:tab-1"));
+        }
+        assert!(drain_states(&mut rx).is_empty(), "navigation must not change state");
+    }
+
+    #[test]
+    fn interrupt_is_ignored_for_agents_that_report_their_own_cancel() {
+        // Opt-in per agent: opencode is not flagged, so its hook stays the sole
+        // authority and ESC must not move the tab.
+        let mut m = AgentStateMod::new();
+        let mut rx = register_tab(&mut m, "proj:tab-1");
+        m.on_hook_event(&payload("opencode", "session_start", Some("proj:tab-1"), Some("s-y")));
+        m.on_hook_event(&payload("opencode", "working", Some("proj:tab-1"), Some("s-y")));
+        assert_eq!(drain_states(&mut rx), vec!["idle", "in-progress"]);
+
+        let h = CtxHarness::new();
+        m.on_input(b"\x1b", &h.ctx("proj:tab-1"));
+        assert!(drain_states(&mut rx).is_empty(), "unflagged agent must be untouched");
+    }
+
+    #[test]
+    fn interrupt_does_not_disturb_an_idle_tab() {
+        let mut m = AgentStateMod::new();
+        let mut rx = register_tab(&mut m, "proj:tab-1");
+        m.on_hook_event(&payload("claude-code", "SessionStart", Some("proj:tab-1"), Some("s-y")));
+        assert_eq!(drain_states(&mut rx), vec!["idle"]);
+
+        let h = CtxHarness::new();
+        m.on_input(b"\x1b", &h.ctx("proj:tab-1"));
+        assert!(drain_states(&mut rx).is_empty());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/mod_engine/mods/agent_state.rs
+++ b/apps/desktop/src-tauri/src/mod_engine/mods/agent_state.rs
@@ -637,6 +637,17 @@ mod tests {
     }
 
     #[test]
+    fn opinionless_osc_keeps_working_hook() {
+        // An agent whose OSC carries no liveness signal (Claude 2.x: one static
+        // title, no OSC 9) must leave the hook channel authoritative. When the
+        // detector inferred Idle from that static title instead, this case took
+        // the OSC_STALE branch and the in-progress badge never rendered.
+        let now = Instant::now();
+        let i = inputs(AgentState::Working, None, true, false, now);
+        assert_eq!(effective_state(&i, now), AgentState::Working);
+    }
+
+    #[test]
     fn hook_wins_by_default() {
         let now = Instant::now();
         let i = inputs(AgentState::Blocked, None, true, false, now);

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agent Terminal",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.daniakash.agent-terminal",
   "build": {
     "beforeDevCommand": "bun run --filter @agent-terminal/desktop dev",

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "apps/desktop": {
       "name": "@agent-terminal/desktop",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Problem

The in-progress badge never renders for Claude Code tabs. Widening Claude's hook subscription in #141 did not fix it, because the hooks were never the problem: they fire correctly and reach the hook server. A second channel overrides them.

`effective_state` fuses three channels (hook, OSC, floor). One branch releases a hook that looks stuck:

```rust
if let Some((OscState::Idle, at)) = i.osc {
    if i.hook == AgentState::Working && now.duration_since(at) > OSC_STALE { // 1500ms
        return AgentState::Idle;
    }
}
```

Claude's OSC detector fed that branch a permanent `Idle`. It looks for two positive signals, a Braille spinner glyph leading the title, or OSC 9 progress `4;0;`, and otherwise treated any settled non-Braille title as the prompt showing.

Both positive signals are gone in Claude Code 2.1.236. Probing the shipped binary and a live PTY session:

| Probe | Result |
|---|---|
| Clustered Braille spinner frame arrays | absent (117 scattered U+28xx bytes, 0 groups of 4+ within 6 bytes) |
| `ESC]9;` progress emission | 0 occurrences |
| `✳` U+2733 | 1 occurrence, the static title glyph |
| Live PTY capture, 11 OSC emissions | all identical: `OSC 0: '✳ Claude Code'` |

So the detector always fell through to the settled-title branch and returned `Idle`. `OscState::Working` is unreachable for Claude.

`recompute_osc` compounds it: it only re-stamps the timestamp when the derived value *changes*. Claude sets its title once at startup and never changes it, so the recorded dwell time grows without bound and is always past `OSC_STALE`. The veto is permanent from roughly 1.5 seconds into a tab's life onward.

`Blocked` and `Completed` were unaffected, since the branch is guarded on the hook reporting `Working`. Only the in-progress state was suppressed, which is exactly the reported symptom.

## Fix

Return `None` when neither positive signal is present:

```diff
     if view.progress.starts_with("4;0;") {
         return Some(OscState::Idle);
     }
-    if first.is_some() {
-        return Some(OscState::Idle);
-    }
     None
```

A settled title carries no liveness information, so inferring `Idle` from it asserted knowledge the signal does not contain. Saying nothing leaves the hook channel authoritative.

Two safety nets remain live:

- The floor still forces `Idle` when the process dies or the shell prompt returns. Claude emits no OSC 133 itself, but the surrounding shell does, so `prompt_returned` still flips when Claude exits.
- `PTY_SILENCE` becomes reachable for Claude for the first time, since it is guarded on the OSC channel having no opinion and was dead code while the detector always returned `Some`. A `Working` hook with no terminal output for 20 seconds now releases to `Idle`, covering a missed `Stop`. Claude animates its spinner and token counter continuously while working, so this only fires on a genuinely dropped event.

Both positive branches stay so the detector self-heals if either signal returns.

## Tests

- `settled_title_yields_no_opinion` replaces `settled_title_is_idle`, pinning the real observed title.
- `opinionless_osc_keeps_working_hook` proves at the fusion level that an OSC channel with no opinion leaves a `Working` hook intact.
- `osc_idle_stales_stuck_working_hook` still passes, so the stale-release path is preserved for agents that genuinely report idle.

Full Rust suite green: 174 passed, 0 failed.

## Scope

Claude Code only. `amp` uses an identical "non-Braille title means idle" shape, and the codex / kilo / opencode / kimi / mastracode detectors have not been probed against their current releases. Same class of bug, tracked separately.

---

## Follow-up: user cancellation

Manual testing of the above surfaced a gap this PR is responsible for. Starting a task pulses correctly and completion shows the checkmark, but cancelling a task left the tab pulsing forever.

Claude does not fire `Stop` when a turn is interrupted, so `hook_state` stayed `Working` with no terminating event. That used to be masked: the settled-title detector's permanent `Idle` staled the working hook away after `OSC_STALE`. Removing the veto removed the accidental coverage with it.

`PTY_SILENCE` does not cover it either, because Claude keeps redrawing after the interrupt, so `last_activity` refreshes and the 20s window never accumulates.

Signals considered:

1. A dedicated interrupt hook event. Does not exist. Enumerating hook-event names in the shipped binary found the ten already subscribed plus `SubagentStart`, `PreCompact`, and `PostCompact`, and nothing for abort or cancel.
2. Scraping output for `[Request interrupted by user]`. The marker is real, but the interface re-renders scrollback, so redrawing an old marker would clear a live turn, and the string can split across reads or wrap across lines.
3. Reading the keypress from `on_input`. Chosen.

`on_input` was already wired from both the desktop (`commands.rs`) and the companion app (`wss_server.rs`), but no mod implemented it, so cancelling now works from the phone too.

A lone `ESC` or `Ctrl-C` matches as an exact single byte, since navigation keys arrive as longer escape sequences and must not read as a cancel. The tab releases to `Idle` rather than `Completed`, because a cancelled turn produced no result and should not present as finished.

Gated behind a new `interrupt_ends_turn` flag on `AgentProfile` so the behaviour stays registry-driven instead of hardcoding an agent id in the engine. Only Claude opts in; whether ESC ends a turn for the other six agents is unverified, so they keep their current behaviour exactly.

The failure mode degrades safely in a way the current bug does not: if the keypress did not actually cancel, the next hook event restores `Working` within one event. A missed cancellation never self-corrects.

New tests: `interrupt_key_releases_a_cancelled_turn`, `ctrl_c_also_releases_a_cancelled_turn`, `arrow_keys_are_not_a_cancel`, `interrupt_is_ignored_for_agents_that_report_their_own_cancel`, `interrupt_does_not_disturb_an_idle_tab`. Suite at 179 passed / 0 failed, and `bun run check` exits 0 across the monorepo.


---

## Follow-up: trailing progress reopened a finished turn

Reported from testing: a completed tab pulsed as in-progress underneath its own completion tick, showing both at once.

Cause: Claude emits `SubagentStop` **after** `Stop`. A captured session shows it landing 8.5 seconds later:

```
UserPromptSubmit
Stop            <- turn done, tab goes Completed
SubagentStop    <- 8.5s later, was mapped to progress -> back to in-progress
```

That event was mapped to progress, so it reopened a turn that had already finished. The frontend lingers the completion tick, so the pulse and the tick rendered together.

### Fix

Split the progress role in two:

- `TurnStart` opens a turn and may always move the tab to working, including out of `Completed`, since a new turn supersedes the previous result. It also clears the stale completion message.
- `Working` is now strictly a mid-turn heartbeat, ignored while the tab reports `Completed`.

Only Claude subscribes to several progress events, so only Claude could hit this. Every other agent has a single progress event that doubles as its turn opener, so those become `TurnStart` and their behaviour is unchanged. Mapping them to the heartbeat role instead would have stranded them in `Completed` forever, because their next turn would have been ignored; `single_signal_agents_still_start_their_next_turn` pins that.

`SubagentStop` is also dropped from the subscription. It reports a subagent finishing, which is a stop rather than progress, and the Task tool's own `PostToolUse` already covers the case. Existing installations keep the stale registration in their agent config, but an event the profile no longer claims is dropped before it reaches the state machine, so they are covered without a config migration.

The guard additionally closes a race that was latent here: hook delivery is fire-and-forget with no ordering guarantee, and the `Stop` path reads the session transcript before recording its result, so a `PostToolUse` issued before `Stop` could still land after it.

New tests: `trailing_progress_does_not_reopen_a_completed_turn`, `a_new_prompt_reopens_a_completed_turn`, `single_signal_agents_still_start_their_next_turn`. Suite at 182 passed / 0 failed, `bun run check` exits 0.
